### PR TITLE
Moved override input parameters into a namespace

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -168,8 +168,12 @@ class VaspCalculation(VaspCalcBase):
 
     @property
     def _parameters(self):
+        """Make sure all parameters are lowercase."""
         all_parameters = self.inputs.parameters.get_dict()
-        return {k.lower(): v for k, v in all_parameters.items()}
+        try:
+            return {k.lower(): v for k, v in all_parameters.items()}
+        except KeyError:
+            return {}
 
     def _need_kp(self):
         """

--- a/aiida_vasp/parsers/file_parsers/incar.py
+++ b/aiida_vasp/parsers/file_parsers/incar.py
@@ -48,7 +48,7 @@ class IncarParser(BaseFileParser):
         """
         Return an instance of parsevasp.incar.Incar.
 
-        Corresponds to the stored data in inputs.parameters.incar.
+        Corresponds to the stored data in inputs.parameters.
 
         """
 

--- a/aiida_vasp/utils/tests/test_parameters.py
+++ b/aiida_vasp/utils/tests/test_parameters.py
@@ -1,5 +1,5 @@
 """Test aiida_parameters."""
-# pylint: disable=unused-import,redefined-outer-name,unused-argument,unused-wildcard-import,wildcard-import,no-member
+# pylint: disable=unused-import,redefined-outer-name,unused-argument,unused-wildcard-import,wildcard-import,no-member, import-outside-toplevel
 
 import pytest
 
@@ -280,3 +280,58 @@ def test_orbital_projections():  # pylint: disable=too-many-statements
     parameters.bands.wigner_seitz_radius = 2.0
     with pytest.raises(ValueError):
         massager = ParametersMassage(None, parameters)
+
+
+def test_vasp_parameter_override(init_relax_parameters):
+    """Test of the override functionality works as intended."""
+    init_relax_parameters.vasp = AttributeDict()
+    # Redefine to from 3 to 0.
+    init_relax_parameters.vasp.isif = 0
+    massager = ParametersMassage(None, init_relax_parameters)
+    assert massager.exit_code is None
+    assert massager.parameters.isif == 0
+
+
+def test_inherit_and_merge():
+    """Test the inherit and merge functionality for the parameters and inputs."""
+    from aiida.plugins import DataFactory
+    from aiida_vasp.utils.parameters import inherit_and_merge_parameters
+
+    inputs = AttributeDict()
+    inputs.bands = AttributeDict()
+    inputs.bands.somekey = DataFactory('bool')(True)
+    inputs.relax = AttributeDict()
+    inputs.relax.somekey = DataFactory('bool')(True)
+    inputs.smearing = AttributeDict()
+    inputs.smearing.somekey = DataFactory('bool')(True)
+    inputs.charge = AttributeDict()
+    inputs.charge.somekey = DataFactory('bool')(True)
+    inputs.converge = AttributeDict()
+    inputs.converge.somekey = DataFactory('bool')(True)
+    inputs.electronic = AttributeDict()
+    inputs.electronic.somekey = DataFactory('bool')(True)
+    # Check that parameters does not have to be present
+    parameters = inherit_and_merge_parameters(inputs)
+    # Check that an empty parameters is allowed
+    inputs.parameters = DataFactory('dict')(dict={})
+    parameters = inherit_and_merge_parameters(inputs)
+    print(parameters)
+    test_parameters = AttributeDict({
+        'electronic': AttributeDict({'somekey': True}),
+        'bands': AttributeDict({'somekey': True}),
+        'smearing': AttributeDict({'somekey': True}),
+        'charge': AttributeDict({'somekey': True}),
+        'relax': AttributeDict({'somekey': True}),
+        'converge': AttributeDict({'somekey': True})
+    })
+    assert parameters == test_parameters
+    # Test ignored
+    inputs.ignored = AttributeDict()
+    inputs.ignored.ignored = DataFactory('bool')(True)
+    parameters = inherit_and_merge_parameters(inputs)
+    assert parameters == test_parameters
+    # Test to override inputs.bands.somekey
+    inputs.parameters = DataFactory('dict')(dict={'bands': {'somekey': False}})
+    parameters = inherit_and_merge_parameters(inputs)
+    test_parameters.bands.somekey = False
+    assert parameters == test_parameters

--- a/aiida_vasp/workchains/bands.py
+++ b/aiida_vasp/workchains/bands.py
@@ -27,7 +27,6 @@ class BandsWorkChain(WorkChain):
         super(BandsWorkChain, cls).define(spec)
         spec.expose_inputs(cls._next_workchain, exclude=('parameters', 'settings', 'kpoints'))
         spec.input('parameters', valid_type=get_data_class('dict'), required=False)
-        spec.input('bands.parameters', valid_type=get_data_class('dict'), required=False)
         spec.input('settings', valid_type=get_data_class('dict'), required=False)
         spec.input('smearing.gaussian', valid_type=get_data_class('bool'), required=False, default=lambda: get_data_node('bool', True))
         spec.input('smearing.sigma', valid_type=get_data_class('float'), required=False, default=lambda: get_data_node('float', 0.05))
@@ -133,11 +132,6 @@ class BandsWorkChain(WorkChain):
             self.ctx.inputs.verbose = self.inputs.verbose
         except AttributeError:
             pass
-
-    def _add_overrides(self, parameters):
-        """Add parameters tag overrides, except the ones controlled by other inputs (for provenance)."""
-        overrides = AttributeDict({k.lower(): v for k, v in self.inputs.bands.parameters.get_dict().items()})
-        parameters.update(overrides)
 
     def _init_parameters(self):
         """Collect input to the workchain in the relax namespace and put that into the parameters."""

--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -10,12 +10,12 @@ import numpy as np
 
 from aiida.engine import WorkChain, append_, while_, if_, calcfunction
 from aiida.common.extendeddicts import AttributeDict
-from aiida.plugins import WorkflowFactory, DataFactory
+from aiida.plugins import WorkflowFactory
 from aiida.orm.nodes.data.array.bands import find_bandgap
 
 from aiida_vasp.utils.aiida_utils import (get_data_class, get_data_node, displaced_structure, compressed_structure)
 from aiida_vasp.utils.workchains import fetch_k_grid, prepare_process_inputs, compose_exit_code
-from aiida_vasp.utils.extended_dicts import update_nested_dict
+from aiida_vasp.utils.parameters import inherit_and_merge_parameters
 
 
 class ConvergeWorkChain(WorkChain):
@@ -283,39 +283,7 @@ class ConvergeWorkChain(WorkChain):
         # At some point we will replace this with possibly input checking using the PortNamespace on
         # a dict parameter type. As such we remove the workchain input parameters as node entities. Much of
         # the following is just a workaround until that is in place in AiiDA core.
-
-        # First collect input that is under the converge namespace defined on the workchain itself and
-        # put that into parameters.
-        parameters = AttributeDict()
-        parameters.converge = AttributeDict()
-        for key, item in self.inputs.converge.items():
-            # Make sure we unwrap the AiiDA data nodes
-            if isinstance(item, DataFactory('array')):
-                parameters.converge[key] = item.get_array('array')
-            else:
-                # Assume only Str, Int, Float except ArrayData
-                parameters.converge[key] = item.value
-        # Second collect input that is under the relax namespace defined on the workchain itself and
-        # put that into parameters.
-        parameters.relax = AttributeDict()
-        for key, item in self.inputs.relax.items():
-            # Make sure we unwrap the AiiDA data nodes
-            if isinstance(item, DataFactory('array')):
-                parameters.relax[key] = item.get_array('array')
-            else:
-                # Assume only Str, Int, Float except ArrayData
-                parameters.relax[key] = item.value
-
-        # Now get the input parameters and update the dictionary. This means,
-        # any supplied parameters in the converge namespace will override what is supplied to the workchain
-        # in the converge and relax namespace.
-        try:
-            input_parameters = AttributeDict(self.inputs.parameters.get_dict())
-            # We cannot use update here, as we only want to replace each key if it exists, if a key
-            # contains a new dict we need to traverse that, hence we have a function to perform this update
-            update_nested_dict(parameters, input_parameters)
-        except AttributeError:
-            pass
+        parameters = inherit_and_merge_parameters(self.inputs)
 
         return parameters
 
@@ -390,17 +358,12 @@ class ConvergeWorkChain(WorkChain):
         self.ctx.converge.pwcutoff_sampling = None
         self.ctx.converge.pw_iteration = 0
         settings.pwcutoff = None
-        # Set supplied pwcutoff
         try:
-            settings.pwcutoff = copy.deepcopy(self.inputs.converge.pwcutoff.value)
-        except AttributeError:
-            pass
-        # Check if pwcutoff is supplied in the parameters input, this takes presence over
-        # the pwcutoff supplied in the workchain inputs.
-        try:
-            parameters_dict = self.inputs.parameters.get_dict()
-            pwcutoff = parameters_dict.get('pwcutoff', None)
-            settings.pwcutoff = pwcutoff
+            parameters_dict = self.ctx.inputs.parameters.get_dict()
+            electronic = parameters_dict.get('electronic', None)
+            if electronic is not None:
+                pwcutoff = electronic.get('pwcutoff', None)
+                settings.pwcutoff = pwcutoff
         except AttributeError:
             pass
         # We need a copy of the original pwcutoff as we will modify it
@@ -609,7 +572,7 @@ class ConvergeWorkChain(WorkChain):
             pass
         # The plane wave cutoff needs to be updated in the parameters to the set
         # value.
-        self.ctx.inputs.parameters.update({'pwcutoff': self.ctx.converge.settings.pwcutoff})
+        self.ctx.inputs.parameters.update({'electronic': {'pwcutoff': self.ctx.converge.settings.pwcutoff}})
         # And finally, the k-point grid needs to be updated to the set value, but
         # only if a kpoint mesh was not supplied
         if not self.ctx.converge.settings.supplied_kmesh:
@@ -700,7 +663,7 @@ class ConvergeWorkChain(WorkChain):
                 else:
                     location = 'test-case:test_converge_wc/both/' + str(int(settings.pwcutoff)) + '_' + str(settings.kgrid[0]) + '_' + str(
                         settings.kgrid[1]) + '_' + str(settings.kgrid[2])
-            param_dict['system'] = location
+            param_dict['vasp'] = {'system': location}
             self.ctx.converge.parameters = param_dict
 
         # Set input nodes

--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -15,7 +15,7 @@ from aiida.plugins import WorkflowFactory
 
 from aiida_vasp.utils.aiida_utils import get_data_class, get_data_node
 from aiida_vasp.utils.workchains import compare_structures, prepare_process_inputs, compose_exit_code
-from aiida_vasp.utils.extended_dicts import update_nested_dict
+from aiida_vasp.utils.parameters import inherit_and_merge_parameters
 
 
 class RelaxWorkChain(WorkChain):
@@ -223,21 +223,8 @@ class RelaxWorkChain(WorkChain):
         # At some point we will replace this with possibly input checking using the PortNamespace on
         # a dict parameter type. As such we remove the workchain input parameters as node entities. Much of
         # the following is just a workaround until that is in place in AiiDA core.
+        parameters = inherit_and_merge_parameters(self.inputs)
 
-        # First collect input that is under the relax namespace defined on the workchain itself and
-        # put that into parameters.
-        parameters = AttributeDict()
-        parameters.relax = AttributeDict()
-        for key, item in self.inputs.relax.items():
-            # Make sure we do not store AiiDA nodes (hence the use of value)
-            parameters.relax[key] = item.value
-        # Now get the input parameters and update the dictionary. This means,
-        # any supplied parameters in the relax namespace will override what is supplied to the workchain
-        # in the relax namespace.
-        input_parameters = AttributeDict(self.inputs.parameters.get_dict())
-        # We cannot use update here, as we only want to replace each key if it exists, if a key
-        # contains a new dict we need to traverse that, hence we have a function to perform this update
-        update_nested_dict(parameters, input_parameters)
         # Need to save the parameter that controls if relaxation should be performed
         self.ctx.relax = parameters.relax.perform
         if not parameters.relax.perform:

--- a/aiida_vasp/workchains/tests/test_bands_wc.py
+++ b/aiida_vasp/workchains/tests/test_bands_wc.py
@@ -36,9 +36,10 @@ def test_bands_wc(fresh_aiida_env, potentials, mock_vasp):
     structure = PoscarParser(file_path=data_path('test_bands_wc', 'inp', 'POSCAR')).structure
     parameters = IncarParser(file_path=data_path('test_bands_wc', 'inp', 'INCAR')).incar
     parameters['system'] = 'test-case:test_bands_wc'
-    # make sure we replace encut with pwcutoff
+    # Make sure we replace encut with pwcutoff
     del parameters['encut']
-    parameters['pwcutoff'] = 200
+    parameters = {'vasp': parameters}
+    parameters['electronic'] = {'pwcutoff': 200}
 
     inputs = AttributeDict()
     inputs.code = Code.get_from_string('mock-vasp@localhost')

--- a/aiida_vasp/workchains/tests/test_converge_wc.py
+++ b/aiida_vasp/workchains/tests/test_converge_wc.py
@@ -36,8 +36,8 @@ def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
 
     structure = PoscarParser(file_path=data_path('test_converge_wc', 'inp', 'POSCAR')).structure
     parameters = IncarParser(file_path=data_path('test_converge_wc', 'inp', 'INCAR')).incar
-    parameters = {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}
     parameters['system'] = 'test-case:test_converge_wc'
+    parameters = {'vasp': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}}
 
     restart_clean_workdir = get_data_node('bool', False)
     restart_clean_workdir.store()
@@ -102,9 +102,9 @@ def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
 
     structure = PoscarParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'POSCAR')).structure
     parameters = IncarParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'INCAR')).incar
-    parameters = {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}
-    kpoints = KpointsParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'KPOINTS')).kpoints
     parameters['system'] = 'test-case:test_converge_wc'
+    parameters = {'vasp': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}}
+    kpoints = KpointsParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'KPOINTS')).kpoints
 
     restart_clean_workdir = get_data_node('bool', False)
     restart_clean_workdir.store()
@@ -150,6 +150,7 @@ def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
         conv_data = conv_data.get_array('pw_regular')
     except KeyError:
         pytest.fail('Did not find pw_regular in converge.data')
+    print(conv_data)
     conv_data_test = np.array([[200.0, -10.77974998, 0.0, 0.0, 0.5984], [250.0, -10.80762044, 0.0, 0.0, 0.5912],
                                [300.0, -10.82261992, 0.0, 0.0, 0.5876]])
     np.testing.assert_allclose(conv_data, conv_data_test)

--- a/aiida_vasp/workchains/tests/test_relax_wc.py
+++ b/aiida_vasp/workchains/tests/test_relax_wc.py
@@ -35,8 +35,8 @@ def test_relax_wc(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     structure = PoscarParser(file_path=data_path('test_relax_wc', 'inp', 'POSCAR')).structure
     kpoints = KpointsParser(file_path=data_path('test_relax_wc', 'inp', 'KPOINTS')).kpoints
     parameters = IncarParser(file_path=data_path('test_relax_wc', 'inp', 'INCAR')).incar
-    parameters = {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'nsw', 'ediffg']}
     parameters['system'] = 'test-case:test_relax_wc'
+    parameters = {'vasp': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'nsw', 'ediffg']}}
     parameters['relax'] = {}
     parameters['relax']['perform'] = True
     parameters['relax']['algo'] = 'cg'
@@ -63,7 +63,6 @@ def test_relax_wc(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     inputs.max_iterations = get_data_node('int', 1)
     inputs.clean_workdir = get_data_node('bool', False)
     inputs.verbose = get_data_node('bool', True)
-    #raise ValueError(inputs.parameters.get_dict())
     results, node = run.get_node(workchain, **inputs)
     assert node.exit_status == 0
     assert 'relax' in results

--- a/examples/run_bands.py
+++ b/examples/run_bands.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'prec': 'NORMAL', 'pwcutoff': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}
+    INCAR = {'vasp': {'prec': 'NORMAL', 'pwcutoff': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_converge.py
+++ b/examples/run_converge.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     # INCAR equivalent
     # Set input parameters (make sure we do not set ENCUT in order to run convergence tests
     # on the plane wave cutoff)
-    INCAR = {'prec': 'NORMAL', 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}
+    INCAR = {'vasp': {'prec': 'NORMAL', 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_relax.py
+++ b/examples/run_relax.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'encut': 240, 'ismear': 0, 'sigma': 0.1, 'system': 'test system'}
+    INCAR = {'vasp': {'encut': 240, 'ismear': 0, 'sigma': 0.1, 'system': 'test system'}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_vasp_lean.py
+++ b/examples/run_vasp_lean.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}
+    INCAR = {'vasp': {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_vasp_prep_w90.py
+++ b/examples/run_vasp_prep_w90.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}
+    INCAR = {'vasp': {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes:
#333 

blocks:

## Description
In order to be able to check any supplied override parameters we needed to move these into a dedicated namespace. This namespace, now also corresponds well to the workchain where the conversion takes place.