### PR TITLE
No output files break

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -121,11 +121,17 @@ class VaspCalculation(VaspCalcBase):
                        'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
                        message='the retrieved_temporary folder data node could not be accessed.')
         spec.exit_code(352, 'ERROR_CRITICAL_MISSING_FILE', message='a file that is marked by the parser as critical is missing.')
+        spec.exit_code(333, 'ERROR_VASP_DID_NOT_EXECUTE', message='VASP did not produce any output files and did likely not execute properly.')
         spec.exit_code(1001, 'ERROR_PARSING_FILE_FAILED', message='parsing a file has failed.')
         spec.exit_code(1002, 'ERROR_NOT_ABLE_TO_PARSE_QUANTITY', message='the parser is not able to parse the requested quantity')
 
     def prepare_for_submission(self, tempfolder):
-        """Add EIGENVAL, DOSCAR, and all files starting with wannier90 to the list of files to be retrieved."""
+        """
+        Add all files to the list of files to be retrieved.
+
+        Notice that we here utilize both the retrieve batch of files, which are always stored after retrieval and
+        the temporary retrieve list which is automatically cleared after parsing.
+        """
         calcinfo = super(VaspCalculation, self).prepare_for_submission(tempfolder)
         # Still need the exceptions in case settings is not defined on inputs
         # Check if we want to store all always retrieve files
@@ -152,7 +158,7 @@ class VaspCalculation(VaspCalcBase):
             provenance_exclude_list = self.inputs.settings.get_attribute('PROVENANCE_EXCLUDE_LIST', default=[])
         except AttributeError:
             provenance_exclude_list = []
-        # Always include POTCAR in the exclude list (not added to the repository)
+        # Always include POTCAR in the exclude list (not added to the repository, regardless of store)
         calcinfo.provenance_exclude_list = list(set(provenance_exclude_list + ['POTCAR']))
 
         return calcinfo

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -121,7 +121,9 @@ class VaspCalculation(VaspCalcBase):
                        'ERROR_NO_RETRIEVED_TEMPORARY_FOLDER',
                        message='the retrieved_temporary folder data node could not be accessed.')
         spec.exit_code(352, 'ERROR_CRITICAL_MISSING_FILE', message='a file that is marked by the parser as critical is missing.')
-        spec.exit_code(333, 'ERROR_VASP_DID_NOT_EXECUTE', message='VASP did not produce any output files and did likely not execute properly.')
+        spec.exit_code(333,
+                       'ERROR_VASP_DID_NOT_EXECUTE',
+                       message='VASP did not produce any output files and did likely not execute properly.')
         spec.exit_code(1001, 'ERROR_PARSING_FILE_FAILED', message='parsing a file has failed.')
         spec.exit_code(1002, 'ERROR_NOT_ABLE_TO_PARSE_QUANTITY', message='the parser is not able to parse the requested quantity')
 

--- a/aiida_vasp/parsers/base.py
+++ b/aiida_vasp/parsers/base.py
@@ -48,12 +48,23 @@ class BaseParser(Parser):
                 for retrieved_file in os.listdir(self.retrieved_temporary):
                     retrieved[retrieved_file] = {'path': self.retrieved_temporary, 'status': 'temporary'}
 
+        # Check if there are other files than the AiiDA generated scheduler files in retrieved and
+        # if there are any files in the retrieved_temporary. If not, return an error.
+        aiida_required_files = [self.node.get_attribute('scheduler_stderr'), self.node.get_attribute('scheduler_stdout')]
+        vasp_output_files_present = False
+        for file_name in retrieved.keys():
+            if file_name not in aiida_required_files:
+                vasp_output_files_present = True
+
+        if not vasp_output_files_present:
+            return self.exit_codes.ERROR_VASP_DID_NOT_EXECUTE
+
         # Store the retrieved content
         self.retrieved_content = retrieved
         # OK if a least one of the folders are present
         if exit_code_permanent is None or exit_code_temporary is None:
             return None
-        # Both are not present, exit code of teh temporary folder take precedence
+        # Both are not present, exit code of the temporary folder take precedence
         return exit_code_temporary if not None else exit_code_permanent
 
     def check_temporary_folder(self, parser_kwargs):

--- a/aiida_vasp/parsers/base.py
+++ b/aiida_vasp/parsers/base.py
@@ -52,7 +52,7 @@ class BaseParser(Parser):
         # if there are any files in the retrieved_temporary. If not, return an error.
         aiida_required_files = [self.node.get_attribute('scheduler_stderr'), self.node.get_attribute('scheduler_stdout')]
         vasp_output_files_present = False
-        for file_name in retrieved.keys():
+        for file_name in retrieved:
             if file_name not in aiida_required_files:
                 vasp_output_files_present = True
 

--- a/aiida_vasp/utils/fixtures/calcs.py
+++ b/aiida_vasp/utils/fixtures/calcs.py
@@ -33,7 +33,9 @@ def calc_with_retrieved(localhost):
         node = CalcJobNode(computer=computer, process_type=process_type)
         node.set_attribute('input_filename', 'INCAR')
         node.set_attribute('output_filename', 'OUTCAR')
-        node.set_attribute('error_filename', 'aiida.err')
+        #node.set_attribute('error_filename', 'aiida.err')
+        node.set_attribute('scheduler_stderr', '_scheduler-stderr.txt')
+        node.set_attribute('scheduler_stdout', '_scheduler-stdout.txt')
         node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         node.set_option('max_wallclock_seconds', 1800)
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Adds a check to see if there are any VASP output files present in the `retrieved` and `retrieved_temporary` folders. This is a rather strong test to check that the code did not execute properly. Even though we introduce parsing of the standard stream from VASP, that parsing could fail, so it is convenient to check this first. Also, if there are no files (including standard stream) then there is no point to parse.