### PR TITLE
Use positive match for restart folder copy

### DIFF
--- a/aiida_vasp/calcs/base.py
+++ b/aiida_vasp/calcs/base.py
@@ -113,10 +113,17 @@ class VaspCalcBase(CalcJob):
         """Add all files required for restart to the list of files to be copied from the previous calculation."""
         restart_folder = self.inputs.restart_folder
         computer = self.node.computer
-        excluded = ['KPOINTS', 'POSCAR', 'INCAR', 'POTCAR', '_aiidasubmit.sh', '.aiida']
-        copy_list = [(computer.uuid, os.path.join(restart_folder.get_remote_path(), name), '.')
-                     for name in restart_folder.listdir()
-                     if name not in excluded]
+        included = ['CHGCAR', 'WAVECAR']
+        existing_files = restart_folder.listdir()
+        to_copy = []
+        for name in included:
+            if name not in existing_files:
+                # Here we simple issue an warning as the requirement of files will be explicitly checked by
+                # `write_additional` method
+                self.report('WARNING: File {} does not exist in the restart folder.'.format(name))
+            else:
+                to_copy.append(name)
+        copy_list = [(computer.uuid, os.path.join(restart_folder.get_remote_path(), name), '.') for name in to_copy]
         return copy_list
 
     def verify_inputs(self):


### PR DESCRIPTION
Previously the copying of the restart folder will copy all files
including the output files such as vasprun.xml and OUTCAR. Which
can result in incorrect outcome if the remote job is kill.
The copy is now limited to CHGCAR and WAVECAR, and the remote folder
is checked for constructing the list.

The `write_additonal` method now simply checks the existence of the
files in the copy list.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#414 
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
