### PR TITLE
Fix immigrant when POTCAR exists

### DIFF
--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -86,7 +86,7 @@ def get_potcar_input(dir_path, structure=None, potcar_spec=None):
     potentials = {}
     if local_potcar.exists():
         potentials = MultiPotcarIo.read(local_potcar.strpath).get_potentials_dict(structure)
-        potentials = {(kind,): potcar for kind, potcar in potentials}
+        potentials = {(kind,): potentials[kind] for kind in potentials}
     elif potcar_spec:
         potentials = PotcarData.get_potcars_from_structure(structure, potcar_spec['family'], potcar_spec['map'])
     else:


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
This fixes the problem that raises error when POTCAR file exists in the directory to be immigrated. This fix is compatible between python 2.x and 3.