### PR TITLE
Updated dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,27 +12,33 @@ repos:
   - id: forbid-new-submodules
 
 - repo: https://github.com/pre-commit/mirrors-yapf
-  rev: v0.28.0
+  rev: v0.30.0
   hooks:
   - id: yapf
     language: system
     types: [python]
-
-- repo: https://github.com/PyCQA/prospector
-  rev: 1.1.7
-  hooks:
-  - id: prospector
-    language: system
-    types: [python]
+    exclude: &exclude_files >
+      (?x)^(
+        doc/.*|
+          )$
+    args: ['-i']
 
 - repo: local
   hooks:
+  - id: pylint
+    name: pylint
+    entry: pylint
+    types: [python]
+    language: system
+    exclude: ^tutorials/
+
   - id: travis-linter
     name: travis
     entry: travis lint
     files: .travis.yml
     language: ruby
     additional_dependencies: ['travis']
+
   - id: version-updater
     name: updating version entries
     language: system

--- a/aiida_vasp/parsers/file_parsers/parser.py
+++ b/aiida_vasp/parsers/file_parsers/parser.py
@@ -77,7 +77,6 @@ class BaseFileParser(BaseParser):
         self._logger = aiidalogger.getChild(self.__class__.__name__)
         self._vasp_parser = calc_parser_cls
         self.settings = None
-
         if calc_parser_cls is not None:
             calc_parser_cls.get_quantity.append(self.get_quantity)
             self.settings = calc_parser_cls.settings

--- a/aiida_vasp/parsers/file_parsers/tests/test_potcar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_potcar_parser.py
@@ -30,9 +30,7 @@ def test_potcar_from_file_node(potcar_family):
     potcar_file_in = get_data_class('vasp.potcar_file').find_one(element='In')
     from_ctor = PotcarIo(potcar_file_node=potcar_file_in)
     verify_potcario(from_ctor)
-    #print("in:", type(potcar_file_in))
     from_from = PotcarIo.from_(potcar_file_in)
-    #assert False
     assert from_ctor == from_from
 
 
@@ -42,8 +40,6 @@ def test_potcar_from_node(potcar_family):
     from_ctor = PotcarIo(potcar_node=potcar_ga)
     verify_potcario(from_ctor)
     from_from = PotcarIo.from_(potcar_ga)
-    #print(type(potcar_ga))
-    #assert False
     assert from_ctor == from_from
 
 
@@ -53,9 +49,7 @@ def test_potcar_from_contents(potcar_family):
     from_ctor = PotcarIo(contents=contents_as.encode('utf-8'))
     verify_potcario(from_ctor)
     assert from_ctor.node.uuid == get_data_class('vasp.potcar').find_one(element='As').uuid
-    #print(type(contents_as))
     from_from = PotcarIo.from_(contents_as)
-    #assert False
     assert from_ctor == from_from
 
 

--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -10,6 +10,12 @@ from aiida_vasp.utils.aiida_utils import get_data_class
 from aiida_vasp.parsers.node_composer import NodeComposer
 
 
+def test_version(fresh_aiida_env, vasprun_parser):
+    """Parse a reference vasprun.xml and fetch the VASP version."""
+    quantity = vasprun_parser.get_quantity('version')
+    assert quantity['version'] == '5.4.4'
+
+
 def test_parse_vasprun(fresh_aiida_env, vasprun_parser):
     """Parse a reference vasprun.xml file with the VasprunParser and compare the result to a reference string."""
 
@@ -21,7 +27,7 @@ def test_parse_vasprun(fresh_aiida_env, vasprun_parser):
     #assert  == 7.29482275
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
 def test_parameter_results(fresh_aiida_env, vasprun_parser):
     """
     Test that the parameter node is a ParametersData instance.
@@ -45,14 +51,14 @@ def test_parameter_results(fresh_aiida_env, vasprun_parser):
     assert isinstance(data_obj, ref_class)
     data_dict = data_obj.get_dict()
     assert data_dict['fermi_level'] == 5.96764939
-    assert data_dict['total_energies']['energy_no_entropy'] == -42.91113621
-    assert data_dict['energies']['energy_no_entropy'][0] == -42.91113621
+    assert data_dict['total_energies']['energy_extrapolated'] == -42.91113621
+    assert data_dict['energies']['energy_extrapolated'][0] == -42.91113621
     assert data_dict['maximum_stress'] == 28.803993008871014
     assert data_dict['maximum_force'] == 3.41460162
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_kpoints_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_kpoints(fresh_aiida_env, vasprun_parser):
     """Test that the kpoints result node is a KpointsData instance."""
 
     composer = NodeComposer(file_parsers=[vasprun_parser])
@@ -64,8 +70,8 @@ def test_kpoints_result(fresh_aiida_env, vasprun_parser):
     assert np.all(data_obj.get_kpoints()[-1] == np.array([0.42857143, -0.42857143, 0.42857143]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_structure_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_structure(fresh_aiida_env, vasprun_parser):
     """
     Test that the structure result node is a StructureData instance.
 
