### PR TITLE
Fix potcar warnings

### DIFF
--- a/aiida_vasp/data/archive.py
+++ b/aiida_vasp/data/archive.py
@@ -7,6 +7,7 @@ Archive data class: store multiple files together in a compressed archive in the
 # pylint: disable=abstract-method
 # explanation: pylint wrongly complains about (aiida) Node not implementing query
 import tarfile
+from contextlib import contextmanager
 import os
 from io import StringIO
 from aiida.orm.nodes import Data
@@ -19,12 +20,19 @@ class ArchiveData(Data):
         self._filelist = []
         super(ArchiveData, self).__init__(*args, **kwargs)
 
+    @contextmanager
     def get_archive(self):
-        return tarfile.open(fileobj=self.open('archive.tar.gz', mode='rb'), mode='r:gz')
+        with self.open('archive.tar.gz', mode='rb') as fobj:
+            yield tarfile.open(fileobj=fobj, mode='r:gz')
+
+    @contextmanager
+    def archive(self):
+        with self.open('archive.tar.gz', mode='rb') as fobj:
+            yield tarfile.open(fileobj=fobj, mode='r:gz')
 
     def get_archive_list(self):
-        archive = self.get_archive()
-        archive.list()
+        with self.get_archive() as archive:
+            return archive.list()
 
     def add_file(self, src_abs, dst_filename=None):
         if not dst_filename:
@@ -34,20 +42,14 @@ class ArchiveData(Data):
     def _make_archive(self):
         """Create the archive file on disk with all it's contents."""
         self.put_object_from_filelike(StringIO(), 'archive.tar.gz')
+        with self.open('archive.tar.gz', mode='wb') as fobj:
+            archive = tarfile.open(fileobj=fobj, mode='w:gz')
 
-        archive = tarfile.open(fileobj=self.open('archive.tar.gz', mode='wb'), mode='w:gz')
-
-        for src, dstn in self._filelist:
-            archive.add(src, arcname=dstn)
-
-        archive.close()
+            for src, dstn in self._filelist:
+                archive.add(src, arcname=dstn)
 
     # pylint: disable=arguments-differ
     def store(self, *args, **kwargs):
         self._make_archive()
         del self._filelist
         super(ArchiveData, self).store(*args, **kwargs)
-
-    @property
-    def archive(self):
-        return self.get_archive()

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -460,18 +460,32 @@ class PotcarFileData(ArchiveData, PotcarMetadataMixin, VersioningMixin):
     def get_file_obj(self):
         """Open a readonly file object to read the stored POTCAR file."""
         file_obj = None
-        try:
-            file_obj = self.archive.extractfile(self.archive.members[0])
-            yield file_obj
-        finally:
-            if file_obj:
-                file_obj.close()
+        with self.get_archive() as archive:
+            try:
+                file_obj = archive.extractfile(archive.members[0])
+                yield file_obj
+            finally:
+                if file_obj:
+                    file_obj.close()
+
+    @contextmanager
+    def get_file_obj_and_tar_obj(self):
+        """Return both decompressed file object and the archive object"""
+        file_obj = None
+        with self.get_archive() as archive:
+            try:
+                file_obj = archive.extractfile(archive.members[0])
+                yield file_obj, archive
+            finally:
+                if file_obj:
+                    file_obj.close()
 
     def export_archive(self, archive, dry_run=False):
         """Add the stored POTCAR file to an archive for export."""
-        with self.get_file_obj() as potcar_fo:
+        with self.get_file_obj_and_tar_obj() as objects:
+            potcar_fo, tar_fo = objects
             arcname = '{}/POTCAR'.format(self.symbol)
-            tarinfo = self.archive.members[0]
+            tarinfo = tar_fo.members[0]
             tarinfo.name = arcname
             if not dry_run:
                 archive.addfile(tarinfo, fileobj=potcar_fo)

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -82,6 +82,8 @@ def temp_pot_folder(tmp_path):
     assert not potcar_ga.exists()
     pot_archive = Path(data_path('potcar'))
     target = tmp_path / 'potentials'
+    # Ensure that the target path exists
+    Path(target).mkdir(exist_ok=True)
     copytree(pot_archive, target)
     return target
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#420
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Fix deprecation warnings issued by `aiida-core` related to using `open` method of a `Node` class without going through the context manger interface (e.g. `with ....`). 

Also, fix a bug in the tests related to `copytree` with the non-existing destination. This somehow works just fine with the older ubuntu github action environment, and also on my local computer. However, it started to fail after an image update. I have got no idea why it is the case, but having the folder (`potential`) created in the first place seems to be the sensible thing to do and does no harm. 