### PR TITLE
Removed py.path dependencies

### DIFF
--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -7,7 +7,7 @@ Base and meta classes for VASP calculation classes.
 # pylint: disable=abstract-method,invalid-metaclass,ungrouped-imports
 # explanation: pylint wrongly complains about Node not implementing query
 import os
-from py import path as py_path  # pylint: disable=no-name-in-module,no-member
+from pathlib import Path
 
 from aiida.engine import CalcJob
 from aiida.common import CalcInfo, CodeInfo, ValidationError
@@ -171,7 +171,7 @@ class VaspCalcBase(CalcJob):
         """
 
         from aiida_vasp.calcs import immigrant as imgr  # pylint: disable=import-outside-toplevel
-        remote_path = py_path.local(remote_path)
+        remote_path = Path(remote_path)
         proc_cls = imgr.VaspImmigrant
         builder = proc_cls.get_builder()
         builder.code = code
@@ -183,15 +183,15 @@ class VaspCalcBase(CalcJob):
         builder.metadata['options']['max_wallclock_seconds'] = max_wallclock_seconds  # pylint: disable=no-member
         builder.metadata['options']['resources'] = resources  # pylint: disable=no-member
         settings = kwargs.get('settings', {})
-        settings.update({'import_from_path': remote_path.strpath})
+        settings.update({'import_from_path': str(remote_path)})
         builder.settings = get_data_node('dict', dict=settings)
         with cmp_get_transport(code.computer) as transport:
             with SandboxFolder() as sandbox:
-                sandbox_path = py_path.local(sandbox.abspath)
-                transport.get(remote_path.join('INCAR').strpath, sandbox_path.strpath)
-                transport.get(remote_path.join('POSCAR').strpath, sandbox_path.strpath)
-                transport.get(remote_path.join('POTCAR').strpath, sandbox_path.strpath, ignore_nonexisting=True)
-                transport.get(remote_path.join('KPOINTS').strpath, sandbox_path.strpath)
+                sandbox_path = Path(sandbox.abspath)
+                transport.get(str(remote_path / 'INCAR'), str(sandbox_path))
+                transport.get(str(remote_path / 'POSCAR'), str(sandbox_path))
+                transport.get(str(remote_path / 'POTCAR'), str(sandbox_path), ignore_nonexisting=True)
+                transport.get(str(remote_path / 'KPOINTS'), str(sandbox_path))
                 builder.parameters = imgr.get_incar_input(sandbox_path)
                 builder.structure = imgr.get_poscar_input(sandbox_path)
                 builder.potential = imgr.get_potcar_input(sandbox_path,

--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -55,21 +55,21 @@ class VaspImmigrant(VaspCalculation):
 
 
 def get_incar_input(dir_path):
-    incar = IncarParser(file_path=dir_path.join('INCAR').strpath).incar
+    incar = IncarParser(file_path=str(dir_path / 'INCAR')).incar
     return get_data_node('dict', dict=incar)
 
 
 def get_poscar_input(dir_path):
-    return PoscarParser(file_path=dir_path.join('POSCAR').strpath).structure
+    return PoscarParser(file_path=str(dir_path / 'POSCAR')).structure
 
 
 def get_potcar_input(dir_path, structure=None, potential_family=None, potential_mapping=None):
     """Read potentials from a POTCAR file or set it up from a structure."""
-    local_potcar = dir_path.join('POTCAR')
+    local_potcar = dir_path / 'POTCAR'
     structure = structure or get_poscar_input(dir_path)
     potentials = {}
     if local_potcar.exists():
-        potentials = MultiPotcarIo.read(local_potcar.strpath).get_potentials_dict(structure)
+        potentials = MultiPotcarIo.read(str(local_potcar)).get_potentials_dict(structure)
         potentials = {kind: potentials[kind] for kind in potentials}
     elif potential_family:
         potentials = PotcarData.get_potcars_from_structure(structure, potential_family, mapping=potential_mapping)
@@ -81,14 +81,14 @@ def get_potcar_input(dir_path, structure=None, potential_family=None, potential_
 
 def get_kpoints_input(dir_path, structure=None):
     structure = structure or get_poscar_input(dir_path)
-    kpoints = KpointsParser(file_path=dir_path.join('KPOINTS').strpath).kpoints
+    kpoints = KpointsParser(file_path=str(dir_path / 'KPOINTS')).kpoints
     kpoints.set_cell_from_structure(structure)
     return kpoints
 
 
 def get_chgcar_input(dir_path):
-    return ChgcarParser(file_path=dir_path.join('CHGCAR').strpath).chgcar
+    return ChgcarParser(file_path=str(dir_path / 'CHGCAR')).chgcar
 
 
 def get_wavecar_input(dir_path):
-    return WavecarParser(file_path=dir_path.join('WAVECAR').strpath).wavecar
+    return WavecarParser(file_path=str(dir_path / 'WAVECAR')).wavecar

--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -57,7 +57,7 @@ def test_write_chgcar(localhost_dir, vasp_calc, vasp_inputs, vasp_chgcar):
     inputs.charge_density = chgcar
 
     calc = vasp_calc(inputs=inputs)
-    temp_folder = Folder(str(localhost_dir.dirpath()))
+    temp_folder = Folder(str(localhost_dir.parent))
 
     calcinfo = calc.prepare_for_submission(temp_folder)
 
@@ -72,7 +72,7 @@ def test_write_wavecar(localhost_dir, vasp_calc, vasp_inputs, vasp_wavecar):
     inputs = vasp_inputs(parameters={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'istart': 1})
     inputs.wavefunctions = wavecar
     calc = vasp_calc(inputs=inputs)
-    temp_folder = Folder(str(localhost_dir.dirpath()))
+    temp_folder = Folder(str(localhost_dir.parent))
     calcinfo = calc.prepare_for_submission(temp_folder)
 
     assert 'WAVECAR' in [item[1] for item in calcinfo.local_copy_list]
@@ -90,7 +90,7 @@ def test_incar_validate(vasp_calc, vasp_inputs, localhost_dir):
     inputs = vasp_inputs(parameters=inputs_dict)
     calc = vasp_calc(inputs=inputs)
 
-    temp_folder = Folder(str(localhost_dir.dirpath()))
+    temp_folder = Folder(str(localhost_dir.parent))
     with pytest.raises(InputValidationError):
         calc.prepare_for_submission(temp_folder)
 
@@ -110,7 +110,7 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
     inputs.wavefunctions = wavecar
 
     calc = vasp_calc(inputs=inputs)
-    temp_folder = Folder(str(localhost_dir.dirpath()))
+    temp_folder = Folder(str(localhost_dir.parent))
     calcinfo = calc.prepare_for_submission(temp_folder)
     input_files = temp_folder.get_content_list()
 
@@ -128,7 +128,7 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
     inputs.wavefunctions = wavecar
 
     calc = vasp_calc(inputs=inputs)
-    temp_folder = Folder(str(localhost_dir.dirpath()))
+    temp_folder = Folder(str(localhost_dir.parent))
 
     calcinfo = calc.prepare_for_submission(temp_folder)
 

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -345,10 +345,10 @@ class VaspCalculation(VaspCalcBase):
         add_wavecar = kwargs.get('use_wavecar') or bool(builder.parameters.get_dict().get('istart', 0))
         add_chgcar = kwargs.get('use_chgcar') or builder.parameters.get_dict().get('icharg', -1) in [1, 11]
         if add_chgcar:
-            transport.get(remote_path.join('CHGCAR').strpath, sandbox_path.strpath)
+            transport.get(str(remote_path / 'CHGCAR'), str(sandbox_path))
             builder.charge_density = get_chgcar_input(sandbox_path)
         if add_wavecar:
-            transport.get(remote_path.join('WAVECAR').strpath, sandbox_path.strpath)
+            transport.get(str(remote_path / 'WAVECAR'), str(sandbox_path))
             builder.wavefunctions = get_wavecar_input(sandbox_path)
 
 

--- a/aiida_vasp/commands/potcar.py
+++ b/aiida_vasp/commands/potcar.py
@@ -95,7 +95,6 @@ def listfamilies(element, symbol, description):
 @click.option('-v', '--verbose', is_flag=True, help='Print the names of all created files.')
 def exportfamily(path, name, dry_run, as_archive, verbose):
     """Export a POTCAR family into a compressed tar archive or folder."""
-
     potcar_data_cls = get_data_class('vasp.potcar')
 
     if not as_archive:

--- a/aiida_vasp/data/tests/test_potcar_walker.py
+++ b/aiida_vasp/data/tests/test_potcar_walker.py
@@ -6,8 +6,9 @@ searching for POTCAR files, when it encounters a tar archive, it should be extra
 a folder on the same level as the archive and the extracted folder added to the search.
 """
 # pylint: disable=unused-import,unused-argument,redefined-outer-name, import-outside-toplevel