@@ -90,8 +96,8 @@ def test_structure_result(fresh_aiida_env, vasprun_parser):
     assert data_obj.get_cell_volume() == np.float(163.22171870360754)
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_final_force_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_final_force(fresh_aiida_env, vasprun_parser):
     """Test that the forces are returned correctly."""
 
     composer = NodeComposer(file_parsers=[vasprun_parser])
@@ -110,8 +116,8 @@ def test_final_force_result(fresh_aiida_env, vasprun_parser):
     assert np.all(forces[7] == forces_check[7])
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_final_stress_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_final_stress(fresh_aiida_env, vasprun_parser):
     """Test that the stress are returned correctly."""
 
     composer = NodeComposer(file_parsers=[vasprun_parser])
@@ -128,8 +134,8 @@ def test_final_stress_result(fresh_aiida_env, vasprun_parser):
     assert np.all(stress[2] == stress_check[2])
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_traj_forces_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_traj_forces(fresh_aiida_env, vasprun_parser):
     """
     Check that the parsed forces in TrajectoryData are of type ArrayData.
 
@@ -159,7 +165,7 @@ def test_traj_forces_result(fresh_aiida_env, vasprun_parser):
     assert np.all(data_obj[0][0] == data_obj[1][0])
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('relax',)], indirect=True)
+@pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
 def test_traj_forces_result_relax(fresh_aiida_env, vasprun_parser):
     """
     Check that the parsed forces in TrajectoryData are of type ArrayData.
@@ -184,7 +190,7 @@ def test_traj_forces_result_relax(fresh_aiida_env, vasprun_parser):
     assert np.all(data_obj_arr[-1][-1] == np.array([-1.75970000e-03, 1.12150000e-04, 1.12150000e-04]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('relax',)], indirect=True)
+@pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
 def test_unitcells_result_relax(fresh_aiida_env, vasprun_parser):
     """
     Check that the parsed unitcells are of type ArrayData.
@@ -209,7 +215,7 @@ def test_unitcells_result_relax(fresh_aiida_env, vasprun_parser):
     assert np.all(data_obj_arr[-1][-1] == np.array([0.0, 2.19104000e-03, 5.46705225e+00]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('relax',)], indirect=True)
+@pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
 def test_positions_result_relax(fresh_aiida_env, vasprun_parser):
     """
     Check that the parsed positions are of type ArrayData.
@@ -234,8 +240,8 @@ def test_positions_result_relax(fresh_aiida_env, vasprun_parser):
     assert np.all(data_obj_arr[-1][-1] == np.array([0.7437189, 0.74989833, 0.24989833]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('dielectric',)], indirect=True)
-def test_dielectrics_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('dielectric', {})], indirect=True)
+def test_dielectrics(fresh_aiida_env, vasprun_parser):
     """
     Check that the parsed dielectrics are of type ArrayData.
 
@@ -266,8 +272,8 @@ def test_dielectrics_result(fresh_aiida_env, vasprun_parser):
     assert energy[500] == 10.2933
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('disp_details',)], indirect=True)
-def test_epsilon_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('disp_details', {})], indirect=True)
+def test_epsilon(fresh_aiida_env, vasprun_parser):
     """
     Check that epsilon is returned inside the dielectric node.
 
@@ -292,8 +298,8 @@ def test_epsilon_result(fresh_aiida_env, vasprun_parser):
     assert np.allclose(epsilon_ion, test)
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('localfield',)], indirect=True)
-def test_born_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('localfield', {})], indirect=True)
+def test_born(fresh_aiida_env, vasprun_parser):
     """
     Check that the Born effective charges are of type ArrayData.
 
@@ -315,8 +321,8 @@ def test_born_result(fresh_aiida_env, vasprun_parser):
     assert np.all(born[4][0] == np.array([1.68565200e-01, -2.92058000e-02, -2.92058000e-02]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_dos_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_dos(fresh_aiida_env, vasprun_parser):
     """
     Check that the density of states are of type ArrayData.
 
@@ -339,8 +345,8 @@ def test_dos_result(fresh_aiida_env, vasprun_parser):
     assert energy[150] == 2.3373
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('spin',)], indirect=True)
-def test_dos_spin_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('spin', {})], indirect=True)
+def test_dos_spin(fresh_aiida_env, vasprun_parser):
     """
     Check that the density of states are of type ArrayData.
 
@@ -366,8 +372,8 @@ def test_dos_spin_result(fresh_aiida_env, vasprun_parser):
     assert dos[1, 500] == 0.9844
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('partial',)], indirect=True)
-def test_pdos_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('partial', {})], indirect=True)
+def test_pdos(fresh_aiida_env, vasprun_parser):
     """
     Check that the density of states are of type ArrayData.
 
@@ -391,8 +397,8 @@ def test_pdos_result(fresh_aiida_env, vasprun_parser):
     assert energy[500] == 0.01
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('partial',)], indirect=True)
-def test_projectors_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('partial', {})], indirect=True)
+def test_projectors(fresh_aiida_env, vasprun_parser):
     """
     Check that the projectors are of type ArrayData.
 
@@ -414,8 +420,8 @@ def test_projectors_result(fresh_aiida_env, vasprun_parser):
     assert np.all(proj[4, 3, 5] == np.array([0.2033, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_bands_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_bands(fresh_aiida_env, vasprun_parser):
     """
     Check that the eigenvalues are of type BandData.
 
