### PR TITLE
Use relative path for `dst` when writing CHGCAR and WAVECAR

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -265,7 +265,7 @@ class VaspCalculation(VaspCalcBase):
             # If we restart, we do not require inputs, but we should have a basic check
             # that the CHGCAR file is present
             if not self._is_restart():
-                self.write_chgcar("CHGCAR", calcinfo)
+                self.write_chgcar('CHGCAR', calcinfo)
             else:
                 remote_folder = self.inputs.restart_folder
                 if not self._check_chgcar(remote_folder):
@@ -274,7 +274,7 @@ class VaspCalculation(VaspCalcBase):
             # If we restart, we do not require inputs, but we should have a basic check
             # that the WAVECAR file is present
             if not self._is_restart():
-                self.write_wavecar("WAVECAR", calcinfo)
+                self.write_wavecar('WAVECAR', calcinfo)
             else:
                 remote_folder = self.inputs.restart_folder
                 if not self._check_wavecar(remote_folder):

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -265,8 +265,7 @@ class VaspCalculation(VaspCalcBase):
             # If we restart, we do not require inputs, but we should have a basic check
             # that the CHGCAR file is present
             if not self._is_restart():
-                chgcar = tempfolder.get_abs_path('CHGCAR')
-                self.write_chgcar(chgcar, calcinfo)
+                self.write_chgcar("CHGCAR", calcinfo)
             else:
                 remote_folder = self.inputs.restart_folder
                 if not self._check_chgcar(remote_folder):
@@ -275,8 +274,7 @@ class VaspCalculation(VaspCalcBase):
             # If we restart, we do not require inputs, but we should have a basic check
             # that the WAVECAR file is present
             if not self._is_restart():
-                wavecar = tempfolder.get_abs_path('WAVECAR')
-                self.write_wavecar(wavecar, calcinfo)
+                self.write_wavecar("WAVECAR", calcinfo)
             else:
                 remote_folder = self.inputs.restart_folder
                 if not self._check_wavecar(remote_folder):


### PR DESCRIPTION
When using `calcinfo.local_copy_list.append`, we use the relative path for dst, so this should just be "CHGCAR" and "WAVECAR".
Otherwise when trying to write these files, AiiDA runs into the following errors: (VaspCalculation is stuck on upload
and verdi process report gives:)
![image (19)](https://user-images.githubusercontent.com/51478689/96147488-49a60b00-0eff-11eb-94a6-d3c147fe3f5f.png)

Tested with this code fix and works as it should.

I think this issue may have occurred because of a previous update in `calcinfo.local_copy_list.append`.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
