### PR TITLE
Add lambda on input defaults

### DIFF
--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -51,56 +51,56 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.pwcutoff_start',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 200.0),
+                   default=lambda: get_data_node('float', 200.0),
                    help="""
                    The plane-wave cutoff in electron volts.
                    """)
         spec.input('converge.pwcutoff_step',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 50.0),
+                   default=lambda: get_data_node('float', 50.0),
                    help="""
                    The plane-wave cutoff step (increment) in electron volts.
                    """)
         spec.input('converge.pwcutoff_samples',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 10),
+                   default=lambda: get_data_node('int', 10),
                    help="""
                    The number of plane-wave cutoff samples.
                    """)
         spec.input('converge.k_dense',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.07),
+                   default=lambda: get_data_node('float', 0.07),
                    help="""
                    The target k-point stepping at the densest grid in inverse AA.
                    """)
         spec.input('converge.k_course',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.35),
+                   default=lambda: get_data_node('float', 0.35),
                    help="""
                    The target k-point stepping at the coursest grid in inverse AA.
                    """)
         spec.input('converge.k_spacing',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.1),
+                   default=lambda: get_data_node('float', 0.1),
                    help="""
                    The default k-point spacing in inverse AA.
                    """)
         spec.input('converge.k_samples',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 10),
+                   default=lambda: get_data_node('int', 10),
                    help="""
                    The number of k-point samples.
                    """)
         spec.input('converge.cutoff_type',
                    valid_type=get_data_class('str'),
                    required=False,
-                   default=get_data_node('str', 'energy'),
+                   default=lambda: get_data_node('str', 'energy'),
                    help="""
                    The cutoff_type to check convergence against. Currently the following
                    options are accepted:
@@ -112,7 +112,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.cutoff_value',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.01),
+                   default=lambda: get_data_node('float', 0.01),
                    help="""
                    The cutoff value to be used. When the difference between two convergence
                    calculations are within this value for ``cutoff_type``, then it is
@@ -121,7 +121,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.cutoff_value_r',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.01),
+                   default=lambda: get_data_node('float', 0.01),
                    help="""
                    The relative cutoff value to be used. When the difference between two convergence
                    calculations are within this value for ``cutoff_type``, then it is
@@ -132,7 +132,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.compress',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, a convergence test of the compressed structure is also
                    performed. The difference of the ``cutoff_type`` values for each
@@ -143,7 +143,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.displace',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, a convergence test of the displaced structure is also
                    performed. The difference of the ``cutoff_type`` values for each
@@ -154,7 +154,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.displacement_vector',
                    valid_type=get_data_class('array'),
                    required=False,
-                   default=default_array('array', np.array([1.0, 1.0, 1.0])),
+                   default=lambda: default_array('array', np.array([1.0, 1.0, 1.0])),
                    help="""
                    The displacement unit vector for the displacement test. Sets the direction
                    of displacement.
@@ -162,7 +162,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.displacement_distance',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.2),
+                   default=lambda: get_data_node('float', 0.2),
                    help="""
                    The displacement distance (L2 norm) for the displacement test in AA. Follows
                    the direction of ``displacement_vector``.
@@ -170,7 +170,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.displacement_atom',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 1),
+                   default=lambda: get_data_node('int', 1),
                    help="""
                    Which atom to displace? Index starts from 1 and follows the sequence for the
                    sites in the Aiida ``structure`` object.
@@ -178,21 +178,21 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.volume_change',
                    valid_type=get_data_class('array'),
                    required=False,
-                   default=default_array('array', np.array([1.05, 1.05, 1.05])),
+                   default=lambda: default_array('array', np.array([1.05, 1.05, 1.05])),
                    help="""
                    The volume change in direct coordinates for each lattice vector.
                    """)
         spec.input('converge.relax',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, we relax for each convergence test.
                    """)
         spec.input('converge.total_energy_type',
                    valid_type=get_data_class('str'),
                    required=False,
-                   default=get_data_node('str', 'energy_no_entropy'),
+                   default=lambda: get_data_node('str', 'energy_no_entropy'),
                    help="""
                    The energy type that is used when ``cutoff_type`` is set to `energy`.
                    Consult the options available in the parser for the current version.
@@ -200,7 +200,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.testing',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, we assume testing to be performed (e.g. dummy calculations).
                    """)

--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -34,13 +34,13 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.perform',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
             If True, perform relaxation.
             """)
         spec.input('relax.algo',
                    valid_type=get_data_class('str'),
-                   default=get_data_node('str', 'cg'),
+                   default=lambda: get_data_node('str', 'cg'),
                    help="""
             The algorithm to use during relaxation.
             """)
