### PR TITLE
Added nightly test against aiida-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ matrix.python }} == '3.8'
         run: pytest --cov-report=xml --cov-append --cov=aiida_vasp
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.13
         with:
           name: aiida-vasp
           fail_ci_if_error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,74 @@
+name: nightly against develop aiida-core
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:10
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+    strategy:
+      matrix:
+        python: ['3.6', '3.7', '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install system dependencies
+        run: |
+          curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+          sudo apt update
+          sudo .ci/enable_ssh_localhost.sh
+          sudo apt install locate
+          sudo updatedb
+          sudo apt install postgresql-10
+      - name: Upgrade pip
+        run: |
+          pip install --upgrade pip
+          pip --version
+      - name: Install Tox
+        run: pip install tox
+      - name: Install AiiDA-Wannier90
+        run: pip install git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
+      - name: Install AiiDA-VASP
+        id: install_plugin
+        run: |
+          pip install -e .[graphs,dev]
+          pip freeze
+      - name: Install AiiDA develop branch
+        id: install_aiida
+        run: |
+          pip install git+https://github.com/aiidateam/aiida-core@develop
+          reentry scan
+      - name: Remove dot in Python version for passing version to tox
+        uses: frabert/replace-string-action@master
+        id: tox
+        with:
+          pattern: '\.'
+          string: ${{ matrix.python }}
+          replace-with: ''
+      - name: Run tox
+        run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
+      - name: Notification to Slack channel
+        if: steps.install_plugin.outcome == 'Failure' || steps.install_aiida.outcome == 'Failure' || steps.tox.outcome == 'Failure'
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_ICON: https://www.materialscloud.org/discover/images/0ba0a17d.aiida-logo-128.png
+          SLACK_USERNAME: aiida-vasp
+          SLACK_CHANNEL: nightly
+          SLACK_COLOR: b60205
+          SLACK_TITLE: "Nightly build against `aiida-core/develop` failed"
+          SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/develop`."


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Here we implement a nightly test against `aiida-core` develop branch in order to detect if something brakes upstream that we need to take action on. The build runs at midnight, but depending on where it runs, it can be shifted due to time differences.