+import shutil
+from pathlib import Path
 import pytest
-from py import path as py_path  # pylint: disable=no-member,no-name-in-module
 
 from aiida_vasp.utils.fixtures import fresh_aiida_env
 from aiida_vasp.utils.fixtures.testdata import data_path
@@ -16,8 +17,8 @@ from aiida_vasp.utils.fixtures.data import temp_pot_folder
 
 @pytest.fixture
 def temp_data_folder(tmpdir):
-    pot_archive = py_path.local(data_path('pot_archive.tar.gz'))
-    pot_archive.copy(tmpdir)
+    pot_archive = Path(data_path('pot_archive.tar.gz'))
+    shutil.copy(pot_archive, tmpdir)
     return tmpdir.join('pot_archive.tar.gz')
 
 
@@ -29,8 +30,8 @@ def potcar_walker_cls(fresh_aiida_env):
 
 def test_find_potcars(potcar_walker_cls, temp_data_folder):
     """Make sure the walker finds the right number fo POTCAR files."""
-    potcar_archive = py_path.local(data_path('.')).join('pot_archive')
-    walker = potcar_walker_cls(temp_data_folder.strpath)
+    potcar_archive = Path(data_path('.')) / 'pot_archive'
+    walker = potcar_walker_cls(str(temp_data_folder))
     walker.walk()
     assert len(walker.potcars) == 7
     assert not potcar_archive.exists()