@@ -444,8 +450,8 @@ def test_bands_result(fresh_aiida_env, vasprun_parser):
     assert occ[0, 6, 4] == 1.0
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('spin',)], indirect=True)
-def test_eigenocc_spin_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('spin', {})], indirect=True)
+def test_eigenocc_spin(fresh_aiida_env, vasprun_parser):
     """
     Check that the eigenvalues are of type BandData.
 
@@ -480,31 +486,90 @@ def test_eigenocc_spin_result(fresh_aiida_env, vasprun_parser):
     assert occ[1, 6, 4] == 1.0
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
-def test_toten_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
+def test_toten(fresh_aiida_env, vasprun_parser):
     """
     Check that the total energy are of type ArrayData.
 
     Also check that the entries are as expected.
 
     """
-
     composer = NodeComposer(file_parsers=[vasprun_parser])
     data_obj = composer.compose('array', quantities=['energies'])
-    # test object
+    # Test that the object is of the right type
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
-    energies = data_obj.get_array('energy_no_entropy')
-    # test number of entries
+    # Test that the default arrays are present
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated')
+    test_array = np.array([-42.91113621])
+    assert np.allclose(test_array, energies)
+    # Test number of entries
     assert energies.shape == (1,)
-    # check energy
-    assert energies[0] == -42.91113621
+    # Electronic steps should be one
+    test_array = np.array([1])
+    assert np.allclose(test_array, data_obj.get_array('electronic_steps'))
+    # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
+    test_array = np.array([-0.00236711])
+    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('relax',)], indirect=True)
-def test_totens_relax_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('basic', {'energy_type': ['energy_free', 'energy_no_entropy']})], indirect=True)
+def test_toten_multiple(fresh_aiida_env, vasprun_parser):
     """
-    Check that the total energies are of type ArrayData.
+    Check that the total energy are of type ArrayData and that we can extract multiple total energies.
+
+    Also check that the entries are as expected.
+
+    """
+    composer = NodeComposer(file_parsers=[vasprun_parser])
+    data_obj = composer.compose('array', quantities=['energies'])
+    # Test that the object is of the right type
+    ref_obj = get_data_class('array')
+    assert isinstance(data_obj, ref_obj)
+    assert set(data_obj.get_arraynames()) == set(
+        ['electronic_steps', 'energy_free', 'energy_free_final', 'energy_no_entropy', 'energy_no_entropy_final'])
+    test_array = np.array([-42.91231976])
+    assert np.allclose(test_array, data_obj.get_array('energy_free'))
+    assert np.allclose(test_array, data_obj.get_array('energy_free_final'))
+    test_array = np.array([-42.90995265])
+    assert np.allclose(test_array, data_obj.get_array('energy_no_entropy'))
+    test_array = np.array([-42.91113621])
+    assert np.allclose(test_array, data_obj.get_array('energy_no_entropy_final'))
+
+
+@pytest.mark.parametrize('vasprun_parser', [('basic', {'electronic_step_energies': True})], indirect=True)
+def test_toten_electronic(fresh_aiida_env, vasprun_parser):
+    """
+    Check that the total energy are of type ArrayData and that we have entries per electronic step
+
+    Also check that the entries are as expected.
+
+    """
+    composer = NodeComposer(file_parsers=[vasprun_parser])
+    data_obj = composer.compose('array', quantities=['energies'])
+    # Test that the object is of the right type
+    ref_obj = get_data_class('array')
+    assert isinstance(data_obj, ref_obj)
+    # Test that the default arrays are present
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated')
+    test_array = np.array([-42.91113666, -42.91113621])
+    assert np.allclose(test_array, energies)
+    # Test number of entries
+    assert energies.shape == (2,)
+    # Electronic steps should be two
+    test_array = np.array([2])
+    assert np.allclose(test_array, data_obj.get_array('electronic_steps'))
+    # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
+    test_array = np.array([-0.00236711])
+    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
+
+
+@pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
+def test_toten_relax(fresh_aiida_env, vasprun_parser):
+    """
+    Check that the total energies are of type ArrayData for runs with multiple ionic steps.
 
     Also check that the entries are as expected.
 
@@ -512,20 +577,89 @@ def test_totens_relax_result(fresh_aiida_env, vasprun_parser):
 
     composer = NodeComposer(file_parsers=[vasprun_parser])
     data_obj = composer.compose('array', quantities=['energies'])
