### PR TITLE
Enable GitHub Actions and Codecov

### DIFF
--- a/.ci/enable_ssh_localhost.sh
+++ b/.ci/enable_ssh_localhost.sh
@@ -1,19 +1,8 @@
-#!/bin/bash
-# Allow ``ssh localhost`` with empty passphrase on travis-ci.org continuous
-# integration platform.
+et -ev
 
-# Make sure we are on Travis.
-if [[ ! $TRAVIS ]]; then
-    echo "This script is made for travis-ci.org! It cannot run without \$TRAVIS."
-    exit 1
-fi
+ssh-keygen -q -t rsa -b 4096 -m PEM -N "" -f "${HOME}/.ssh/id_rsa"
+ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
+ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
 
-# Run SSH service, configure automatic access to localhost.
-sudo start ssh
-ssh-keygen -t rsa -f ~/.ssh/id_rsa -N "" -q
-cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-ssh-keyscan -t rsa localhost >> ~/.ssh/known_hosts
-cat << EOF >> ~/.ssh/config
-Host localhost
-     IdentityFile ~/.ssh/id_rsa
-EOF
+# The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
+chmod 755 "${HOME}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: aiida-vasp
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python: ['3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
+          pip --version
+      - name: Install AiiDA-VASP
+        run:
+          pip install -e .[graphs,dev]
+          pip freeze
+      - name: Run pre-commit
+        run: pre-commit run --all-files || ( git diff; git status; exit 1; )
+  tests:
+    needs: [pre-commit]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:10
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+    strategy:
+      matrix:
+        python: ['3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install system dependencies
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+          curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+          sudo apt update
+          sudo .ci/enable_ssh_localhost.sh
+          sudo apt install locate
+          sudo updatedb
+          sudo apt install postgresql-10
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
+          pip --version
+      - name: Install Tox
+        run: pip install tox
+      - name: Install Coveralls
+        if: ${{ matrix.python }} == '3.8'
+        run: pip install coveralls
+      - name: Install AiiDA
+        run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
+      - name: Install AiiDA-Wannier90
+        run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
+      - name: Install AiiDA-VASP
+        run: |
+          pip install -e .[graphs,dev]
+          pip freeze
+      - name: Remove dot in Python version for passing version to tox
+        uses: frabert/replace-string-action@master
+        id: tox
+        with:
+          pattern: '\.'
+          string: ${{ matrix.python }}
+          replace-with: ''
+      - name: Run tox
+        run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
+      - name: Run coverage from coverage-python by running pytest yet again
+        if: ${{ matrix.python }} == '3.8'
+        run: pytest --cov-report=xml --cov-append --cov=aiida_vasp aiida_vasp/calcs/tests/test_base.py
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          name: aiida-vasp
+          fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-aiida_dev
+envlist = {py36,py37,py38}-aiida_vasp
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Here we enable GitHub Actions and Codecov for running tests.

In the transition from travis-ci.org to travis-ci.com we never got the checks to be shown for pull requests. Also, having everything in one place on GitHub Actions is at this point beneficial. Due to the lack of non LCOV file support (and the fact that we cannot access secrets from forks in GitHub Actions at the moment) we needed to move the coverage analysis to Codecov from Coveralls.