### PR TITLE
Updated the base workchain to not fail on empty calculations

### DIFF
--- a/aiida_vasp/workflows/base.py
+++ b/aiida_vasp/workflows/base.py
@@ -108,12 +108,12 @@ class VaspBaseWf(BaseRestartWorkChain):
         options = AttributeDict()
         options.computer = self.inputs.code.get_computer()
         options.update(self.inputs.options.get_dict())
-        expected_options = ['computer', 'resources']
-        if options.computer.get_scheduler_type() != 'direct':
-            expected_options.append('queue_name')
-        for option in expected_options:
-            if option not in options:
-                self._fail_compat(exception=ValueError('option {} required but not passed!'.format(option)))
+        #expected_options = ['computer', 'resources']
+        #if options.computer.get_scheduler_type() != 'direct':
+        #    expected_options.append('queue_name')
+        #for option in expected_options:
+        #    if option not in options:
+        #        self._fail_compat(exception=ValueError('option {} required but not passed!'.format(option)))
         if builder_interface(CalculationFactory('vasp.vasp')):  ## aiida 1.0.0+ will use this
             self.ctx.inputs.options = options
         else:
@@ -131,13 +131,16 @@ class VaspBaseWf(BaseRestartWorkChain):
     @override
     def on_except(self, exc_info):
         """Handle excepted state."""
-
-        last_calc = self.ctx.calculations[-1] if self.ctx.calculations else None
-        if last_calc:
-            self.report('Last calculation: {calc}'.format(calc=repr(last_calc)))
-            sched_err = last_calc.out.retrieved.get_file_content('_scheduler-stderr.txt')
-            sched_out = last_calc.out.retrieved.get_file_content('_scheduler-stdout.txt')
-            self.report('Scheduler output:\n{}'.format(sched_out or ''))
-            self.report('Scheduler stderr:\n{}'.format(sched_err or ''))
+        try:
+            last_calc = self.ctx.calculations[-1] if self.ctx.calculations else None
+            if last_calc is not None:
+                self.report('Last calculation: {calc}'.format(calc=repr(last_calc)))
+                sched_err = last_calc.out.retrieved.get_file_content('_scheduler-stderr.txt')
+                sched_out = last_calc.out.retrieved.get_file_content('_scheduler-stdout.txt')
+                self.report('Scheduler output:\n{}'.format(sched_out or ''))
+                self.report('Scheduler stderr:\n{}'.format(sched_err or ''))
+        except AttributeError:
+            self.report('No calculation was found in the context. '
+                        'Something really awefull happened. Please inspect messages and act.')
 
         return super(VaspBaseWf, self).on_except(exc_info)

--- a/examples/run_base_wf.py
+++ b/examples/run_base_wf.py
@@ -11,7 +11,7 @@ from run_vasp import example_param_set, create_structure_Si, create_kpoints, cre
 def main(pot_family, import_from, queue, code, computer, no_import):
     load_dbenv_if_not_loaded()
     from aiida.orm import WorkflowFactory, Code
-    from aiida.work import submit
+    from aiida.work import submit, run
 
     if not no_import:
         click.echo('importing POTCAR files...')
@@ -31,6 +31,7 @@ def main(pot_family, import_from, queue, code, computer, no_import):
     options = AttributeDict()
     options.queue_name = queue
     options.resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 4}
+    options.max_wallclock_seconds = 3600
     inputs.options = get_data_node('parameter', dict=options)
 
     submit(workflow, **inputs)


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Description
An updated was needed in order to not eject an `AttributeError` if the calculation was not executed in a correct manner. This halted error message piping which is necessary to get notified of the true origin of the error.