-    # test object
+    # Test that the object is of the right type
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
-    energies = data_obj.get_array('energy_no_entropy')
-    # test number of entries
-    assert energies.shape == (19,)
-    # test a few entries
-    assert energies[0] == -42.91113348
-    assert energies[3] == -43.37734069
-    assert energies[-1] == -43.39087657
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated')
+    test_array = np.array([
+        -42.91113348, -43.27757545, -43.36648855, -43.37734069, -43.38062479, -43.38334165, -43.38753003, -43.38708193, -43.38641449,
+        -43.38701639, -43.38699488, -43.38773717, -43.38988315, -43.3898822, -43.39011239, -43.39020751, -43.39034244, -43.39044584,
+        -43.39087657
+    ])
+    # Test energies
+    assert np.allclose(test_array, energies)
+    # Test number of entries
+    assert energies.shape == test_array.shape
+    # Electronic steps should be entries times one
+    assert np.allclose(np.ones(19, dtype=int), data_obj.get_array('electronic_steps'))
+    # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
+    test_array = np.array([
+        -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
+        -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
+    ])
+    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('disp',)], indirect=True)
-def test_hessian_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('relax', {'electronic_step_energies': True})], indirect=True)
+def test_toten_relax_electronic(fresh_aiida_env, vasprun_parser):
+    """
+    Check that the total energies are of type ArrayData for runs with multiple ionic steps and electronic steps.
+
+    Also check that the entries are as expected.
+
+    """
+
+    composer = NodeComposer(file_parsers=[vasprun_parser])
+    data_obj = composer.compose('array', quantities=['energies'])
+    # Test that the object is of the right type
+    ref_obj = get_data_class('array')
+    assert isinstance(data_obj, ref_obj)
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated')
+    test_array_energies = [
+        np.array([
+            163.37398579, 14.26925896, -23.05190509, -34.91615104, -40.20080347, -42.18390876, -42.97469852, -43.31556073, -43.60169068,
+            -43.61723125, -43.61871511, -43.61879751, -43.12548175, -42.90647187, -42.91031846, -42.91099027, -42.91111107, -42.91113348
+        ]),
+        np.array([-43.34236449, -43.31102002, -43.27768275, -43.27791002, -43.27761357, -43.27757545]),
+        np.array([-43.40320524, -43.38084022, -43.36835045, -43.36666248, -43.36666583, -43.36649036, -43.36648855]),
+        np.array([-43.37749056, -43.37749102, -43.37734414, -43.37734069]),
+        np.array([-43.38117265, -43.38082881, -43.38063293, -43.38062479]),
+        np.array([-43.38337336, -43.38334165]),
+        np.array([-43.38778922, -43.38766017, -43.38752953, -43.38753003]),
+        np.array([-43.38714489, -43.38708193]),
+        np.array([-43.38640951, -43.38641449]),
+        np.array([-43.3874799, -43.3871553, -43.38701949, -43.38701639]),
+        np.array([-43.38790942, -43.38727062, -43.38700335, -43.38699488]),
+        np.array([-43.38774394, -43.38773717]),
+        np.array([-43.38984942, -43.3899134, -43.38988315]),
+        np.array([-43.38988117, -43.3898822]),
+        np.array([-43.39032165, -43.39017866, -43.39011239]),
+        np.array([-43.39021044, -43.39020751]),
+        np.array([-43.39034135, -43.39034244]),
+        np.array([-43.39044466, -43.39044584]),
+        np.array([-43.39084354, -43.39088709, -43.39087657])
+    ]
+    test_array_steps = np.array([18, 6, 7, 4, 4, 2, 4, 2, 2, 4, 4, 2, 3, 2, 3, 2, 2, 2, 3])
+    # Build a flattened array (not using flatten from NumPy as the content is staggered) and
+    # test number of electronic steps per ionic step
+    test_array_energies_flattened = np.array([])
+    for ionic_step in test_array_energies:
+        test_array_energies_flattened = np.append(test_array_energies_flattened, ionic_step)
+    assert energies.shape == test_array_energies_flattened.shape
+    assert np.allclose(test_array_energies_flattened, energies)
+    assert np.allclose(test_array_steps, data_obj.get_array('electronic_steps'))
+    test_array_energies = np.array([
+        -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
+        -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
+    ])
+    # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
+    assert np.allclose(test_array_energies, data_obj.get_array('energy_extrapolated_final'))
+
+
+@pytest.mark.parametrize('vasprun_parser', [('disp', {})], indirect=True)
+def test_hessian(fresh_aiida_env, vasprun_parser):
     """
     Check that the Hessian matrix are of type ArrayData.
 
@@ -554,8 +688,8 @@ def test_hessian_result(fresh_aiida_env, vasprun_parser):
     ]))
 
 
-@pytest.mark.parametrize(['vasprun_parser'], [('disp',)], indirect=True)
-def test_dynmat_result(fresh_aiida_env, vasprun_parser):
+@pytest.mark.parametrize('vasprun_parser', [('disp', {})], indirect=True)
+def test_dynmat(fresh_aiida_env, vasprun_parser):
     """
     Check parsing of the dynamical eigenvectors and eigenvalues.
 

