### PR TITLE
Initial attempt to add energies_sc to store SCF energies

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -111,6 +111,7 @@ class VaspCalculation(VaspCalcBase):
         spec.output('dos', valid_type=get_data_class('array'), required=False, help='The output dos.')
         spec.output('occupancies', valid_type=get_data_class('array'), required=False, help='The output band occupancies.')
         spec.output('energies', valid_type=get_data_class('array'), required=False, help='The output total energies.')
+        spec.output('energies_sc', valid_type=get_data_class('array'), required=False, help='The output total energies at all SCF steps.')
         spec.output('projectors', valid_type=get_data_class('array'), required=False, help='The output projectors of decomposition.')
         spec.output('dielectrics', valid_type=get_data_class('array'), required=False, help='The output dielectric functions.')
         spec.output('born_charges', valid_type=get_data_class('array'), required=False, help='The output Born effective charges.')

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -111,7 +111,6 @@ class VaspCalculation(VaspCalcBase):
         spec.output('dos', valid_type=get_data_class('array'), required=False, help='The output dos.')
         spec.output('occupancies', valid_type=get_data_class('array'), required=False, help='The output band occupancies.')
         spec.output('energies', valid_type=get_data_class('array'), required=False, help='The output total energies.')
-        spec.output('energies_sc', valid_type=get_data_class('array'), required=False, help='The output total energies at all SCF steps.')
         spec.output('projectors', valid_type=get_data_class('array'), required=False, help='The output projectors of decomposition.')
         spec.output('dielectrics', valid_type=get_data_class('array'), required=False, help='The output dielectric functions.')
         spec.output('born_charges', valid_type=get_data_class('array'), required=False, help='The output Born effective charges.')

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -119,11 +119,6 @@ NODES = {
         'type': 'array',
         'quantities': ['energies'],
     },
-    'energies_sc': {
-        'link_name': 'energies_sc',
-        'type': 'array',
-        'quantities': ['energies_sc'],
-    },
     'projectors': {
         'link_name': 'projectors',
         'type': 'array',

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -119,6 +119,11 @@ NODES = {
         'type': 'array',
         'quantities': ['energies'],
     },
+    'energies_sc': {
+        'link_name': 'energies_sc',
+        'type': 'array',
+        'quantities': ['energies_sc'],
+    },
     'projectors': {
         'link_name': 'projectors',
         'type': 'array',

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -29,7 +29,6 @@ DEFAULT_OPTIONS = {
     'add_dos': False,
     'add_kpoints': False,
     'add_energies': False,
-    'add_energies_sc': False,
     'add_misc': True,
     'add_structure': False,
     'add_projectors': False,
@@ -42,6 +41,7 @@ DEFAULT_OPTIONS = {
     'add_stress': False,
     'add_site_magnetization': False,
     'file_parser_set': 'default',
+    'store_energies_sc': False,
 }
 
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -29,6 +29,7 @@ DEFAULT_OPTIONS = {
     'add_dos': False,
     'add_kpoints': False,
     'add_energies': False,
+    'add_energies_sc': False,
     'add_misc': True,
     'add_structure': False,
     'add_projectors': False,

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -116,6 +116,7 @@ class VaspWorkChain(BaseRestartWorkChain):
         spec.output('dos', valid_type=get_data_class('array'), required=False)
         spec.output('occupancies', valid_type=get_data_class('array'), required=False)
         spec.output('energies', valid_type=get_data_class('array'), required=False)
+        spec.output('energies_sc', valid_type=get_data_class('array'), required=False)
         spec.output('projectors', valid_type=get_data_class('array'), required=False)
         spec.output('dielectrics', valid_type=get_data_class('array'), required=False)
         spec.output('born_charges', valid_type=get_data_class('array'), required=False)

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -116,7 +116,6 @@ class VaspWorkChain(BaseRestartWorkChain):
         spec.output('dos', valid_type=get_data_class('array'), required=False)
         spec.output('occupancies', valid_type=get_data_class('array'), required=False)
         spec.output('energies', valid_type=get_data_class('array'), required=False)
-        spec.output('energies_sc', valid_type=get_data_class('array'), required=False)
         spec.output('projectors', valid_type=get_data_class('array'), required=False)
         spec.output('dielectrics', valid_type=get_data_class('array'), required=False)
         spec.output('born_charges', valid_type=get_data_class('array'), required=False)

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,6 @@ commands =
 [flake8]
 max-line-length = 140
 import-order-style = edited
+
+[pycodestyle]
+max-line-length = 140


### PR DESCRIPTION
 Initial attempt to add `energies_sc` output node to store SCF energies information during SCF

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

## Status
This works with the latest AiiDA-core develop and AiiDA-VASP develop. Tests have not written yet.

## Description

I added `energies_sc` output node to `VaspCalculation` and `VaspWorkChain`. AiiDA type is the `ArrayData` and two (or more) datasets of `energy_no_entropy` (and the other energy types when specified) and 'sc_iters'. The former contains the energies of all SCF steps in all ionic steps. The iteration numbers of the ionic steps can be different, so the energy values are simply concatenated. To split this 1D data array into the bunches of respective ionic steps, `sc_iters` is stored as 1D array of integers where each integer is the number of SCF iterations for each ionic step. The following example shows the calculation with three ionic steps with 10, 4, 4 SCF iterations.

```
In [6]: n = load_node(4480)

In [7]: n
Out[7]: <ArrayData: uuid: 923e9877-9b78-445a-8081-eea89f428c56 (pk: 4480)>

In [8]: n.get_arraynames()
Out[8]: ['sc_iters', 'energy_no_entropy']

In [9]: n.get_array('energy_no_entropy')
Out[9]:
array([ -8.64597234, -10.99439958, -10.99746215, -10.99746397,
       -10.99746397, -10.87345087, -10.81726051, -10.81812574,
       -10.81836654, -10.81837809, -10.82612867, -10.82243689,
       -10.82059313, -10.8205931 , -10.82320133, -10.82266919,
       -10.82239957, -10.82239963])

In [10]: n.get_array('sc_iters')
Out[10]: array([10,  4,  4])
```  

## What should be discussed
* The implementation is done only for `VasprunParser` but not other `FileParser`s. Is it fine?
* `VasprunParser._energies()` was modified. I feel my modification is dangerous, e.g., checking return value of parsevasp is done by either the first element of the return valus is a list of ndarray's or not, i.e., maybe standing on my fragile assumptions. I will make it safer after getting @espenfl's advise. Maybe it is safer not to touch `VasprunParser._energies()` but create a new `VasprunParser._energies_sc()` method, by which the current handling of `energies` is protected. In addition, exit_code handling has to be considered for `energies_sc`.
* How this data should be exposed to `RelaxWorkChain` must be defined because the `RelaxWorkChain` has another iteration inside. Simply not to be exposed is a choice.