### PR TITLE
Introduced retrieve_temporary_list

### DIFF
--- a/aiida_vasp/parsers/quantity.py
+++ b/aiida_vasp/parsers/quantity.py
@@ -74,10 +74,8 @@ class ParsableQuantities(object):  # pylint: disable=useless-object-inheritance
     def setup(self):
         """Set the parsable_quantities dictionary based on parsable_items obtained from the FileParsers."""
 
-        retrieved = [item.name for item in self._vasp_parser.retrieved.list_objects()]
-
         # check uniqueness and add parsable quantities
-        self._check_uniqueness_add_parsable(retrieved)
+        self._check_uniqueness_add_parsable(self._vasp_parser.retrieved_content.keys())
 
         # check consistency, that the quantity is parsable and
         # alternatives

--- a/aiida_vasp/parsers/tests/test_base_parser.py
+++ b/aiida_vasp/parsers/tests/test_base_parser.py
@@ -19,6 +19,7 @@ def base_parser(calc_with_retrieved):
 
 def test_get_file(base_parser):
     """Test getting a retrieved output file."""
+    base_parser.check_folders()
     assert os.path.isfile(base_parser.get_file('OUTCAR'))
     assert os.path.exists(base_parser.get_file('OUTCAR'))
     # This should now not eject an OSError as this is handled by the logger

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -75,8 +75,10 @@ class ExampleFileParser2(BaseFileParser):
 def vasp_parser_with_test(calc_with_retrieved):
     """Fixture providing a VaspParser instance coupled to a VaspCalculation."""
     from aiida.plugins import ParserFactory
+    from aiida.plugins import CalculationFactory
 
     settings_dict = {
+        #'ADDITIONAL_RETRIEVE_LIST': CalculationFactory('vasp.vasp')._ALWAYS_RETRIEVE_TEMPORARY_LIST,
         'parser_settings': {
             'add_custom': {
                 'link_name': 'custom_node',
@@ -99,7 +101,7 @@ def vasp_parser_with_test(calc_with_retrieved):
             'prerequisites': [],
         },
     )
-    success = parser.parse()
+    success = parser.parse(retrieved_temporary_folder=file_path)
     try:
         yield parser
     finally:
@@ -177,7 +179,7 @@ def test_parser_nodes(request, calc_with_retrieved):
     node = calc_with_retrieved(file_path, settings_dict)
 
     parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False)
+    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
     misc = result['misc']
     bands = result['bands']
@@ -219,7 +221,7 @@ def test_structure(request, calc_with_retrieved):
     node = calc_with_retrieved(file_path, settings_dict)
 
     parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False)
+    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
     # First fetch structure from vasprun
 
@@ -232,7 +234,7 @@ def test_structure(request, calc_with_retrieved):
     node = calc_with_retrieved(file_path, settings_dict)
 
     parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False)
+    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
     structure_poscar = result['structure']
 
@@ -281,7 +283,7 @@ def test_misc(request, calc_with_retrieved):
     node = calc_with_retrieved(file_path, settings_dict)
 
     parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False)
+    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
     misc = result['misc']
     assert isinstance(misc, get_data_class('dict'))

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -96,8 +96,6 @@ class VaspParser(BaseParser):
         # Initialise the 'get_quantity' delegate:
         setattr(self, 'get_quantity', Delegate())
 
-        self.out_folder = None
-
         try:
             calc_settings = self.node.inputs.settings
         except NotExistent:
@@ -137,16 +135,17 @@ class VaspParser(BaseParser):
 
         def missing_critical_file():
             for file_name, value_dict in self.settings.parser_definitions.items():
-                if file_name not in [item.name for item in self.retrieved.list_objects()] and value_dict['is_critical']:
+                if file_name not in self.retrieved_content.keys() and value_dict['is_critical']:
                     return True
             return False
 
-        error_code = self.get_folder()
+        error_code = self.check_folders(kwargs)
         if error_code is not None:
             return error_code
         if missing_critical_file():
-            # A critical file i.e. OUTCAR does not exist. Abort parsing.
-            return self.exit_codes.ERROR_MISSING_FILE
+            # A critical file is missing. Abort parsing
+            # in case we do not find this or other files marked with is_critical
+            return self.exit_codes.ERROR_CRITICAL_MISSING_FILE
 
         # Get the _quantities from the FileParsers.
         self.quantities.setup()

--- a/aiida_vasp/utils/fixtures/__init__.py
+++ b/aiida_vasp/utils/fixtures/__init__.py
@@ -3,11 +3,12 @@ from .data import localhost_dir, localhost, vasp_params, potentials, vasp_struct
     ref_incar_vasp2w90, vasp_chgcar, vasp_wavecar, ref_retrieved, vasp_structure_poscar, temp_pot_folder, potcar_family, \
     vasprun_parser, outcar_parser, mock_vasp, wannier_params, wannier_projections, ref_win, phonondb_run, vasp_inputs, vasp2w90_inputs
 from .environment import fresh_aiida_env
-from .calcs import base_calc, vasp_calc_and_ref, vasp2w90_calc_and_ref, vasp2w90_calc, vasp_calc
+from .calcs import base_calc, vasp_calc_and_ref, vasp2w90_calc_and_ref, vasp2w90_calc, vasp_calc, run_vasp_calc
 
 __all__ = [
     'fresh_aiida_env', 'localhost_dir', 'localhost', 'vasp_params', 'potentials', 'vasp_structure', 'vasp_kpoints', 'vasp_code',
     'ref_incar', 'ref_incar_vasp2w90', 'vasp_chgcar', 'vasp_wavecar', 'ref_retrieved', 'vasp_calc_and_ref', 'vasp2w90_calc_and_ref',
     'vasp2w90_calc', 'vasp_structure_poscar', 'temp_pot_folder', 'potcar_family', 'vasprun_parser', 'outcar_parser', 'mock_vasp',
-    'wannier_params', 'wannier_projections', 'ref_win', 'phonondb_run', 'base_calc', 'vasp_calc', 'vasp_inputs', 'vasp2w90_inputs'
+    'wannier_params', 'wannier_projections', 'ref_win', 'phonondb_run', 'base_calc', 'vasp_calc', 'vasp_inputs', 'vasp2w90_inputs',
+    'run_vasp_calc'
 ]


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#241 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
In order to enable automatic deletion of files after parsing `retrieve_temporary_list` is available in AiiDA. This replaced the `retrieve_list` which do not delete any file after parsing is completed. The current behavior is that all files are delated after parsing unless specific filenames are added using `ADDITIONAL_RETRIEVE_LIST`.