--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -16,9 +16,10 @@ from aiida_vasp.parsers.file_parsers.parser import BaseFileParser, SingleFile
 DEFAULT_OPTIONS = {
     'quantities_to_parse': [
         'structure', 'eigenvalues', 'dos', 'bands', 'kpoints', 'occupancies', 'trajectory', 'energies', 'projectors', 'dielectrics',
-        'born_charges', 'hessian', 'dynmat', 'forces', 'stress', 'total_energies', 'maximum_force', 'maximum_stress'
+        'born_charges', 'hessian', 'dynmat', 'forces', 'stress', 'total_energies', 'maximum_force', 'maximum_stress', 'version'
     ],
-    'energy_type': ['energy_no_entropy']
+    'energy_type': ['energy_extrapolated'],
+    'electronic_step_energies': False
 }
 
 
@@ -120,6 +121,11 @@ class VasprunParser(BaseFileParser):
             'name': 'maximum_stress',
             'prerequisites': []
         },
+        'version': {
+            'inputs': [],
+            'name': 'version',
+            'prerequisites': [],
+        }
     }
 
     def __init__(self, *args, **kwargs):
@@ -188,6 +194,21 @@ class VasprunParser(BaseFileParser):
                     quantities=list(result.keys()))
 
         return result
+
+    @property
+    def version(self):
+        """Fetch the VASP version from parsevasp and return it as a string object."""
+
+        # fetch version
+        version = self._xml.get_version()
+
+        if version is None:
+            # version not present
+            self._vasp_parser.exit_code = self._vasp_parser.exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(
+                quantity=sys._getframe().f_code.co_name)
+            return None
+
+        return version
 
     @property
     def eigenvalues(self):
@@ -290,7 +311,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        last_lattice = self._xml.get_lattice('final')
+        last_lattice = self._xml.get_lattice('last')
         if last_lattice is None:
             self._vasp_parser.exit_code = self._vasp_parser.exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(
                 quantity=sys._getframe().f_code.co_name)
@@ -318,7 +339,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        force = self._xml.get_forces('final')
+        force = self._xml.get_forces('last')
         return force
 
     @property
@@ -369,7 +390,7 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        stress = self._xml.get_stress('final')
+        stress = self._xml.get_stress('last')
         return stress
 
     @property
@@ -437,7 +458,7 @@ class VasprunParser(BaseFileParser):
         stress = np.asarray([item[1] for item in stress])
         # Aiida wants the species as symbols, so invert
         elements = _invert_dict(parsevaspct.elements)
-        symbols = np.asarray([elements[item].title() for item in species])
+        symbols = np.asarray([elements[item].title() for item in species.tolist()])
 
         if (unitcell is not None) and (positions is not None) and \
            (species is not None) and (forces is not None) and \
@@ -459,66 +480,43 @@ class VasprunParser(BaseFileParser):
     @property
     def total_energies(self):
         """Fetch the total energies after the last ionic run."""
-
         energies = self.energies
         if energies is None:
             self._vasp_parser.exit_code = self._vasp_parser.exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(
                 quantity=sys._getframe().f_code.co_name)
             return None
-        # fetch the type of energies that the user wants to extract
-        settings = self._parsed_data.get('settings', DEFAULT_OPTIONS)
         energies_dict = {}
-        for etype in settings.get('energy_type', DEFAULT_OPTIONS['energy_type']):
+        for etype in self.settings.get('energy_type', DEFAULT_OPTIONS['energy_type']):
             energies_dict[etype] = energies[etype][-1]
 
         return energies_dict
 
     @property
     def energies(self):
-        return self._energies(nosc=True)
+        """Fetch the total energies."""
+        # Check if we want total energy entries for each electronic step.
+        electronic_step_energies = self.settings.get('electronic_step_energies', DEFAULT_OPTIONS['electronic_step_energies'])
 
-    @property
-    def energies_sc(self):
-        """
-        Fetch the total energies.
-
-        Store in ArrayData for all self-consistent electronic steps.
-
-        """
-
-        # raise error due to lack of knowledge if
-        # the Aiida data structure support for instance
-        # lists of ndarrays.
-        raise NotImplementedError
-        #return self.energies(nosc = False)
+        return self._energies(nosc=not electronic_step_energies)
 
     def _energies(self, nosc):
-        """Fetch the total energies for all calculations (i.e. ionic steps)."""
-        # fetch the type of energies that the user wants to extract
-        settings = self._parsed_data.get('settings', DEFAULT_OPTIONS)
+        """
+        Fetch the total energies for all energy types, calculations (ionic steps) and electronic steps.
 
-        enrgy = {}
-        for etype in settings.get('energy_type', DEFAULT_OPTIONS['energy_type']):
+        The returned dict from the parser contains the total energy types as a key (plus the _final, which is
+        the final total energy ejected by VASP after the closure of the electronic steps). The energies can then
+        be found in the flattened ndarray where the key `electronic_steps` indicate how many electronic steps
+        there is per ionic step. Using the combination, one can rebuild the electronic step energy per ionic step etc.
 
-            # this returns a list, not an ndarray due to
-            # the posibility of returning the energies for all
-            # self consistent steps, which contain a different
-            # number of elements, not supported by Numpy's std.
-            # arrays
-            enrgies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
-            if enrgies is None:
-                self._vasp_parser.exit_code = self._vasp_parser.exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(
-                    quantity=str(sys._getframe().f_code.co_name))
-                return None
-            # should be a list, but convert to ndarray, here
-            # staggered arrays are not a problem
-            # two elements for a static run, both are similar,
-            # only take the last
-            if len(enrgies) == 2:
-                enrgies = enrgies[-1:]
-            enrgy[etype] = np.asarray(enrgies)
+        """
+        etype = self.settings.get('energy_type', DEFAULT_OPTIONS['energy_type'])
+        energies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
+        if energies is None:
+            self._vasp_parser.exit_code = self._vasp_parser.exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(
+                quantity=str(sys._getframe().f_code.co_name))
+            return None
 