@@ -63,7 +63,7 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.steps',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 60),
+                   default=lambda: get_data_node('int', 60),
                    help="""
                    The number of relaxation steps to perform (updates to the atomic positions,
             unit cell size or shape).
@@ -71,49 +71,49 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.positions',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', True),
+                   default=lambda: get_data_node('bool', True),
                    help="""
                    If True, perform relaxation of the atomic positions.
                    """)
         spec.input('relax.shape',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, perform relaxation of the unit cell shape.
                    """)
         spec.input('relax.volume',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, perform relaxation of the unit cell volume..
                    """)
         spec.input('relax.convergence_on',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, test convergence based on selected criterias set.
                    """)
         spec.input('relax.convergence_absolute',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
                    If True, test convergence based on absolute differences.
                    """)
         spec.input('relax.convergence_max_iterations',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 5),
+                   default=lambda: get_data_node('int', 5),
                    help="""
                    The number of iterations to perform if the convergence criteria is not met.
                    """)
         spec.input('relax.convergence_volume',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.01),
+                   default=lambda: get_data_node('float', 0.01),
                    help="""
                    The cutoff value for the convergence check on volume. If ``convergence_absolute``
                    is True in AA, otherwise in relative.
@@ -121,7 +121,7 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.convergence_positions',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.01),
+                   default=lambda: get_data_node('float', 0.01),
                    help="""
                    The cutoff value for the convergence check on positions. If ``convergence_absolute``
                    is True in AA, otherwise in relative difference.
@@ -129,7 +129,7 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.convergence_shape_lengths',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.1),
+                   default=lambda: get_data_node('float', 0.1),
                    help="""
                    The cutoff value for the convergence check on the lengths of the unit cell
                    vecotrs. If ``convergence_absolute``
@@ -138,7 +138,7 @@ class RelaxWorkChain(WorkChain):
         spec.input('relax.convergence_shape_angles',
                    valid_type=get_data_class('float'),
                    required=False,
-                   default=get_data_node('float', 0.1),
+                   default=lambda: get_data_node('float', 0.1),
                    help="""
                    The cutoff value for the convergence check on the angles of the unit cell.
                    If ``convergence_absolute`` is True in degrees, otherwise in relative difference.

--- a/aiida_vasp/workchains/tests/test_converge_wc.py
+++ b/aiida_vasp/workchains/tests/test_converge_wc.py
@@ -21,7 +21,7 @@ from aiida_vasp.parsers.file_parsers.incar import IncarParser
 from aiida_vasp.utils.aiida_utils import create_authinfo
 
 
-@pytest.mark.skip(reason='Can not run two consecutive workchain tests. Disabling convergence tests. They run fine separately.')
+#@pytest.mark.skip(reason='Can not run two consecutive workchain tests. Disabling convergence tests. They run fine separately.')
 @pytest.mark.wc
 def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
     """Test submitting only, not correctness, with mocked vasp code."""
@@ -87,7 +87,7 @@ def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
         pytest.fail('Did not find kpoints_regular in converge.data')
 
 
-@pytest.mark.skip(reason='Can not run two consecutive workchain tests. Disabling convergence tests. They run fine separately.')
+#@pytest.mark.skip(reason='Can not run two consecutive workchain tests. Disabling convergence tests. They run fine separately.')
 @pytest.mark.wc
 def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     """Test convergence workflow using mock code."""

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -71,21 +71,21 @@ class VaspWorkChain(BaseRestartWorkChain):
         spec.input('max_iterations',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 5),
+                   default=lambda: get_data_node('int', 5),
                    help="""
             The maximum number of iterations to perform.
             """)
         spec.input('clean_workdir',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', True),
+                   default=lambda: get_data_node('bool', True),
                    help="""
             If True, clean the work dir upon the completion of a successfull calculation.
             """)
         spec.input('verbose',
                    valid_type=get_data_class('bool'),
                    required=False,
-                   default=get_data_node('bool', False),
+                   default=lambda: get_data_node('bool', False),
                    help="""
             If True, enable more detailed output during workchain execution.
             """)

--- a/aiida_vasp/workchains/verify.py
+++ b/aiida_vasp/workchains/verify.py
@@ -29,7 +29,7 @@ class VerifyWorkChain(WorkChain):
         spec.input('verify.max_iterations',
                    valid_type=get_data_class('int'),
                    required=False,
-                   default=get_data_node('int', 1),
+                   default=lambda: get_data_node('int', 1),
                    help="""
                    The maximum number of iterations to perform.
                    """)


### PR DESCRIPTION
To comply with the update https://github.com/aiidateam/aiida-core/pull/3466 we here incorporate lambda on all input nodes that are of an AiiDA data type. This is done to make it clear that we want to supply a immutable object as input. This also fixes the problem of not being able to run consequetive workchain tests, so in this PR all of the present workchain tests are finally enabled. In addition this PR fixes the previous problems of not being able to build RTD due to the need of a backend. Please consult https://github.com/aiidateam/aiida-core/pull/3466 and reference therein for additional details.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
