### PR TITLE
Enable longer than 10 minute runs on Travis (now 20 minutes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ python: 2.7
 services:
     - postgresql
 addons:
-    postgresql: "9.5"
+    postgresql: "11.0"
 cache: pip
 before_install:  # copied from pgtest's travis.yml
     - sudo apt-get install locate
     - sudo service postgresql stop
-    - sudo apt-get remove postgresql
+    - sudo apt-get remove postgresql-9.2 postgresql-client-9.2
     - sudo apt-get install postgresql
     - sudo updatedb
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - TEST_TYPE="unittests" TOX_ENV=py27-aiida_11
     - TEST_TYPE="unittests" TOX_ENV=py27-aiida_stable
     - TEST_TYPE="unittests" TOX_ENV=py27-aiida_dev
-script: ./run_ci_tests.sh
+script: travis_wait ./run_ci_tests.sh
 after_success:
     - coverage combine
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,10 @@ python: 2.7
 services:
     - postgresql
 addons:
-    postgresql: "11.0"
+    postgresql: "9.5"
 cache: pip
-before_install:  # copied from pgtest's travis.yml
+before_install:
     - sudo apt-get install locate
-    - sudo service postgresql stop
-    - sudo apt-get remove postgresql-9.2 postgresql-client-9.2
-    - sudo apt-get install postgresql
     - sudo updatedb
 install:
     - pip install --upgrade pip


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 
*type "#" followed by search words to find issues / PRs*

fixes:
#224 
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
To enable longer runs than 10 minutes on Travis. Typically some workchain tests takes some time to complete and the default 10 minutes is not sufficient. The time out is now 20 minutes, but can be increased by adding a number after `travis_wait`.