### PR TITLE
Replace git: by https: in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: double-quote-string-fixer
   - id: forbid-new-submodules
 
-- repo: git://github.com/pre-commit/mirrors-yapf
+- repo: https://github.com/pre-commit/mirrors-yapf
   rev: v0.28.0
   hooks:
   - id: yapf
@@ -39,7 +39,7 @@ repos:
     entry: python ops/update_version.py
     always_run: true
 
-- repo: git://github.com/Lucas-C/pre-commit-hooks-markup
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
   rev: v1.0.0
   hooks:
   - id: rst-linter


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
My system can't reach repos in .pre-commit-config.yaml with `git://` probably because the port is closed by the institute. `https://` works using the provided proxy server.