--- a/aiida_vasp/parsers/file_parsers/parser.py
+++ b/aiida_vasp/parsers/file_parsers/parser.py
@@ -229,7 +229,6 @@ class KeyValueParser(BaseParser):
     A simple example, which tries to convert values to python objects on a best effort basis. Usage::
 
         import re
-        import py
 
         from aiida_vasp.parsers.file_parsers.parser import KeyValueParser
 

--- a/aiida_vasp/parsers/file_parsers/tests/test_potcar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_potcar_parser.py
@@ -30,7 +30,9 @@ def test_potcar_from_file_node(potcar_family):
     potcar_file_in = get_data_class('vasp.potcar_file').find_one(element='In')
     from_ctor = PotcarIo(potcar_file_node=potcar_file_in)
     verify_potcario(from_ctor)
+    #print("in:", type(potcar_file_in))
     from_from = PotcarIo.from_(potcar_file_in)
+    #assert False
     assert from_ctor == from_from
 
 
@@ -40,6 +42,8 @@ def test_potcar_from_node(potcar_family):
     from_ctor = PotcarIo(potcar_node=potcar_ga)
     verify_potcario(from_ctor)
     from_from = PotcarIo.from_(potcar_ga)
+    #print(type(potcar_ga))
+    #assert False
     assert from_ctor == from_from
 
 
@@ -49,7 +53,9 @@ def test_potcar_from_contents(potcar_family):
     from_ctor = PotcarIo(contents=contents_as.encode('utf-8'))
     verify_potcario(from_ctor)
     assert from_ctor.node.uuid == get_data_class('vasp.potcar').find_one(element='As').uuid
+    #print(type(contents_as))
     from_from = PotcarIo.from_(contents_as)
+    #assert False
     assert from_ctor == from_from
 
 
@@ -60,12 +66,13 @@ def test_file_contents_equivalence(fresh_aiida_env):
     assert from_file.sha512 == from_contents.sha512
 
 
-def test_multi_round_trip(potcar_family, tmpdir):
+def test_multi_round_trip(potcar_family, tmp_path):
     """Write multiple POTCAR potentials to a file and recover the nodes stored in the db."""
-    test_dir = tmpdir.mkdir('round_trip')
+    test_dir = tmp_path / 'round_trip'
+    test_dir.mkdir()
     potcar_cls = get_data_class('vasp.potcar')
     multi = MultiPotcarIo(potcar_cls.get_potcars_dict(elements=POTCAR_MAP.keys(), family_name=potcar_family, mapping=POTCAR_MAP).values())
-    tempfile = test_dir.join('POTCAR')
+    tempfile = test_dir / 'POTCAR'
     multi.write(tempfile)
     recovered = multi.read(tempfile)
     uuids_start = [potcar.node.uuid for potcar in multi.potcars]

--- a/aiida_vasp/utils/fixtures/environment.py
+++ b/aiida_vasp/utils/fixtures/environment.py
@@ -11,7 +11,6 @@ testing. AiiDA contributes with its own fixture manager, which we use.
 from __future__ import absolute_import
 from __future__ import print_function
 import pytest
-from py import path as py_path  # pylint: disable=no-member,no-name-in-module
 
 
 @pytest.fixture()

--- a/aiida_vasp/utils/general.py
+++ b/aiida_vasp/utils/general.py
@@ -1,0 +1,24 @@
+"""
+General utils.
+
+--------------
+Contains general utils that is not directly coupled to the plugin or AiiDA.
+"""
+import os
+import shutil
+
+
+def copytree(src, dst, symlinks=False, ignore=None):
+    """
+    Fixes annoying complaint about existing directory running tests
+
+    In Python 3.8 there is a flag for shutil.copytree that handles this,
+    but we still support 3.6 and 3.7.
+    """
+    for item in os.listdir(src):
+        source = os.path.join(src, item)
+        destination = os.path.join(dst, item)
+        if os.path.isdir(source):
+            shutil.copytree(source, destination, symlinks, ignore)
+        else:
+            shutil.copy2(source, destination)

--- a/setup.json
+++ b/setup.json
@@ -81,7 +81,6 @@
     "install_requires": [
         "aiida-core[atomic_tools] >= 1.2.1",
         "subprocess32",
-        "py == 1.5.4",
         "lxml",
         "packaging",
         "parsevasp >= 1.0.0"


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#395 #264

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Here we remove the `py` dependency and replacing it with the standard `pathlib` and `shutil` (for copy operations).