### PR TITLE
fix issue for using kspacing tag

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -81,7 +81,7 @@ class VaspCalculation(VaspCalcBase):
         # Need namespace on this as it should also accept keys that are of `kind`. These are unknown
         # until execution.
         spec.input_namespace('potential', valid_type=get_data_class('vasp.potcar'), help='The potentials (POTCAR).', dynamic=True)
-        spec.input('kpoints', valid_type=get_data_class('array.kpoints'), help='The kpoints to use (KPOINTS).')
+        spec.input('kpoints', valid_type=get_data_class('array.kpoints'), required=False, help='The kpoints to use (KPOINTS).')
         spec.input('charge_density', valid_type=get_data_class('vasp.chargedensity'), required=False, help='The charge density. (CHGCAR)')
         spec.input('wavefunctions',
                    valid_type=get_data_class('vasp.wavefun'),
@@ -320,8 +320,9 @@ class VaspCalculation(VaspCalcBase):
 
         :param dst: absolute path of the file to write to
         """
-        kpoint_parser = KpointsParser(data=self.inputs.kpoints)
-        kpoint_parser.write(dst)
+        if self._need_kp():
+            kpoint_parser = KpointsParser(data=self.inputs.kpoints)
+            kpoint_parser.write(dst)
 
     def write_chgcar(self, dst, calcinfo):  # pylint: disable=unused-argument
         charge_density = self.inputs.charge_density


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*
fixes:
blocks:
is blocked by:
None of the above but is still related to the following:

## Description
Although it is seen in the `plugin` that user can have `KSPACING` keyword in `INCAR`, and there is `_need_kp` to return whether providing input is necessary, it is not being called currently and used. 
Solving this issue requires following changes which are made in this PR:

* Setting the requirement for `spec.input('kpoints')` to `False
* Calling `_need_kp` within `write_kpoint` method!

I'm relatively newbie user of plugin and therefore, I've made the PR as draft in case we need to reflect these changes to other parts of plugin that can be affected by this PR.
