### PR TITLE
Fixed immigrator by adding explicit call to presubmit

### DIFF
--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -33,8 +33,13 @@ class VaspImmigrant(VaspCalculation):
     def run(self):
         import plumpy
         from aiida.engine.processes.calcjobs.tasks import RETRIEVE_COMMAND
+        from aiida.common.folders import SandboxFolder
 
         _ = super(VaspImmigrant, self).run()
+
+        # Make sure the retrieve list is set (done in presubmit so we need to call that also)
+        with SandboxFolder() as folder:
+            _, _ = self.presubmit(folder)
 
         settings = self.inputs.get('settings', None)
         settings = settings.get_dict() if settings else {}

--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -39,7 +39,7 @@ class VaspImmigrant(VaspCalculation):
 
         # Make sure the retrieve list is set (done in presubmit so we need to call that also)
         with SandboxFolder() as folder:
-            _, _ = self.presubmit(folder)
+            self.presubmit(folder)
 
         settings = self.inputs.get('settings', None)
         settings = settings.get_dict() if settings else {}


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes:
#313 

## Description
Upon enabling to use an exclude list for the retrieved files in AiiDA, the call was moved to `presubmit`, which we did not call in our `run` override. An explicit call has been added which fixes the failed immigrator tests. In addition, both tests were modified.