### PR TITLE
Remove AiiDA 1.4.0 and 1.4.1 as this allow POTCAR to rest in repository

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -79,7 +79,7 @@
     },
     "include_package_data": true,
     "install_requires": [
-        "aiida-core[atomic_tools] >= 1.2.1",
+        "aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
         "subprocess32",
         "lxml",
         "packaging",


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Due to updates in `aiida_core==1.4.0, 1.4.1`, we need to exclude these versions due to the fact that files in the exclude list was allowed to reside in the repository. 