### PR TITLE
Catch invalid INCAR tags

### DIFF
--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -78,6 +78,23 @@ def test_write_wavecar(localhost_dir, vasp_calc, vasp_inputs, vasp_wavecar):
     assert 'WAVECAR' in [item[1] for item in calcinfo.local_copy_list]
 
 
+@ONLY_ONE_CALC
+def test_incar_validate(vasp_calc, vasp_inputs, localhost_dir):
+    """Test incar with invaid tags raises exception"""
+    from aiida.common import InputValidationError
+    from aiida.common.folders import Folder
+    inputs_dict = {
+        'gga': 'PE',
+        'smear': 3  # <- Invalid tag
+    }
+    inputs = vasp_inputs(parameters=inputs_dict)
+    calc = vasp_calc(inputs=inputs)
+
+    temp_folder = Folder(str(localhost_dir.dirpath()))
+    with pytest.raises(InputValidationError):
+        calc.prepare_for_submission(temp_folder)
+
+
 # pylint: disable=protected-access
 @ONLY_ONE_CALC
 def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_dir):
@@ -86,7 +103,7 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
     wavecar, _ = vasp_wavecar
     chgcar, _ = vasp_chgcar
 
-    inputs_dict = {'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sima': 0.5, 'magmom': '30 * 2*0.', 'charg': 11}
+    inputs_dict = {'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'icharg': 11}
 
     inputs = vasp_inputs(parameters=inputs_dict)
     inputs.charge_density = chgcar
@@ -94,7 +111,6 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
 
     calc = vasp_calc(inputs=inputs)
     temp_folder = Folder(str(localhost_dir.dirpath()))
-
     calcinfo = calc.prepare_for_submission(temp_folder)
     input_files = temp_folder.get_content_list()
 

--- a/aiida_vasp/parsers/file_parsers/incar.py
+++ b/aiida_vasp/parsers/file_parsers/incar.py
@@ -5,8 +5,9 @@ INCAR parser.
 The file parser that handles the parsing of INCAR files.
 """
 from parsevasp.incar import Incar
-from aiida_vasp.parsers.file_parsers.parser import BaseFileParser
+from aiida.common import InputValidationError
 
+from aiida_vasp.parsers.file_parsers.parser import BaseFileParser
 from aiida_vasp.utils.aiida_utils import get_data_class
 
 
@@ -56,8 +57,8 @@ class IncarParser(BaseFileParser):
 
         try:
             return Incar(incar_dict=incar_dict, logger=self._logger)
-        except SystemExit:
-            return None
+        except SystemExit as error:
+            raise InputValidationError(error.args[0])
 
     def _parse_file(self, inputs):
         """Create a DB Node from an INCAR file."""

--- a/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
@@ -3,6 +3,7 @@
 
 import pytest
 from pytest import raises
+from aiida.common import InputValidationError
 
 from aiida_vasp.utils.fixtures import *
 from aiida_vasp.utils.fixtures.testdata import data_path
@@ -94,3 +95,11 @@ def test_write_parser(fresh_aiida_env, tmpdir, incar_dict_example):
     # compare
     comp_dict = {'encut': 350, 'sigma': 0.05, 'lreal': False, 'prec': 'Accurate'}
     assert str(sorted(result)) == str(sorted(comp_dict))
+
+    # Test validation
+    with_invalid = dict(incar_dict_example)
+    with_invalid.update(foo='bar')
+    incar_params = get_data_class('dict')(dict=with_invalid)
+    parser = IncarParser(data=incar_params)
+    with pytest.raises(InputValidationError):
+        parser.write(temp_file)

--- a/aiida_vasp/utils/parameters.py
+++ b/aiida_vasp/utils/parameters.py
@@ -55,10 +55,6 @@ class IntSmearingEnum(enum.IntEnum):
     PARTIAL = -2
     TETRA = -5
 
-# Name spaces that are know to be valid and will be further processed by
-# ParameterSetFunctions
-KNOWN_NAMESPACES = ['relax']
-
 
 class OrbitEnum(enum.IntEnum):
     """

--- a/aiida_vasp/utils/tests/test_parameters.py
+++ b/aiida_vasp/utils/tests/test_parameters.py
@@ -78,16 +78,15 @@ def test_relax_parameters_all_set(init_relax_parameters):
     assert parameters.isif == 3
 
 
-
-def test_catch_invalid_tags(init_general_parameters, init_simple_workchain):
-    with_invalid = AttributeDict(init_general_parameters)
+def test_catch_invalid_tags(init_relax_parameters, init_simple_workchain):
+    init_relax_parameters.vasp = AttributeDict()
     mock_workchain = init_simple_workchain
-    with_invalid.update(smear=1)  # This is an invalid tag
-    massager = ParametersMassage(mock_workchain, with_invalid)
+    init_relax_parameters.vasp.smear = 1  # This is an invalid tag
+    massager = ParametersMassage(mock_workchain, init_relax_parameters)
     assert massager.exit_code is not None
 
 
-def test_relax_parameters_energy(init_general_parameters):
+def test_relax_parameters_energy(init_relax_parameters):
     """Test no provided force cutoff. It should be set to a default value."""
     del init_relax_parameters.relax.force_cutoff
     massager = ParametersMassage(None, init_relax_parameters)

--- a/aiida_vasp/utils/tests/test_parameters.py
+++ b/aiida_vasp/utils/tests/test_parameters.py
@@ -78,7 +78,16 @@ def test_relax_parameters_all_set(init_relax_parameters):
     assert parameters.isif == 3
 
 
-def test_relax_parameters_energy(init_relax_parameters):
+
+def test_catch_invalid_tags(init_general_parameters, init_simple_workchain):
+    with_invalid = AttributeDict(init_general_parameters)
+    mock_workchain = init_simple_workchain
+    with_invalid.update(smear=1)  # This is an invalid tag
+    massager = ParametersMassage(mock_workchain, with_invalid)
+    assert massager.exit_code is not None
+
+
+def test_relax_parameters_energy(init_general_parameters):
     """Test no provided force cutoff. It should be set to a default value."""
     del init_relax_parameters.relax.force_cutoff
     massager = ParametersMassage(None, init_relax_parameters)


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #332 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Try to fix #332, catch invalid INCAR tags at both `VaspCalculation` and `VaspWorkChain` level.