-        return enrgy
+        return energies
 
     @property
     def projectors(self):
@@ -532,11 +530,11 @@ class VasprunParser(BaseFileParser):
         projectors = {}
         prj = []
         try:
-            prj.append(proj['total'])
+            prj.append(proj['total'])  # pylint: disable=unsubscriptable-object
         except KeyError:
             try:
-                prj.append(proj['up'])
-                prj.append(proj['down'])
+                prj.append(proj['up'])  # pylint: disable=unsubscriptable-object
+                prj.append(proj['down'])  # pylint: disable=unsubscriptable-object
             except KeyError:
                 self._logger.error('Did not detect any projectors. Returning.')
         if len(prj) == 1:
@@ -608,8 +606,8 @@ class VasprunParser(BaseFileParser):
                 quantity=sys._getframe().f_code.co_name)
             return None
         dyn = {}
-        dyn['dynvec'] = dynmat['eigenvectors']
-        dyn['dyneig'] = dynmat['eigenvalues']
+        dyn['dynvec'] = dynmat['eigenvectors']  # pylint: disable=unsubscriptable-object
+        dyn['dyneig'] = dynmat['eigenvalues']  # pylint: disable=unsubscriptable-object
         return dyn
 
     @property
@@ -624,7 +622,7 @@ class VasprunParser(BaseFileParser):
         densta = {}
         # energy is always there, regardless of
         # total, spin or partial
-        energy = dos['total']['energy']
+        energy = dos['total']['energy']  # pylint: disable=unsubscriptable-object
         densta['energy'] = energy
         tdos = None
         pdos = None

--- a/aiida_vasp/parsers/node_composer.py
+++ b/aiida_vasp/parsers/node_composer.py
@@ -13,7 +13,9 @@ from aiida_vasp.parsers.quantity import ParsableQuantities
 """NODE_TYPES"""  # pylint: disable=pointless-string-statement
 
 NODES_TYPES = {
-    'dict': ['total_energies', 'maximum_force', 'maximum_stress', 'symmetries', 'magnetization', 'site_magnetization', 'notifications'],
+    'dict': [
+        'total_energies', 'maximum_force', 'maximum_stress', 'symmetries', 'magnetization', 'site_magnetization', 'notifications', 'version'
+    ],
     'array.kpoints': ['kpoints'],
     'structure': ['structure'],
     'array.trajectory': ['trajectory'],

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -72,7 +72,7 @@ NODES = {
     'misc': {
         'link_name': 'misc',
         'type': 'dict',
-        'quantities': ['total_energies', 'maximum_stress', 'maximum_force', 'symmetries', 'magnetization', 'notifications']
+        'quantities': ['total_energies', 'maximum_stress', 'maximum_force', 'symmetries', 'magnetization', 'notifications', 'version']
     },
     'kpoints': {
         'link_name': 'kpoints',
@@ -177,7 +177,6 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
     """
 
     def __init__(self, settings, default_settings=None):
-
         self.alternatives = {}
         if settings is None:
             settings = {}

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -295,7 +295,7 @@ def test_misc(request, calc_with_retrieved):
     assert data['fermi_level'] == 6.17267267
     assert data['maximum_stress'] == 42.96872956444064
     assert data['maximum_force'] == 0.21326679
-    assert data['total_energies']['energy_no_entropy'] == -10.823296
+    assert data['total_energies']['energy_extrapolated'] == -10.823296
 
 
 @pytest.mark.parametrize(

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -362,14 +362,15 @@ def ref_retrieved():
     return retrieved
 
 
-@pytest.fixture(params=['vasprun'])
+@pytest.fixture(params=[('vasprun', {})])
 def vasprun_parser(request):
     """Return an instance of VasprunParser for a reference vasprun.xml."""
     from aiida_vasp.parsers.settings import ParserSettings
     from aiida_vasp.calcs.vasp import VaspCalculation
     file_name = 'vasprun.xml'
-    path = data_path(request.param, file_name)
-    parser = VasprunParser(file_path=path, settings=ParserSettings({}))
+    path_to_file, settings = request.param
+    path = data_path(path_to_file, file_name)
+    parser = VasprunParser(file_path=path, settings=ParserSettings(settings))
     parser._vasp_parser = VaspCalculation
     return parser
 

--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -192,7 +192,7 @@ class ConvergeWorkChain(WorkChain):
         spec.input('converge.total_energy_type',
                    valid_type=get_data_class('str'),
                    required=False,
-                   default=lambda: get_data_node('str', 'energy_no_entropy'),
+                   default=lambda: get_data_node('str', 'energy_extrapolated'),
                    help="""
                    The energy type that is used when ``cutoff_type`` is set to `energy`.
                    Consult the options available in the parser for the current version.

--- a/aiida_vasp/workchains/tests/test_vasp_wc.py
+++ b/aiida_vasp/workchains/tests/test_vasp_wc.py
@@ -56,7 +56,7 @@ def test_vasp_wc(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_st
     assert 'remote_folder' in results
     misc = results['misc'].get_dict()
     assert misc['maximum_stress'] == 22.8499295
-    assert misc['total_energies']['energy_no_entropy'] == -14.16209692
+    assert misc['total_energies']['energy_extrapolated'] == -14.16209692
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)

--- a/doc/source/getting_started/test_run.rst
+++ b/doc/source/getting_started/test_run.rst
@@ -156,7 +156,7 @@ In this part we will simply launch a `VASP`_ calculation of silicon using the st
         ]
      },
      "total_energies": {
-     "energy_no_entropy": -10.79608481
+     "energy_extrapolated": -10.79608481
      }
      }
 

