### PR TITLE
relax-wc _set_ibrion to -1 only when p,s,v all False

### DIFF
--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -143,7 +143,7 @@ class RelaxWorkChain(WorkChain):
             required=False,
             default=get_data_node('float', 0.1),
             help="""
-                   The cutoff value for the convergence check on the lengths of the unit cell 
+                   The cutoff value for the convergence check on the lengths of the unit cell
                    vecotrs. If ``convergence_absolute``
                    is True in AA, otherwise in relative difference.
                    """)
@@ -198,7 +198,7 @@ class RelaxWorkChain(WorkChain):
         spec.output('output_final_stress', valid_type=get_data_class('array'), required=False)
 
     def _set_ibrion(self, parameters):
-        if self.inputs.positions.value:
+        if self.inputs.positions.value or self.inputs.shape.value or self.inputs.volume.value:
             parameters.ibrion = self.AlgoEnum.IONIC_RELAXATION_CG
         else:
             parameters.ibrion = self.AlgoEnum.NO_UPDATE


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [X] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks: workchain

is blocked by:

None of the above but is still related to the following:

## Description
When I want set ISIF=5 to have shape_only relax, without setting `relax_parameters` (Line 229), `self.inputs.positions.value==False` cause `ibrion==-1` which don't update the structure. 