### PR TITLE
Allow 'stress' to be None.

### DIFF
--- a/aiida_vasp/io/vasprun.py
+++ b/aiida_vasp/io/vasprun.py
@@ -367,6 +367,8 @@ class VasprunParser(BaseFileParser):
         """Fetch the maximum stress of at the last ionic run."""
 
         stress = self.final_stress
+        if stress is None:
+            return None
         norm = np.linalg.norm(stress, axis=1)
         return np.amax(np.abs(norm))
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
 
## Interactions with issues / other PRs 

*type "#" followed by search words to find issues / PRs*

fixes: parsing failed when ``stress`` was ``None``

blocks:

is blocked by:

None of the above but is still related to the following: #198

## Description

If ``stress`` is ``None``, the ``maximum_stress`` would previously fail due to the call to ``np.linalg.norm``. I am not certain if ``stress`` being ``None`` is now an expected condition, or if that should be fixed instead. If it isn't, I will make a separate issue describing the input that leads to this.