### PR TITLE
Fixed problem of relaxation override

### DIFF
--- a/aiida_vasp/workchains/master.py
+++ b/aiida_vasp/workchains/master.py
@@ -30,6 +30,7 @@ class MasterWorkChain(WorkChain):
         spec.expose_inputs(cls._base_workchain, exclude=['settings', 'clean_workdir'])
         spec.input('settings', valid_type=get_data_class('dict'), required=False)
         spec.input('kpoints', valid_type=get_data_class('array.kpoints'), required=False)
+        spec.input_namespace('relax', required=False, dynamic=True)
         spec.input('extract_bands',
                    valid_type=get_data_class('bool'),
                    required=False,
@@ -206,6 +207,12 @@ class MasterWorkChain(WorkChain):
 
         # Add exposed inputs
         self.ctx.inputs.update(self.exposed_inputs(self._next_workchain))
+
+        # Add relax inputs
+        try:
+            self.ctx.inputs.relax = self.inputs.relax
+        except KeyError:
+            pass
 
         # Make sure we do not have any floating dict (convert to Dict)
         self.ctx.inputs = prepare_process_inputs(self.ctx.inputs, namespaces=['relax', 'converge', 'verify'])

--- a/examples/run_bands.py
+++ b/examples/run_bands.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
     # AttributeDict is just a special dictionary with the extra benefit that
     # you can set and get the key contents with mydict.mykey, instead of mydict['mykey']
     OPTIONS = AttributeDict()
-    OPTIONS.account = ''
+    OPTIONS.account = 'nn9995k'
     OPTIONS.qos = ''
     OPTIONS.resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 16}
     OPTIONS.queue_name = ''


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#297 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
We needed to remove the relaxation flag during convergence runs and re enable the relaxation flags for the final relaxation.