--- a/doc/source/tutorials/fcc_si_step1.rst
+++ b/doc/source/tutorials/fcc_si_step1.rst
@@ -173,7 +173,7 @@ calculations at different volumes.
 	     ]
 	 },
 	 "total_energies": {
-             "energy_no_entropy": -4.87588342
+             "energy_extrapolated": -4.87588342
 	 }
      }
 

--- a/doc/source/tutorials/run_vasp_builder.rst
+++ b/doc/source/tutorials/run_vasp_builder.rst
@@ -227,7 +227,7 @@ And then we load the node::
 
    In [1]: n = load_node(<pk>)
 
-   In [2]: n.outputs.energies.get_array('energy_no_entropy')
+   In [2]: n.outputs.energies.get_array('energy_extrapolated')
    Out[2]: array([-31.80518222])
 
    In [3]: n.outputs.stress.get_array('final')

--- a/setup.json
+++ b/setup.json
@@ -2,16 +2,16 @@
     "author": "Espen Flage-Larsen",
     "author_email": "espen.flage-larsen@sintef.no",
     "classifiers": [
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Plugins",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Topic :: Scientific/Engineering :: Chemistry",
-        "Framework :: AiiDA"
+	"Development Status :: 5 - Production/Stable",
+	"Environment :: Plugins",
+	"Intended Audience :: Science/Research",
+	"License :: OSI Approved :: MIT License",
+	"Programming Language :: Python :: 3.6",
+	"Programming Language :: Python :: 3.7",
+	"Programming Language :: Python :: 3.8",
+	"Topic :: Scientific/Engineering :: Physics",
+	"Topic :: Scientific/Engineering :: Chemistry",
+	"Framework :: AiiDA"
     ],
     "description": "AiiDA Plugin for running VASP calculations.",
     "license": "MIT License, see LICENSE.txt file.",
