### PR TITLE
Replaced old convergence_data

### DIFF
--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -264,7 +264,7 @@ class ConvergeWorkChain(WorkChain):
         )  # yapf: disable
 
         spec.expose_outputs(cls._next_workchain)
-        spec.output('convergence_data', valid_type=get_data_class('array'), required=False)
+        spec.output('convergence.data', valid_type=get_data_class('array'), required=False)
         spec.exit_code(0, 'NO_ERROR', message='the sun is shining')
         spec.exit_code(500, 'ERROR_UNKNOWN', message='unknown error detected in the converge workchain')
         spec.exit_code(420, 'ERROR_NO_CALLED_WORKCHAIN', message='no called workchain detected')

--- a/aiida_vasp/workchains/tests/test_converge_wc.py
+++ b/aiida_vasp/workchains/tests/test_converge_wc.py
@@ -79,18 +79,18 @@ def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
     inputs.verbose = get_data_node('bool', True)
     results, node = run.get_node(workchain, **inputs)
     assert node.exit_status == 0
-    assert 'convergence_data' in results
+    assert 'convergence.data' in results
     assert 'structure_relaxed' in results
 
-    conv_data = results['convergence_data']
+    conv_data = results['convergence.data']
     try:
         conv_data.get_array('pw_regular')
     except KeyError:
-        pytest.fail('Did not find pw_regular in convergence_data')
+        pytest.fail('Did not find pw_regular in convergence.data')
     try:
         conv_data.get_array('kpoints_regular')
     except KeyError:
-        pytest.fail('Did not find kpoints_regular in convergence_data')
+        pytest.fail('Did not find kpoints_regular in convergence.data')
 
 
 @pytest.mark.skip(reason='Too slow')
@@ -148,12 +148,12 @@ def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     inputs.verbose = get_data_node('bool', True)
     results, node = run.get_node(workchain, **inputs)
     assert node.exit_status == 0
-    assert 'convergence_data' in results
-    conv_data = results['convergence_data']
+    assert 'convergence.data' in results
+    conv_data = results['convergence.data']
     try:
         conv_data = conv_data.get_array('pw_regular')
     except KeyError:
-        pytest.fail('Did not find pw_regular in convergence_data')
+        pytest.fail('Did not find pw_regular in convergence.data')
     conv_data_test = np.array([[200.0, -10.77974998, 0.0, 0.0, 0.5984], [250.0, -10.80762044, 0.0, 0.0, 0.5912],
                                [300.0, -10.82261992, 0.0, 0.0, 0.5876]])
     np.testing.assert_allclose(conv_data, conv_data_test)


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#308 
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Replaced `convergence_data` with the updated `converge.data` which was not included when we moved to namespaces in the input and output.