### PR TITLE
Changed ISIF from 1 to 2

### DIFF
--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -35,7 +35,7 @@ class RelaxWorkChain(WorkChain):
         Values can be found here: https://cms.mpi.univie.ac.at/wiki/index.php/ISIF
         """
 
-        POS_ONLY = 1
+        POS_ONLY = 2
         POS_SHAPE_VOL = 3
         POS_SHAPE = 4
         SHAPE_ONLY = 5


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#299

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
`ISIF=1` was stuck in the code, but it is better for us to use `ISIF=2` to give more info on the stress tensor, which is also the VASP default.