@@ -20,69 +20,70 @@
     "version": "1.0.1",
     "reentry_register": true,
     "setup_requires": [
-        "reentry"
+	"reentry"
     ],
     "entry_points": {
-        "aiida.calculations": [
-            "vasp.vasp = aiida_vasp.calcs.vasp:VaspCalculation",
-            "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation"
-        ],
-        "aiida.cmdline.data": [
-            "vasp-potcar = aiida_vasp.commands.potcar:potcar"
-        ],
-        "aiida.data": [
-            "vasp.archive = aiida_vasp.data.archive:ArchiveData",
-            "vasp.chargedensity = aiida_vasp.data.chargedensity:ChargedensityData",
-            "vasp.wavefun = aiida_vasp.data.wavefun:WavefunData",
-            "vasp.potcar = aiida_vasp.data.potcar:PotcarData",
-            "vasp.potcar_file = aiida_vasp.data.potcar:PotcarFileData"
-        ],
-        "aiida.parsers": [
-            "vasp.vasp = aiida_vasp.parsers.vasp:VaspParser",
-            "vasp.vasp2w90 = aiida_vasp.parsers.vasp2w90:Vasp2w90Parser"
-        ],
-        "aiida.workflows": [
-            "vasp.vasp = aiida_vasp.workchains.vasp:VaspWorkChain",
-            "vasp.verify = aiida_vasp.workchains.verify:VerifyWorkChain",
-            "vasp.converge = aiida_vasp.workchains.converge:ConvergeWorkChain",
-            "vasp.bands = aiida_vasp.workchains.bands:BandsWorkChain",
-            "vasp.master = aiida_vasp.workchains.master:MasterWorkChain",
-            "vasp.relax = aiida_vasp.workchains.relax:RelaxWorkChain"
-        ],
-        "console_scripts": [
-            "mock-vasp = aiida_vasp.commands.mock_vasp:mock_vasp"
-        ]
+	"aiida.calculations": [
+	    "vasp.vasp = aiida_vasp.calcs.vasp:VaspCalculation",
+	    "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation"
+	],
+	"aiida.cmdline.data": [
+	    "vasp-potcar = aiida_vasp.commands.potcar:potcar"
+	],
+	"aiida.data": [
+	    "vasp.archive = aiida_vasp.data.archive:ArchiveData",
+	    "vasp.chargedensity = aiida_vasp.data.chargedensity:ChargedensityData",
+	    "vasp.wavefun = aiida_vasp.data.wavefun:WavefunData",
+	    "vasp.potcar = aiida_vasp.data.potcar:PotcarData",
+	    "vasp.potcar_file = aiida_vasp.data.potcar:PotcarFileData"
+	],
+	"aiida.parsers": [
+	    "vasp.vasp = aiida_vasp.parsers.vasp:VaspParser",
+	    "vasp.vasp2w90 = aiida_vasp.parsers.vasp2w90:Vasp2w90Parser"
+	],
+	"aiida.workflows": [
+	    "vasp.vasp = aiida_vasp.workchains.vasp:VaspWorkChain",
+	    "vasp.verify = aiida_vasp.workchains.verify:VerifyWorkChain",
+	    "vasp.converge = aiida_vasp.workchains.converge:ConvergeWorkChain",
+	    "vasp.bands = aiida_vasp.workchains.bands:BandsWorkChain",
+	    "vasp.master = aiida_vasp.workchains.master:MasterWorkChain",
+	    "vasp.relax = aiida_vasp.workchains.relax:RelaxWorkChain"
+	],
+	"console_scripts": [
+	    "mock-vasp = aiida_vasp.commands.mock_vasp:mock_vasp"
+	]
     },
     "extras_require": {
-        "dev": [
-            "aiida-export-migration-tests==0.8.0",
-            "pg8000~=1.13",
-            "pgtest~=1.3,>=1.3.1",
-            "pytest~=5.3",
-            "pytest-timeout~=1.3",
-            "sqlalchemy-diff~=0.1.3",
-            "astroid==2.3.3",
-            "pre-commit==1.18.3",
-            "prospector==1.2.0",
-            "pylint==2.4.4",
-            "toml~=0.10.0",
-            "yapf==0.28.0",
-            "coverage",
-            "pytest-cov"
-        ],
-        "graphs": [
-            "matplotlib"
-        ],
-        "wannier": [
-            "aiida-wannier90"
-        ]
+	"pre-commit": [
+	    "pre-commit~=2.2",
+	    "pylint~=2.5.0",
+	    "yapf==0.28.0"
+	],
+	"tests": [
+	    "aiida-export-migration-tests==0.9.0",
+	    "pg8000~=1.13",
+	    "pgtest~=1.3,>=1.3.1",
+	    "pytest~=6.0",
+	    "pytest-timeout~=1.3",
+	    "pytest-cov~=2.7",
+	    "sqlalchemy-diff~=0.1.3",
+	    "astroid>=2.4.0",
+	    "toml~=0.10.0",
+	    "coverage<5.0"
+	],
+	"graphs": [
+	    "matplotlib"
+	],
+	"wannier": [
+	    "aiida-wannier90"
+	]
     },
     "include_package_data": true,
     "install_requires": [
-        "aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
-        "subprocess32",
-        "lxml",
-        "packaging",
-        "parsevasp >= 1.1.2"
+	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
+	"subprocess32",
+	"lxml",
+	"packaging",
+	"parsevasp >= 2.0.0"
     ]
 }

--- a/tutorials/eos.py
+++ b/tutorials/eos.py
@@ -172,7 +172,7 @@ class EosWorkChain(WorkChain):
 
         # Fetch the total energy
         misc = workchain.outputs.misc.get_dict()
-        total_energy = misc['total_energies']['energy_no_entropy']
+        total_energy = misc['total_energies']['energy_extrapolated']
 
         # Fetch the volume
         volume = self.ctx.inputs.structure.get_cell_volume()

--- a/tutorials/run_fcc_si_multiple_volumes_eos.py
+++ b/tutorials/run_fcc_si_multiple_volumes_eos.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         # The output are stored as AiiDA datatypes, which is Dict in this case. To obtain a regular
         # dictionary, we use get_dict
         misc = output['misc'].get_dict()
-        EOS.append([lattice_constant, misc['total_energies']['energy_no_entropy']])
+        EOS.append([lattice_constant, misc['total_energies']['energy_extrapolated']])
     # Write volume and total energies to file
     with open('eos', 'w') as file_object:
         for item in EOS:


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs
#392, #411, #388, #347, 

## Description
Additional quantities can be parsed in `parsevasp>=2.0.0` and thus we update the
dependencies. In addition, we changed the extra tags when installing to comply with the standard, including `aiida-core`. During the update of the parsing of the total energies in `parsevasp` the default energy was changed from `energy_no_enetropy` to `energy_extrapolated`. Additional tests have been added, in addition to the posibilities of storing the total energies of each electronic step.

Furthermore, we have removed `prospector` and execute `pylint` directly, similar to what has been done in `aiida-core`.