### PR TITLE
Updated convergence data output to rest in the converge namespace

### DIFF
--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -1209,8 +1209,8 @@ class ConvergeWorkChain(WorkChain):
         convergence_context = get_data_node('dict', dict=convergence_dict)
         convergence = store_conv_data(convergence_context)
         if self._verbose:
-            self.report("attaching the node {}<{}> as '{}'".format(convergence.__class__.__name__, convergence.pk, 'convergence_data'))
-        self.out('convergence_data', convergence)
+            self.report("attaching the node {}<{}> as '{}'".format(convergence.__class__.__name__, convergence.pk, 'converge.data'))
+        self.out('converge.data', convergence)
 
     def _check_pw_converged(self, pw_data=None, cutoff_type=None, cutoff_value=None):
         """


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Due to the transition to namespaces we here fix the convergence data, which now reside in the `converge.data` namespace.