### PR TITLE
Fixed issue with analysing positional lengths in relaxation workchain

### DIFF
--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -564,7 +564,7 @@ class ConvergeWorkChain(WorkChain):
         try:
             self.ctx.inputs.relax = self.inputs.relax
         except AttributeError:
-            pass        
+            pass
         # The plane wave cutoff needs to be updated in the parameters to the set
         # value.
         converged_parameters_dict = self.inputs.parameters.get_dict()

--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -442,12 +442,14 @@ class RelaxWorkChain(WorkChain):
         return bool(lengths_converged and angles_converged)
 
     def check_volume_convergence(self, delta):
+        """Check the convergence of the volume, given a cutoff."""
         volume_converged = bool(delta.volume <= self.inputs.relax.convergence_volume.value)
         if not volume_converged:
             self.report('cell volume changed by {}, tolerance is {}'.format(delta.volume, self.inputs.relax.convergence_volume.value))
         return volume_converged
 
     def check_positions_convergence(self, delta):
+        """Check the convergence of the atomic positions, given a cutoff."""
         try:
             positions_converged = bool(delta.pos_lengths.nanmax() <= self.inputs.relax.convergence_positions.value)
         except RuntimeWarning:
@@ -455,7 +457,7 @@ class RelaxWorkChain(WorkChain):
             # we do not know if it is converged, so settings it to False
             self.report('there is NaN entries in the relative comparison for '
                         'the positions during relaxation, assuming position is not converged')
-            position_converged = False
+            positions_converged = False
 
         if not positions_converged:
             try:


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#289

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Due to nan entries the `max` function failed and the relaxation workchain
did not work as expected. This is now fixed, we keep the nan, but act
on the raised `RuntimeWarning` from numpy and force the convergence
to not be complete if this in encountered. An update to the plane wave
and k-point convergence workchain is also performed in order to enable a final
run using relaxation and the converged plane wave and k-point cutoffs.