### PR TITLE
A fix to get final forces and stress in VaspCalculation and VaspWorkChain

### DIFF
--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -320,10 +320,10 @@ class VasprunParser(BaseFileParser):
         """
 
         final_forces = self.final_forces
-        forces = get_data_class('array')()
-        forces.set_array('final', final_forces)
-
-        return forces
+        if final_forces is None:
+            return None
+        else:
+            return {'final': final_forces}
 
     @property
     def maximum_force(self):
@@ -370,9 +370,10 @@ class VasprunParser(BaseFileParser):
         """
 
         final_stress = self.final_stress
-        stress = get_data_class('array')()
-        stress.set_array('final', final_stress)
-        return stress
+        if final_stress is None:
+            return None
+        else:
+            return {'final': final_stress}
 
     @property
     def maximum_stress(self):

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -101,8 +101,8 @@ class VaspWorkChain(BaseRestartWorkChain):
         spec.output('output_born_charges', valid_type=get_data_class('array'), required=False)
         spec.output('output_hessian', valid_type=get_data_class('array'), required=False)
         spec.output('output_dynmat', valid_type=get_data_class('array'), required=False)
-        spec.output('output_final_forces', valid_type=get_data_class('array'), required=False)
-        spec.output('output_final_stress', valid_type=get_data_class('array'), required=False)
+        spec.output('output_forces', valid_type=get_data_class('array'), required=False)
+        spec.output('output_stress', valid_type=get_data_class('array'), required=False)
 
     def init_calculation(self):
         """Set the restart folder and set parameters tags for a restart."""


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
This is a fix to get final forces and stress in (1) VaspCalculation and (2) VaspWorkChain. 

(1) In `io/vasprun.py`, `VasprunParser.forces` and `VasprunParser.stress` returned ArrayData objects, but I changed them to dictionaries. I could not figure out why they were so (i.e., ArrayData). One more thing that I can't see is the difference between 'name' and 'nodeName' keys in `VasprunParser.PARSABLE_ITEMS'. It seems either key works.

(2) These changes of spec.output names provide the links from `WorkCalculation` node to the `output_forces` and `output_stress`.