### PR TITLE
Make sure always retrieve files are stored by default

### DIFF
--- a/aiida_vasp/commands/mock_vasp.py
+++ b/aiida_vasp/commands/mock_vasp.py
@@ -32,6 +32,7 @@ def mock_vasp():
     assert aiida_path.isdir()
     assert aiida_cfg.isfile()
     click.echo(aiida_cfg.read())
+
     incar = pwd.join('INCAR')
     assert incar.isfile(), 'INCAR input file was not found.'
 

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -78,7 +78,7 @@ def vasp_parser_with_test(calc_with_retrieved):
     from aiida.plugins import CalculationFactory
 
     settings_dict = {
-        #'ADDITIONAL_RETRIEVE_LIST': CalculationFactory('vasp.vasp')._ALWAYS_RETRIEVE_TEMPORARY_LIST,
+        #'ADDITIONAL_RETRIEVE_LIST': CalculationFactory('vasp.vasp')._ALWAYS_RETRIEVE_LIST,
         'parser_settings': {
             'add_custom': {
                 'link_name': 'custom_node',

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -99,7 +99,6 @@ def potcar_family(fresh_aiida_env, temp_pot_folder):
     family_desc = 'A POTCAR family used as a test fixture. Contains only unusable POTCAR files.'
     potcar_cls = get_data_class('vasp.potcar')
     potcar_cls.upload_potcar_family(temp_pot_folder.strpath, family_name, family_desc, stop_if_existing=False)
-    print(potcar_cls)
     if len(potcar_cls.find(full_name='In_d')) == 1:
         family_group = potcar_cls.get_potcar_group(POTCAR_FAMILY_NAME)
         in_d = potcar_cls.find(full_name='In_d')[0]

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -99,6 +99,7 @@ def potcar_family(fresh_aiida_env, temp_pot_folder):
     family_desc = 'A POTCAR family used as a test fixture. Contains only unusable POTCAR files.'
     potcar_cls = get_data_class('vasp.potcar')
     potcar_cls.upload_potcar_family(temp_pot_folder.strpath, family_name, family_desc, stop_if_existing=False)
+    print(potcar_cls)
     if len(potcar_cls.find(full_name='In_d')) == 1:
         family_group = potcar_cls.get_potcar_group(POTCAR_FAMILY_NAME)
         in_d = potcar_cls.find(full_name='In_d')[0]

--- a/setup.json
+++ b/setup.json
@@ -67,7 +67,7 @@
     },
     "include_package_data": true,
     "install_requires": [
-        "aiida-core[atomic_tools] >= 1.0.1",
+        "aiida-core[atomic_tools] == 1.1.0",
         "subprocess32",
         "py == 1.5.4",
         "lxml",


### PR DESCRIPTION
The always retrieve files are now stored as a default. This can be changed by setting ALWAYS_STORE to False in the settings, or as before specify ALWAYS_RETRIEVE_LIST and ALWAYS_RETRIEVE_TEMPORARY_LIST, also in settings. A few tests to tests different combinations have been introduced.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

Partly fixes #320.

## Description
In order to make it easier for users to do post processing etc. we here enable the storage of the parsed files by default.