### PR TITLE
[WIP] Updated localhost fixture to the new backend interface

### DIFF
--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -331,7 +331,8 @@ class VaspCalcBase(JobCalculation):
         proc_cls = imgr.VaspImmigrantJobProcess.build(cls)
         builder = proc_cls.get_builder()
         builder.code = code
-        builder.options.resources = kwargs.get('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})  # pylint: disable=no-member
+        default_ressources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1, 'max_wallclock_seconds': 1}
+        builder.options.resources = kwargs.get('resources', default_ressources)  # pylint: disable=no-member
         settings = kwargs.get('settings', {})
         settings.update({'import_from_path': remote_path.strpath})
         builder.settings = get_data_node('parameter', dict=settings)

--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -331,7 +331,8 @@ class VaspCalcBase(JobCalculation):
         proc_cls = imgr.VaspImmigrantJobProcess.build(cls)
         builder = proc_cls.get_builder()
         builder.code = code
-        default_ressources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1, 'max_wallclock_seconds': 1}
+        default_ressources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
+        builder.options.max_wallclock_seconds = 1  # pylint: disable=no-member
         builder.options.resources = kwargs.get('resources', default_ressources)  # pylint: disable=no-member
         settings = kwargs.get('settings', {})
         settings.update({'import_from_path': remote_path.strpath})

--- a/aiida_vasp/calcs/tests/test_immigrant.py
+++ b/aiida_vasp/calcs/tests/test_immigrant.py
@@ -26,6 +26,7 @@ def aiida_runner():
     yield work.runners.new_runner(rmq_config=None)
 
 
+@pytest.mark.xfail(reason="Removing POTCAR from calc.raw_input not implemented yet.")
 @pytest.mark.skipif(aiida_version() < cmp_version('1.0.0a1'), reason='too many JobProcess changes')
 def test_immigrant_additional(fresh_aiida_env, potcar_family, phonondb_run, localhost, mock_vasp, aiida_runner):
     """Provide process class and inputs for importing a AiiDA-external VASP run."""

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -85,10 +85,9 @@ def potcar_node_pair(aiida_env):
 def temp_pot_folder(tmpdir):
     """A temporary copy of the potcar test data folder, to avoid extracting tar files inside the repo."""
     potcar_ga = py_path.local(data_path('potcar')).join('Ga')
-    print potcar_ga.strpath
     assert not potcar_ga.exists()
     pot_archive = py_path.local(data_path('potcar'))
-    target = tmpdir.join('potcar')
+    target = tmpdir.join('potentials')
     pot_archive.copy(target)
     return target
 

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -1,5 +1,5 @@
 """pytest-style test fixtures"""
-# pylint: disable=unused-import,unused-argument,redefined-outer-name,too-many-function-args
+# pylint: disable=unused-import,unused-argument,redefined-outer-name,too-many-function-args, protected-access
 import os
 from collections import OrderedDict
 import subprocess as sp
@@ -27,23 +27,17 @@ def localhost_dir(tmpdir_factory):
 @pytest.fixture
 def localhost(aiida_env, localhost_dir):
     """Fixture for a local computer called localhost"""
-    from aiida.orm import Computer
-    from aiida.orm.querybuilder import QueryBuilder
-    query_builder = QueryBuilder()
-    query_builder.append(Computer, tag='comp')
-    query_builder.add_filter('comp', {'name': {'==': 'localhost'}})
-    query_results = query_builder.all()
-    if query_results:
-        computer = query_results[0][0]
-    else:
-        computer = Computer(
+    from aiida.common import exceptions
+    try:
+        computer = aiida_env._backend.computers.get(name='localhost')
+    except exceptions.NotExistent:
+        computer = aiida_env._backend.computers.create(
             name='localhost',
             description='description',
             hostname='localhost',
             workdir=localhost_dir.strpath,
             transport_type='local',
             scheduler_type='direct',
-            mpirun_command=[],
             enabled_state=True)
     return computer
 

--- a/aiida_vasp/workflows/base.py
+++ b/aiida_vasp/workflows/base.py
@@ -132,7 +132,7 @@ class VaspBaseWf(BaseRestartWorkChain):
     def on_except(self, exc_info):
         """Handle excepted state."""
 
-        last_calc = self.ctx.calculations[-1] if self.ctx.calculations else None
+        last_calc = self.ctx.calculations[-1] if self.ctx.get('calculations') else None
         if last_calc:
             self.report('Last calculation: {calc}'.format(calc=repr(last_calc)))
             sched_err = last_calc.out.retrieved.get_file_content('_scheduler-stderr.txt')

--- a/aiida_vasp/workflows/tests/test_base_wf.py
+++ b/aiida_vasp/workflows/tests/test_base_wf.py
@@ -52,8 +52,10 @@ def test_base(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_struc
     inputs.potcar_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potcar_mapping = get_data_node('parameter', dict=POTCAR_MAP)
     inputs.options = get_data_node(
-        'parameter', dict={
+        'parameter',
+        dict={
             'queue_name': 'None',
+            'max_wallclock_seconds': 1,
             'resources': {
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1

--- a/aiida_vasp/workflows/tests/test_base_wf.py
+++ b/aiida_vasp/workflows/tests/test_base_wf.py
@@ -56,6 +56,7 @@ def test_base(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_struc
         dict={
             'queue_name': 'None',
             'max_wallclock_seconds': 1,
+            'import_sys_environment': True,
             'resources': {
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1

--- a/aiida_vasp/workflows/tests/test_relax_wf.py
+++ b/aiida_vasp/workflows/tests/test_relax_wf.py
@@ -64,6 +64,7 @@ def test_relax_wf(fresh_aiida_env, vasp_params, potentials, mock_vasp):
         dict={
             'queue_name': 'None',
             'max_wallclock_seconds': 1,
+            'import_sys_environment': True,
             'resources': {
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1

--- a/aiida_vasp/workflows/tests/test_relax_wf.py
+++ b/aiida_vasp/workflows/tests/test_relax_wf.py
@@ -60,8 +60,10 @@ def test_relax_wf(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     inputs.potcar_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potcar_mapping = get_data_node('parameter', dict=POTCAR_MAP)
     inputs.options = get_data_node(
-        'parameter', dict={
+        'parameter',
+        dict={
             'queue_name': 'None',
+            'max_wallclock_seconds': 1,
             'resources': {
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1

--- a/setup.json
+++ b/setup.json
@@ -73,7 +73,7 @@
         "aiida-core[atomic_tools] >= 0.11.0", 
         "ase", 
         "scipy", 
-        "pymatgen", 
+        "pymatgen == 2018.4.20", 
         "subprocess32", 
         "click", 
         "chainmap", 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pip>=10
     aiida_11: aiida-core>=0.11.4,<0.12.0
     aiida_stable: aiida-core
-    aiida_dev: git+https://github.com/aiidateam/aiida_core@777c16c14858593bee0a4e2a1027eaa89833a2e2
+    aiida_dev: git+https://github.com/aiidateam/aiida_core
     git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
     .[regen_default_paws,graphs,dev]
 whitelist_externals = 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

The interface for creating instances of `Computer` has been ported to the new backend interface in aiida_core. 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

- Updated `utils.fixtures.data.localhost` for using the new backend interface if it is available in aiida_core.
- Changed the name of the directory in `utils.fixtures.data.temp_pot_folder` from 'potcar' to 'potentials'. The previous name 'potcar' can lead to confusions with 'POTCAR' on (allegedly) case insensitive file systems.
- Marked `test_immigrant_additional` as 'xfail' since the tested feature of cleaning 'POTCAR' from the raw inputs has not been implemented yet.