### PR TITLE
Updated calls to parsevasp to utilize Aiida logger

### DIFF
--- a/aiida_vasp/io/incar.py
+++ b/aiida_vasp/io/incar.py
@@ -396,7 +396,7 @@ class IncarParser(BaseFileParser):
         incar_dict = self._data_obj.get_dict()
 
         try:
-            return IncarParsevasp(incar_dict=incar_dict)
+            return IncarParsevasp(incar_dict=incar_dict, logger=self._logger)
         except SystemExit:
             return None
 
@@ -412,7 +412,7 @@ class IncarParser(BaseFileParser):
         try:
             incar = IncarParsevasp(file_path=self._data_obj.path)
         except SystemExit:
-            self._logger.warning("Parsevasp exitited abnormally. " "Returning None.")
+            self._logger.warning("Parsevasp exitited abnormally. Returning None.")
             return {'incar': None}
 
         result = parsevasp_to_aiida(incar)

--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -134,7 +134,7 @@ class VasprunParser(BaseFileParser):
         # Since vasprun.xml can be fairly large, we will parse it only
         # once and store the parsevasp Xml object.
         try:
-            self._xml = Xml(file_path=path, k_before_band=True)
+            self._xml = Xml(file_path=path, k_before_band=True, logger=self._logger)
         except SystemExit:
             self._logger.warning("Parsevasp exited abruptly. Returning None.")
             self._xml = None
@@ -594,7 +594,7 @@ class VasprunParser(BaseFileParser):
                 prj.append(proj["up"])
                 prj.append(proj["down"])
             except KeyError:
-                self._logger.error("Did not detect any projectors. " "Returning.")
+                self._logger.error("Did not detect any projectors. Returning.")
         if len(prj) == 1:
             projectors.set_array('projectors', prj[0])
         else:

--- a/examples/run_vasp_lean.py
+++ b/examples/run_vasp_lean.py
@@ -56,7 +56,7 @@ def main(potential_family, queue, code, computer):
     # set workchain related inputs
     inputs.verbose = get_data_node('bool', True)
     # submit the requested workchain with the supplied inputs
-    run(workchain, **inputs)
+    submit(workchain, **inputs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
This fix makes sure the Aiida logger is parsed to parsevasp. Since the default log level in parsevasp is currently set to `DEBUG` we were getting debug messages when executing `run`. This is also addressed with this fix.