### PR TITLE
#320 related stuff and other minor fixes

### DIFF
--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -126,6 +126,9 @@ class VaspCalcBase(CalcJob):
         Is called once before submission.
         """
         self.check_restart_folder()
+        parser_name = self.inputs.metadata.options.get('parser_name')
+        if parser_name is None:
+            raise ValidationError("Please specify 'parser_name': {} in metadata.options".format(self._default_parser))
         return True
 
     def check_restart_folder(self):

--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -126,9 +126,6 @@ class VaspCalcBase(CalcJob):
         Is called once before submission.
         """
         self.check_restart_folder()
-        parser_name = self.inputs.metadata.options.get('parser_name')
-        if parser_name is None:
-            raise ValidationError("Please specify 'parser_name': {} in metadata.options".format(self._default_parser))
         return True
 
     def check_restart_folder(self):

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -88,6 +88,7 @@ class VaspCalculation(VaspCalcBase):
                    required=False,
                    help='The wave function coefficients. (WAVECAR)')
         spec.input('settings', valid_type=get_data_class('dict'), required=False, help='Additional parameters not related to VASP itself.')
+        spec.input('metadata.options.parser_name', default='vasp.vasp')
 
         # Define outputs.
         # remote_folder and retrieved are passed automatically

--- a/aiida_vasp/parsers/base.py
+++ b/aiida_vasp/parsers/base.py
@@ -50,14 +50,17 @@ class BaseParser(Parser):
 
         # Store the retrieved content
         self.retrieved_content = retrieved
-        return exit_code_temporary if not None else exit_code_permanent
+        # OK if a least one of the folders are present
+        if exit_code_permanent is None or exit_code_temporary is None:
+            return None
+        else:
+            # Both are not present, exit code of teh temporary folder take precedence  
+            return exit_code_temporary if not None else exit_code_permanent
 
     def check_temporary_folder(self, parser_kwargs):
         """Convenient check of the retrieved_temporary folder."""
-        try:
-            self.retrieved_temporary = parser_kwargs['retrieved_temporary_folder']
-            return None
-        except AttributeError:
+        self.retrieved_temporary = parser_kwargs.get('retrieved_temporary_folder', None)
+        if self.retrieved_temporary is None:
             return self.exit_codes.ERROR_NO_RETRIEVED_TEMPORARY_FOLDER
 
     def check_folder(self):

--- a/aiida_vasp/parsers/base.py
+++ b/aiida_vasp/parsers/base.py
@@ -53,15 +53,15 @@ class BaseParser(Parser):
         # OK if a least one of the folders are present
         if exit_code_permanent is None or exit_code_temporary is None:
             return None
-        else:
-            # Both are not present, exit code of teh temporary folder take precedence  
-            return exit_code_temporary if not None else exit_code_permanent
+        # Both are not present, exit code of teh temporary folder take precedence
+        return exit_code_temporary if not None else exit_code_permanent
 
     def check_temporary_folder(self, parser_kwargs):
         """Convenient check of the retrieved_temporary folder."""
         self.retrieved_temporary = parser_kwargs.get('retrieved_temporary_folder', None)
         if self.retrieved_temporary is None:
             return self.exit_codes.ERROR_NO_RETRIEVED_TEMPORARY_FOLDER
+        return None
 
     def check_folder(self):
         """Convenient check of the retrieved folder."""

--- a/aiida_vasp/utils/fixtures/calcs.py
+++ b/aiida_vasp/utils/fixtures/calcs.py
@@ -164,7 +164,6 @@ def run_vasp_calc(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_s
                                                                                    family_name=POTCAR_FAMILY_NAME,
                                                                                    mapping=POTCAR_MAP)
         options = {
-            'parser_name': 'vasp.vasp',
             'withmpi': False,
             'queue_name': 'None',
             'resources': {

--- a/aiida_vasp/utils/parameters.py
+++ b/aiida_vasp/utils/parameters.py
@@ -118,10 +118,10 @@ class ParametersMassage():
         except AttributeError:
             pass
         # If we find any raw code input key directly on parameter root, override whatever we have set until now
-        # Also, make sure it is lowercase
-        if self._parameters.get(key):
+        # Note that the key may be in upper case, so we test both
+        if key in self._parameters:
             self._massage[key] = self._parameters[key]
-        elif self._parameters.get(key.upper()):
+        elif key.upper() in self._parameters:
             self._massage[key] = self._parameters[key.upper()]
 
     @property

--- a/aiida_vasp/utils/parameters.py
+++ b/aiida_vasp/utils/parameters.py
@@ -119,8 +119,10 @@ class ParametersMassage():
             pass
         # If we find any raw code input key directly on parameter root, override whatever we have set until now
         # Also, make sure it is lowercase
-        if self._parameters.get(key) or self._parameters.get(key.upper()):
+        if self._parameters.get(key):
             self._massage[key] = self._parameters[key]
+        elif self._parameters.get(key.upper()):
+            self._massage[key] = self._parameters[key.upper()]
 
     @property
     def parameters(self):

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -184,12 +184,12 @@ class VaspWorkChain(BaseRestartWorkChain):
             options.update(self.inputs.options)
             self.ctx.inputs.metadata = {}
             self.ctx.inputs.metadata['options'] = options
-            # Also make sure we specify the entry point for the
-            # default parser if that is not already specified
-            default_parser = self.ctx.inputs.metadata['options'].get('parser_name', 'vasp.vasp')
+            # Override the parser name if it is supplied by the user.
+            parser_name = self.ctx.inputs.metadata['options'].get('parser_name')
+            if parser_name:
+                self.ctx.inputs.metadata['options']['parser_name'] = parser_name
             # Set MPI to True, unless the user specifies otherwise
             withmpi = self.ctx.inputs.metadata['options'].get('withmpi', True)
-            self.ctx.inputs.metadata['options']['parser_name'] = default_parser
             self.ctx.inputs.metadata['options']['withmpi'] = withmpi
 
         # Verify and set potentials (potcar)


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

#320 to some extend. A check of `parser_name` is added to `VaspCaculation`.
 
blocks:

is blocked by:

#320 what about the default file retrieve behaviour - permanent or temporary? 

None of the above but is still related to the following:

## Description

In addition to the above, this PR contains the following minor fixes:
* Fixed a bug where `ParameterMassage` does not convert upper case keys properly. 
* Fixed a bug where `VaspParser` throws an error whenever `retrieved_temporary` is absent - it should only do so when both the temporary and permanent retrieves are not there.