### PR TITLE
Fix concept of PotcarFamily to work with `aiida-core==1.2.0`

### DIFF
--- a/aiida_vasp/groups/potcar_family.py
+++ b/aiida_vasp/groups/potcar_family.py
@@ -1,0 +1,5 @@
+from aiida.orm import Group
+
+
+class PotcarFamily(Group):
+    pass

--- a/setup.json
+++ b/setup.json
@@ -25,6 +25,9 @@
             "vasp.potcar = aiida_vasp.data.potcar:PotcarData",
             "vasp.potcar_file = aiida_vasp.data.potcar:PotcarFileData"
         ],
+        "aiida.groups": [
+            "vasp.potcar_family = aiida_vasp.groups.potcar_family:PotcarFamily"
+        ],
         "aiida.parsers": [
             "vasp.vasp = aiida_vasp.parsers.vasp:VaspParser",
             "vasp.vasp2w90 = aiida_vasp.parsers.vasp2w90:Vasp2w90Parser"


### PR DESCRIPTION
In `aiida-core==1.2.0` the `Group` class can be properly subclassed and
so passing a manual `type_string` in the constructor is deprecated. Here
we implement the concept of the potcar family as a proper subclass of
`Group` and register it through the entry points.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

## Description
The way groups are handled in AiiDA changed in a PR that is most likely going into 1.2. This PR illustrates the bare minimum of changes that we need to incorporate to make the current POTCAR code fly.