### PR TITLE
Update of parameter massager

### DIFF
--- a/aiida_vasp/assistant/parameters.py
+++ b/aiida_vasp/assistant/parameters.py
@@ -12,22 +12,8 @@ from aiida.common.extendeddicts import AttributeDict
 from aiida.plugins import DataFactory
 from aiida_vasp.utils.extended_dicts import update_nested_dict
 
-FUNCTIONAL_PARAMETERS = {
-    'charge': {
-        'wave': True,
-        'charge': True,
-        'potential': True,
-        'constant_charge': True,
-        'constant_atomic': True
-    },
-    'smearing': {
-        'mp': True,
-        'gaussian': True,
-        'fermi': True,
-        'partial': True,
-        'tetra': True
-    }
-}
+_BASE_NAMESPACES = ['electronic', 'smearing', 'charge', 'dynamics', 'bands', 'relax', 'converge']
+_DEFAULT_OVERRIDE_NAMESPACE = 'incar'
 
 
 class ChargeEnum(enum.IntEnum):
@@ -135,47 +121,66 @@ class RelaxModeEnum(enum.IntEnum):
             raise ValueError('Invalid combination for degrees of freedom: {}'.format(dict(zip(RELAX_POSSIBILITIES, dof))))
 
 
-class ParametersMassage():
+class ParametersMassage():  # pylint: disable=too-many-instance-attributes
     """
     A class that contains all relevant massaging of the input parameters for VASP.
 
     The idea is that this class accepts the set input parameters from AiiDA (non code specifics), checks if any code specific
     parameters supplied are valid VASP input parameters (only rudimentary at this point, should also cross check and check types)
-    and convert the AiiDA input parameters to VASP specific parameters. A set function needs to be developed for each parameter.
-    This set function takes the AiiDA input and converts it. The parameter property should return ready to go parameters
-    that can be dumped using the parsers in the respective CalcJob plugins.
+    and convert the AiiDA input parameters to VASP specific parameters. A set function needs to be developed for each VASP INCAR
+    parameter that we want to set based on supplied AiiDA/AiiDA-VASP specific parameters. These set functions takes these parameters
+    and converts it to VASP INCAR compatible tags. The parameter property should return ready to go parameters containing the
+    default override namespace, the namespaces set in the `_set_extra_parameters` function and any additional namespaces
+    that might have been set using the `additional_override_namespaces` setting entry in settings
+    that can be supplied to the VaspWorkChain.
+
+    The default override namespace (see `_DEFAULT_OVERRIDE_NAMESPACE`) should always be present when using this VASP plugin.
+    If using additional plugins, one can for instance supply additional namespace override that can be used,
+    depending on what is needed in those plugins and how you construct your workchains.
     """
 
-    def __init__(self, workchain, parameters, unsupported_parameters=None):
-        # First of all make sure parameters is a not a AiiDA Dict datatype
+    def __init__(self, parameters, unsupported_parameters=None, settings=None):
         self.exit_code = None
-        if unsupported_parameters is None:
-            self._unsupported_parameters = {}
-        else:
-            if not isinstance(unsupported_parameters, dict):
-                raise ValueError(
-                    f'The supplied value for unsupported_parameters is not of list, but of type {type(unsupported_parameters)}')
-            self._unsupported_parameters = unsupported_parameters
-        self._workchain = workchain
+
+        # Check type of parameters and set
+        self._parameters = check_inputs(parameters)
+
+        # Check type of supplied unsupported_parameters and set
+        self._unsupported_parameters = check_inputs(unsupported_parameters)
+
+        # Check type of settings and set
+        self._settings = check_inputs(settings)
+
+        # Check setting for any possible supplied additional override namespace and set
+        self._additional_override_namespaces = self._fetch_additional_override_namespaces()
+
         self._massage = AttributeDict()
-        self._massage.code = AttributeDict()
-        if isinstance(parameters, DataFactory('dict')):
-            self._parameters = AttributeDict(parameters.get_dict())
-        elif isinstance(parameters, AttributeDict):
-            self._parameters = parameters
-        else:
-            raise TypeError('The supplied type: {} of parameters is not supported. '
-                            'Supply either a Dict or an AttributeDict'.format(type(parameters)))
+        # Initialize any allowed override namespaces
+        self._massage[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+        for item in self._additional_override_namespaces:
+            self._massage[item] = AttributeDict()
+
+        self._check_valid_namespaces()
+        # Load the valid INCAR parameters that are supported by VASP
         self._load_valid_params()
-        self._functions = ParameterSetFunctions(self._workchain, self._parameters, self._massage.code)
-        self._set_parameters()
-        # Override any parameter set so far by parameters in the code namespace.
-        self._set_override_parameters()
-        # No point to proceed if the override parameters already contains an invalid keys, or the set process trigger another exit code
-        self._set_extra_parameters()
-        if self.exit_code is not None:
-            return
-        self._validate_parameters()
+        # Establish set functions which will convert AiiDA/AiiDA-VASP specific parameters to VASP INCAR tags
+        self._functions = ParameterSetFunctions(self._parameters, self._massage[_DEFAULT_OVERRIDE_NAMESPACE])
+        # Convert general parameters to VASP specific ones, using the set functions
+        self._set_vasp_parameters()
+        # Override or set parameters that are supplied in the default override namespace (should be valid VASP INCAR tags)
+        self._set_override_vasp_parameters()
+        # Set any extra parameters not related to INCAR
+        self._set_extra_vasp_parameters()
+        # Set any additional override namespace that should just be forwarded
+        self._set_additional_override_parameters()
+        # Finally, we validate the INCAR parameters in order to prepare it for dispatch
+        self._validate_vasp_parameters()
+
+    def _check_valid_namespaces(self):
+        """Check that we do not have namespaces on the input parameters that is unsupported."""
+        for key in self._parameters.keys():
+            if key not in list(_BASE_NAMESPACES + self._additional_override_namespaces + [_DEFAULT_OVERRIDE_NAMESPACE]):
+                raise ValueError(f'The supplied namespace: {key} is not supported.')
 
     def _load_valid_params(self):
         """Import a list of valid parameters for VASP. This is generated from the manual."""
@@ -187,38 +192,49 @@ class ParametersMassage():
         # Now add any unsupported parameter to the list
         for key, _ in self._unsupported_parameters.items():
             key = key.lower()
-            try:
-                _ = self._massage[key]
-                raise ValueError(f'The supplied unsupported_parameters with key {key} is already a supported parameter.')
-            except KeyError:
+            if key not in self._valid_parameters:
                 self._valid_parameters.append(key)
 
-    def _set_parameters(self):
+    def _fetch_additional_override_namespaces(self):
+        """Check the settings for any additional supplied override namespace and return it."""
+        try:
+            override_namespaces = self._settings.additional_override_namespaces
+        except AttributeError:
+            override_namespaces = []
+
+        return override_namespaces
+
+    def _set_vasp_parameters(self):
         """Iterate over the valid parameters and call the set function associated with that parameter."""
         for key in self._valid_parameters:
             self._set(key)
-            # We check after each parameter set if there is an exit code set on the WorkChain, if so, return
-            if self.exit_code is not None:
-                return
 
-    def _set_override_parameters(self):
+    def _set_override_vasp_parameters(self):
         """Set the any supplied override parameters."""
         try:
-            if self._parameters.code:
-                self._massage.code = AttributeDict()
-            for key, item in self._parameters.code.items():
-                # Sweep the override input parameters to check if they are valid VASP tags
-                key = key.lower()
-                if self._valid_vasp_parameter(key):
-                    self._massage.code[key] = item
-                else:
-                    break
-        except AttributeError:
-            # The vasp namespace might not be supplied (no override)
+            if self._parameters[_DEFAULT_OVERRIDE_NAMESPACE]:
+                for key, item in self._parameters[_DEFAULT_OVERRIDE_NAMESPACE].items():
+                    # Sweep the override input parameters (only care about the ones in the default override namespace)
+                    # to check if they are valid VASP tags.
+                    key = key.lower()
+                    if self._valid_vasp_parameter(key):
+                        # Add or override in the default override namespace
+                        self._massage[_DEFAULT_OVERRIDE_NAMESPACE][key] = item
+                    else:
+                        break
+        except KeyError:
+            # The default override namespace might not be supplied (no override)
             pass
 
-    def _set_extra_parameters(self):
-        """Find if there are any extra parameters that are not part of the INCAR which should still be passed to the workchai"""
+    def _set_extra_vasp_parameters(self):
+        """
+        Find if there are any extra parameters that are not part of the INCAR that needs to be set.
+
+        One example is the dynamic namespace which handles for instance flags for selective dynamics.
+        These flags are more connected to a calculation than a StructureData and thus it was necessary
+        to make sure it was valid input to the VASP workchain.
+
+        """
         try:
             if self._parameters.dynamics:
                 self._massage.dynamics = AttributeDict()
@@ -231,22 +247,24 @@ class ParametersMassage():
         except AttributeError:
             pass
 
+    def _set_additional_override_parameters(self):
+        """Set any customized parameter namespace, including its content on the massaged container."""
+        parameters_keys = self._parameters.keys()
+        for item in self._additional_override_namespaces:
+            if item in parameters_keys:
+                # Only add if namespace exists in parameters
+                self._massage[item] = AttributeDict(self._parameters[item])
+
     def _valid_vasp_parameter(self, key):
         """Make sure a key are recognized as a valid VASP input parameter."""
         if key not in self._valid_parameters:
-            msg = 'Found an invalid key for the INCAR parameters: {}'.format(key)
-            if self._workchain is not None:
-                self._workchain.report(msg)
-                self.exit_code = self._workchain.exit_codes.ERROR_INVALID_PARAMETER_DETECTED
-            else:
-                self.exit_code = True
-            return False
+            raise ValueError(f'The supplied key: {key} is not a support VASP parameter.')
 
         return True
 
-    def _validate_parameters(self):
+    def _validate_vasp_parameters(self):
         """Make sure all the massaged values are recognized as valid VASP input parameters."""
-        for key in self._massage.code:
+        for key in self._massage[_DEFAULT_OVERRIDE_NAMESPACE]:
             key = key.lower()
             if not self._valid_vasp_parameter(key):
                 break
@@ -254,17 +272,11 @@ class ParametersMassage():
     def _set(self, key):
         """Call the necessary function to set each parameter."""
         try:
-            exit_code = getattr(self._functions, 'set_' + key)()
-            if exit_code is not None:
-                self.exit_code = exit_code
+            getattr(self._functions, 'set_' + key)()
         except AttributeError:
+            # We have no setter function for the valid key, meaning there is no general parameter that is linked
+            # to this key (INCAR tag). These tags have to be supplied in the default override namespace for now.
             pass
-        # If we find any raw code input key directly on parameter root, override whatever we have set until now
-        # Note that the key may be in upper case, so we test both
-        if key in self._parameters:
-            self._massage.code[key] = self._parameters[key]
-        elif key.upper() in self._parameters:
-            self._massage.code[key] = self._parameters[key.upper()]
 
     @property
     def parameters(self):
@@ -273,24 +285,22 @@ class ParametersMassage():
 
 
 class ParameterSetFunctions():
-    """Container for the set functions that converts an AiiDA parameters to a code specific one."""
+    """Container for the set functions that converts an AiiDA parameters to a default override specific one."""
 
-    def __init__(self, workchain, parameters, massage):
+    def __init__(self, parameters, incar):
         self._parameters = parameters
-        self._workchain = workchain
-        self._massage = massage
+        self._incar = incar
 
     def set_encut(self):
         """
         Set which plane wave cutoff to use.
 
         See https://www.vasp.at/wiki/index.php/ENCUT
-
         """
+
         try:
-            self._massage.encut = self._parameters.pwcutoff
+            self._incar.encut = self._parameters.electronic.pwcutoff
         except AttributeError:
-            # VASP accepts defaults
             pass
 
     def set_ibrion(self):
@@ -299,20 +309,17 @@ class ParameterSetFunctions():
 
         See: https://www.vasp.at/wiki/index.php/IBRION
         """
+
         if self._relax():
             try:
                 if self._parameters.relax.algo == 'cg':
-                    self._massage.ibrion = RelaxAlgoEnum.IONIC_RELAXATION_CG.value
+                    self._incar.ibrion = RelaxAlgoEnum.IONIC_RELAXATION_CG.value
                 elif self._parameters.relax.algo == 'rd':
-                    self._massage.ibrion = RelaxAlgoEnum.IONIC_RELAXATION_RMM_DIIS.value
+                    self._incar.ibrion = RelaxAlgoEnum.IONIC_RELAXATION_RMM_DIIS.value
                 else:
-                    self._workchain.report('Invalid algo parameter: {}'.format(self._parameters.relax.algo))
-                    return self._workchain.exit_codes.ERROR_INVALID_PARAMETER_DETECTED
+                    raise ValueError(f'The supplied relax.algo: {self._parameters.relax.algo} is not supported')
             except AttributeError:
-                self._workchain.report('Missing parameter: algo')
-                return self._workchain.exit_codes.ERROR_MISSING_PARAMETER_DETECTED
-
-        return None
+                pass
 
     def set_ediffg(self):
         """
@@ -320,18 +327,20 @@ class ParameterSetFunctions():
 
         See: https://www.vasp.at/wiki/index.php/EDIFFG
         """
+
         if not self._relax():
+            # This flag is only valid if you have enabled relaxation
             return
         energy_cutoff = False
         try:
-            self._massage.ediffg = self._parameters.relax.energy_cutoff
+            self._incar.ediffg = self._parameters.relax.energy_cutoff
             energy_cutoff = True
         except AttributeError:
             pass
         try:
-            self._massage.ediffg = -abs(self._parameters.relax.force_cutoff)
+            self._incar.ediffg = -abs(self._parameters.relax.force_cutoff)
             if energy_cutoff:
-                self._workchain.report('User supplied both a force and an energy cutoff for the relaxation. Utilizing the force cutoff.')
+                raise ValueError('User supplied both a force and an energy cutoff for the relaxation. Please select.')
         except AttributeError:
             pass
 
@@ -341,8 +350,12 @@ class ParameterSetFunctions():
 
         See: https://www.vasp.at/wiki/index.php/NSW
         """
+
         if self._relax():
-            self._set_simple('nsw', self._parameters.relax.steps)
+            try:
+                self._set_simple('nsw', self._parameters.relax.steps)
+            except AttributeError:
+                pass
 
     def set_isif(self):
         """
@@ -350,11 +363,15 @@ class ParameterSetFunctions():
 
         See: https://www.vasp.at/wiki/index.php/ISIF
         """
-        positions = self._parameters.get('relax', {}).get('positions', False)
-        shape = self._parameters.get('relax', {}).get('shape', False)
-        volume = self._parameters.get('relax', {}).get('volume', False)
-        if positions or shape or volume:
-            self._massage.isif = RelaxModeEnum.get_isif_from_dof(positions=positions, shape=shape, volume=volume).value
+
+        if self._relax():
+            positions = self._parameters.get('relax', {}).get('positions', False)
+            shape = self._parameters.get('relax', {}).get('shape', False)
+            volume = self._parameters.get('relax', {}).get('volume', False)
+            try:
+                self._incar.isif = RelaxModeEnum.get_isif_from_dof(positions=positions, shape=shape, volume=volume).value
+            except AttributeError:
+                pass
 
     def set_ismear(self):
         """
@@ -390,6 +407,7 @@ class ParameterSetFunctions():
 
         See: https://www.vasp.at/wiki/index.php/ICHARG
         """
+
         try:
             if self._parameters.charge.from_wave:
                 self._set_simple('icharg', ChargeEnum.WAVE.value)
@@ -435,7 +453,7 @@ class ParameterSetFunctions():
                     raise ValueError('Only projections/decompositions on the bands or the wave function are allowed.')
                 wigner_seitz_radius = False
                 try:
-                    if abs(self._massage.rwigs[0]) > 1E-8:
+                    if abs(self._incar.rwigs[0]) > 1E-8:
                         wigner_seitz_radius = True
                 except AttributeError:
                     pass
@@ -484,16 +502,34 @@ class ParameterSetFunctions():
 
     def _relax(self):
         """Check if we have enabled relaxation."""
-        return self._parameters.get('relax', {}).get('positions') or \
+        return bool(self._parameters.get('relax', {}).get('positions') or \
             self._parameters.get('relax', {}).get('shape') or \
-            self._parameters.get('relax', {}).get('volume')
+            self._parameters.get('relax', {}).get('volume'))
 
     def _set_simple(self, target, value):
         """Set basic parameter."""
         try:
-            self._massage[target] = value
+            self._incar[target] = value
         except AttributeError:
             pass
+
+
+def check_inputs(supplied_inputs):
+    """Check that the inputs are of some correct type and returned as AttributeDict."""
+    inputs = None
+    if supplied_inputs is None:
+        inputs = AttributeDict()
+    else:
+        if isinstance(supplied_inputs, DataFactory('dict')):
+            inputs = AttributeDict(supplied_inputs.get_dict())
+        elif isinstance(supplied_inputs, dict):
+            inputs = AttributeDict(supplied_inputs)
+        elif isinstance(supplied_inputs, AttributeDict):
+            inputs = supplied_inputs
+        else:
+            raise ValueError(f'The supplied type {type(inputs)} of inputs is not supported. Supply a dict, Dict or an AttributeDict.')
+
+    return inputs
 
 
 def inherit_and_merge_parameters(inputs):
@@ -504,7 +540,9 @@ def inherit_and_merge_parameters(inputs):
     in case there is overlap.
     """
     parameters = AttributeDict()
-    namespaces = ['electronic', 'bands', 'smearing', 'charge', 'relax', 'converge', 'dynamics']
+    namespaces = _BASE_NAMESPACES
+
+    # We start with a clean parameters and first set the allowed namespaces and its content from the inputs of the workchain
     for namespace in namespaces:  # pylint: disable=too-many-nested-blocks
         parameters[namespace] = AttributeDict()
         try:
@@ -526,45 +564,19 @@ def inherit_and_merge_parameters(inputs):
         except KeyError:
             pass
 
-    # Now get the input parameters and update the dictionary. This means,
-    # any supplied namespace in the parameters (i.e. inputs.parameters.somekey) will override what is supplied to the workchain
-    # input namespace (i.e. inputs.somekey).
-    input_parameters = vasp_parameter_nesting(inputs=inputs, namespaces=namespaces)
-    # Now check that no loose keys are residing on the root of input_parameters, everything should be in
-    # the vasp or aiida namespace
-    #valid_keys = ['vasp', 'aiida']
-    # if not list(input_parameters.keys()).sort() == valid_keys.sort():
-    #    raise ValueError('Unsupported keys detected on parameter root. '
-    #                     'Please make sure all keys reside inside the vasp or aiida namespace.')
+    # Then obtain the inputs.parameters.
+    # Here we do not do any checks for valid parameters, that is done later when reaching the ParameterMassager.
+    try:
+        input_parameters = AttributeDict(inputs.parameters.get_dict())
+    except AttributeError:
+        # Inputs might not have parameters
+        input_parameters = AttributeDict()
 
+    # Now the namespace and content of the workchain inputs and the inputs.parameters are merged.
+    # Any supplied namespace in the parameters (i.e. inputs.parameters.somekey) will override what
+    # is supplied to the workchain input namespace (i.e. inputs.somekey).
     # We cannot use regular update here, as we only want to replace each key if it exists, if a key
-    # contains a new dict we need to traverse that, hence we have a function to perform this update
+    # contains a new dict we need to traverse that, hence we have a function to perform this update.
     update_nested_dict(parameters, input_parameters)
 
     return parameters
-
-
-def vasp_parameter_nesting(inputs, namespaces):
-    """
-    Helper function to make sure that the namespaces are properly handled when they are nested.
-
-    In the case of no 'code' tag or entries belonging to the 'code' tag being provided.
-    This ensures that the 'code' tag is always created.
-    """
-    try:
-        # inputs might not have parameters, or parameters might be empty
-        if 'code' in inputs.parameters.get_dict():
-            input_parameters = AttributeDict(inputs.parameters.get_dict())
-        else:
-            _parameters = AttributeDict()
-            _parameters.code = AttributeDict()
-            for key, item in inputs.parameters.get_dict().items():
-                if key in namespaces:
-                    _parameters[key] = item
-                else:
-                    _parameters.code[key] = item
-            input_parameters = _parameters
-    except AttributeError:
-        input_parameters = {}
-
-    return input_parameters

--- a/aiida_vasp/assistant/tests/test_parameters.py
+++ b/aiida_vasp/assistant/tests/test_parameters.py
@@ -1,11 +1,12 @@
 """Test aiida_parameters."""
 # pylint: disable=unused-import,redefined-outer-name,unused-argument,unused-wildcard-import,wildcard-import,no-member, import-outside-toplevel
-
+import re
 import pytest
 
 from aiida.common.extendeddicts import AttributeDict
 
 from aiida_vasp.assistant.parameters import ParametersMassage
+from aiida_vasp.assistant.parameters import _DEFAULT_OVERRIDE_NAMESPACE
 
 
 @pytest.fixture
@@ -14,7 +15,6 @@ def init_relax_parameters():
     general_parameters = AttributeDict()
     general_parameters.relax = AttributeDict()
     general_parameters.relax.algo = 'cg'
-    general_parameters.relax.energy_cutoff = 0.01
     general_parameters.relax.force_cutoff = 0.01
     general_parameters.relax.steps = 60
     general_parameters.relax.positions = True
@@ -55,69 +55,86 @@ def init_bands_parameters():
     return general_parameters
 
 
-@pytest.fixture
-def init_simple_workchain():
-    """Fixture to simulate a fake workchain to store the exit codes and a dummy report function."""
-    workchain = AttributeDict()
-    workchain.exit_codes = AttributeDict()
-    workchain.exit_codes.ERROR_INVALID_PARAMETER_DETECTED = 1
-    workchain.exit_codes.ERROR_MISSING_PARAMETER_DETECTED = 1
-    workchain.report = print
-
-    return workchain
+def test_override_namespace():
+    """Test that the default override namespace is incar."""
+    assert _DEFAULT_OVERRIDE_NAMESPACE == 'incar'
 
 
 def test_relax_parameters_all_set(init_relax_parameters):
     """Test all standard relaxation parameters are set."""
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.ediffg == -0.01
     assert parameters.ibrion == 2
     assert parameters.nsw == 60
     assert parameters.isif == 3
 
 
-def test_catch_invalid_tags(init_relax_parameters, init_simple_workchain):
-    init_relax_parameters.code = AttributeDict()
-    mock_workchain = init_simple_workchain
-    init_relax_parameters.code.smear = 1  # This is an invalid tag
-    massager = ParametersMassage(mock_workchain, init_relax_parameters)
-    assert massager.exit_code is not None
+def test_additional_override_namespaces(init_relax_parameters):  # pylint: disable=invalid-name
+    """Test that we can supply additional override namespaces and that they are unmodified in the massager."""
+    init_relax_parameters.myspace = AttributeDict({'myspaceparameter': 1})
+    init_relax_parameters.yourspace = AttributeDict({'yourspaceparameter': 1})
+    massager = ParametersMassage(init_relax_parameters,
+                                 settings=AttributeDict({'additional_override_namespaces': ['myspace', 'yourspace']}))
+    assert massager.parameters.myspace.myspaceparameter == 1
+    assert massager.parameters.yourspace.yourspaceparameter == 1
 
 
-def test_relax_parameters_energy(init_relax_parameters):
-    """Test no provided force cutoff. It should be set to a default value."""
+def test_catch_invalid_tags(init_relax_parameters):
+    """Test to see if the massager accepts an invalid tag."""
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE].smear = 1  # This is an invalid tag
+    matching_string = re.compile(r'^The supplied key: smear is not a support VASP parameter.$')
+    with pytest.raises(ValueError, match=matching_string):
+        _ = ParametersMassage(init_relax_parameters)
+
+
+def test_relax_multiple_cutoffs(init_relax_parameters):
+    """Test if the massager raise exception if both energy and force cutoff is supplied."""
+    init_relax_parameters.relax.energy_cutoff = 0.01
+    matching_string = re.compile(r'^User supplied both a force and an energy cutoff for the relaxation. Please select.$')
+    with pytest.raises(ValueError, match=matching_string):
+        _ = ParametersMassage(init_relax_parameters)
+
+
+def test_allowed_namespaces(init_relax_parameters):
+    """Test if the massager raise exception if an unsupported namespace is supplied."""
+    init_relax_parameters.not_allowed_namespace = 0.1
+    matching_string = re.compile(r'^The supplied namespace: not_allowed_namespace is not supported.$')
+    with pytest.raises(ValueError, match=matching_string):
+        _ = ParametersMassage(init_relax_parameters)
+
+
+def test_relax_parameters_cutoff(init_relax_parameters):
+    """Test no provided cutoff yields no set ediffg."""
     del init_relax_parameters.relax.force_cutoff
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
-    assert parameters.ediffg == 0.01
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
+    with pytest.raises(AttributeError):
+        _ = parameters.ediffg
 
 
-def test_relax_parameters_no_algo(init_relax_parameters, init_simple_workchain):
+def test_relax_parameters_no_algo(init_relax_parameters):
     """Test no provided algo tag."""
-    mock_workchain = init_simple_workchain
     del init_relax_parameters.relax.algo
-    massager = ParametersMassage(mock_workchain, init_relax_parameters)
-    assert massager.exit_code is not None
+    massager = ParametersMassage(init_relax_parameters)
+    with pytest.raises(AttributeError):
+        _ = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].ibrion
 
 
 def test_relax_parameters_vol_shape(init_relax_parameters):
     """Test volume and shape relaxation combinations."""
     del init_relax_parameters.relax.positions
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == 6
 
 
 def test_relax_parameters_pos_shape(init_relax_parameters):
     """Test position and shape relxation combinations."""
     del init_relax_parameters.relax.volume
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == 4
 
 
@@ -125,9 +142,8 @@ def test_relax_parameters_vol(init_relax_parameters):
     """Test only volume relaxation."""
     del init_relax_parameters.relax.positions
     del init_relax_parameters.relax.shape
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == 7
 
 
@@ -135,9 +151,8 @@ def test_relax_parameters_pos(init_relax_parameters):
     """Test only position relaxation."""
     del init_relax_parameters.relax.volume
     del init_relax_parameters.relax.shape
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == 2
 
 
@@ -145,9 +160,8 @@ def test_relax_parameters_shape(init_relax_parameters):
     """Test only shape relaxation."""
     del init_relax_parameters.relax.volume
     del init_relax_parameters.relax.positions
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == 5
 
 
@@ -156,19 +170,20 @@ def test_relax_parameters_nothing(init_relax_parameters):
     del init_relax_parameters.relax.volume
     del init_relax_parameters.relax.positions
     del init_relax_parameters.relax.shape
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters == AttributeDict()
 
 
-def test_relax_parameters_override(init_relax_parameters):
+def test_parameters_override(init_relax_parameters):
     """Test what happens if we override a parameters."""
-    value = 1
-    init_relax_parameters.isif = value
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    parameters = massager.parameters.code
+    value = 1  # should from init_relax_parameters be 3, verified in test_relax_parameters_all_set
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    # Add this override to the incar namespace which is considered the override namespace before reaching
+    # ParameterMassager
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE].isif = value
+    massager = ParametersMassage(init_relax_parameters)
+    parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
     assert parameters.isif == value
 
 
@@ -177,24 +192,20 @@ def test_smearing_parameters():
     parameters = AttributeDict()
     parameters.smearing = AttributeDict()
     parameters.smearing.gaussian = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.ismear == 0
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].ismear == 0
     parameters.smearing.gaussian = False
     parameters.smearing.fermi = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.ismear == -1
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].ismear == -1
     parameters.smearing.fermi = False
     parameters.smearing.tetra = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.ismear == -5
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].ismear == -5
     parameters.smearing.tetra = False
     parameters.smearing.mp = 4
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.ismear == 4
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].ismear == 4
 
 
 def test_charge_parameters():
@@ -202,33 +213,27 @@ def test_charge_parameters():
     parameters = AttributeDict()
     parameters.charge = AttributeDict()
     parameters.charge.from_wave = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
+    massager = ParametersMassage(parameters)
     parameters.charge.from_wave = False
     parameters.charge.from_charge = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.icharg == 1
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].icharg == 1
     parameters.charge.from_charge = False
     parameters.charge.from_atomic = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.icharg == 2
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].icharg == 2
     parameters.charge.from_atomic = False
     parameters.charge.from_potential = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.icharg == 4
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].icharg == 4
     parameters.charge.from_potential = False
     parameters.charge.constant_charge = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.icharg == 11
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].icharg == 11
     parameters.charge.constant_charge = False
     parameters.charge.constant_atomic = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.icharg == 12
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].icharg == 12
 
 
 def test_orbital_projections():  # pylint: disable=too-many-statements
@@ -236,67 +241,56 @@ def test_orbital_projections():  # pylint: disable=too-many-statements
     parameters = AttributeDict()
     parameters.bands = AttributeDict()
     parameters.bands.decompose_wave = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 5
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 5
     parameters.bands.decompose_wave = False
     parameters.bands.decompose_bands = True
     parameters.bands.decompose_auto = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 14
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 14
     parameters.bands.decompose_auto = False
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 10
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 10
     parameters.bands.lm = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 11
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 11
     parameters.bands.phase = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 12
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 12
     parameters.bands.lm = False
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 12
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 12
 
     # Now do the once with a Wigner-Seitz radius supplied
     parameters.bands.wigner_seitz_radius = [2.0]
     parameters.bands.lm = False
     parameters.bands.phase = False
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 0
-    assert int(massager.parameters.code.rwigs[0]) == 2
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 0
+    assert int(massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].rwigs[0]) == 2
     parameters.bands.lm = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 1
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 1
     parameters.bands.phase = True
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 2
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 2
     parameters.bands.lm = False
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.lorbit == 2
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].lorbit == 2
 
     # Should raise ValueError if Wigner-Seitz radius is not defined as a list.
     parameters.bands.wigner_seitz_radius = 2.0
     with pytest.raises(ValueError):
-        massager = ParametersMassage(None, parameters)
+        massager = ParametersMassage(parameters)
 
 
 def test_vasp_parameter_override(init_relax_parameters):
     """Test of the override functionality works as intended."""
-    init_relax_parameters.code = AttributeDict()
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
     # Redefine to from 3 to 0.
-    init_relax_parameters.code.isif = 0
-    massager = ParametersMassage(None, init_relax_parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.isif == 0
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE].isif = 0
+    massager = ParametersMassage(init_relax_parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].isif == 0
 
 
 def test_inherit_and_merge():
@@ -325,7 +319,6 @@ def test_inherit_and_merge():
     inputs.parameters = DataFactory('dict')(dict={})
     parameters = inherit_and_merge_parameters(inputs)
     test_parameters = AttributeDict({
-        'code': AttributeDict(),
         'electronic': AttributeDict({'somekey': True}),
         'bands': AttributeDict({'somekey': True}),
         'smearing': AttributeDict({'somekey': True}),
@@ -350,42 +343,33 @@ def test_inherit_and_merge():
 def test_unsupported_fail_override():
     """Test that any supplied unsupported parameters in the regular parameters dictionary yield error."""
     parameters = AttributeDict()
-    parameters.code = AttributeDict()
-    parameters.code.not_valid = 200
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid = 200
+    matching_string = re.compile(r'^The supplied key: not_valid is not a support VASP parameter.$')
+    with pytest.raises(ValueError, match=matching_string):
+        _ = ParametersMassage(parameters)
 
 
-def test_unsupported_fail():
-    """Test that any supplied unsupported parameters in the regular overload parameters dictionary does not yield an error."""
+def test_unsupported_parameters_in_unsupported_namespace():  # pylint: disable=invalid-name
+    """Test that it is possibly to supply unsupported parameters in the incar namespace if the configuration is also
+    supplied."""
     parameters = AttributeDict()
-    parameters.not_valid = 200
-    massager = ParametersMassage(None, parameters)
-    # The not valid parameter was never set as there is no setter function for it.
-    assert massager.parameters.code == {}
-
-
-def test_unsupported_parameters():
-    """Test that it is possibly to supply unsupported parameters."""
-    parameters = AttributeDict()
-    parameters.not_valid = 200
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid = 200
     massager = ParametersMassage(
-        None,
-        parameters,
-        unsupported_parameters={'not_valid': {
+        parameters, unsupported_parameters={'not_valid': {
             'default': 1.0,
             'description': 'Something',
             'type': float,
             'values': [1.0, 2.0]
         }})
-    assert massager.exit_code is None
-    assert massager.parameters.code.not_valid == parameters.not_valid
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid == 200
 
 
 def test_pwcutoff_to_encut():
     """Test that the pwcutoff is converted to encut."""
     parameters = AttributeDict()
-    parameters.pwcutoff = 200
-    massager = ParametersMassage(None, parameters)
-    assert massager.exit_code is None
-    assert massager.parameters.code.encut == parameters.pwcutoff
+    parameters.electronic = AttributeDict()
+    parameters.electronic.pwcutoff = 200
+    massager = ParametersMassage(parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].encut == parameters.electronic.pwcutoff

--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -56,7 +56,7 @@ class VaspImmigrant(VaspCalculation):
 
 def get_incar_input(dir_path):
     incar = IncarParser(file_path=str(dir_path / 'INCAR')).incar
-    return get_data_node('dict', dict={'code': incar})
+    return get_data_node('dict', dict=incar)
 
 
 def get_poscar_input(dir_path):

--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -23,7 +23,7 @@ def test_write_incar(vasp_calc_and_ref):
     with managed_temp_file() as temp_file:
         vasp_calc.write_incar(temp_file)
         with open(temp_file, 'r') as result_incar_fo:
-            assert result_incar_fo.readlines() == reference['code']
+            assert result_incar_fo.readlines() == reference['incar']
 
 
 @ONLY_ONE_CALC
@@ -52,15 +52,7 @@ def test_write_chgcar(localhost_dir, vasp_calc, vasp_inputs, vasp_chgcar):
     from aiida.common.folders import Folder
     chgcar, _ = vasp_chgcar
 
-    inputs = vasp_inputs(
-        parameters={'code': {
-            'gga': 'PE',
-            'gga_compat': False,
-            'lorbit': 11,
-            'sigma': 0.5,
-            'magmom': '30 * 2*0.',
-            'icharg': 1
-        }})
+    inputs = vasp_inputs(parameters={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'icharg': 1})
 
     inputs.charge_density = chgcar
     calc = vasp_calc(inputs=inputs)
@@ -75,15 +67,7 @@ def test_write_wavecar(localhost_dir, vasp_calc, vasp_inputs, vasp_wavecar):
     """Test that WAVECAR file is written correctly."""
     from aiida.common.folders import Folder
     wavecar, _ = vasp_wavecar
-    inputs = vasp_inputs(
-        parameters={'code': {
-            'gga': 'PE',
-            'gga_compat': False,
-            'lorbit': 11,
-            'sigma': 0.5,
-            'magmom': '30 * 2*0.',
-            'istart': 1
-        }})
+    inputs = vasp_inputs(parameters={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'istart': 1})
     inputs.wavefunctions = wavecar
     calc = vasp_calc(inputs=inputs)
     temp_folder = Folder(str(localhost_dir.parent))
@@ -98,10 +82,8 @@ def test_incar_validate(vasp_calc, vasp_inputs, localhost_dir):
     from aiida.common import InputValidationError
     from aiida.common.folders import Folder
     inputs_dict = {
-        'code': {
-            'gga': 'PE',
-            'smear': 3  # <- Invalid tag
-        }
+        'gga': 'PE',
+        'smear': 3  # <- Invalid tag
     }
     inputs = vasp_inputs(parameters=inputs_dict)
     calc = vasp_calc(inputs=inputs)
@@ -119,7 +101,7 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
     wavecar, _ = vasp_wavecar
     chgcar, _ = vasp_chgcar
 
-    inputs_dict = {'code': {'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'icharg': 11}}
+    inputs_dict = {'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.', 'icharg': 11}
 
     inputs = vasp_inputs(parameters=inputs_dict)
     inputs.charge_density = chgcar

--- a/aiida_vasp/calcs/tests/test_vasp2w90.py
+++ b/aiida_vasp/calcs/tests/test_vasp2w90.py
@@ -45,7 +45,7 @@ def test_prepare_for_submission(vasp2w90_calc_and_ref, tmp_path):
     with managed_temp_file() as temp_file:
         vasp_calc.write_incar(temp_file)
         with open(temp_file, 'r') as result_incar_fo:
-            assert result_incar_fo.readlines() == reference['code']
+            assert result_incar_fo.readlines() == reference['incar']
 
 
 @ONLY_ONE_CALC

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -79,6 +79,10 @@ class VaspCalculation(VaspCalcBase):
         # Define the inputs.
         # options is passed automatically.
         spec.input('parameters', valid_type=get_data_class('dict'), help='The VASP input parameters (INCAR).')
+        spec.input('dynamics',
+                   valid_type=get_data_class('dict'),
+                   help='The VASP parameters related to ionic dynamics, e.g. flags to set the selective dynamics',
+                   required=False)
         spec.input('structure', valid_type=(get_data_class('structure'), get_data_class('cif')), help='The input structure (POSCAR).')
         # Need namespace on this as it should also accept keys that are of `kind`. These are unknown
         # until execution.
@@ -222,7 +226,7 @@ class VaspCalculation(VaspCalcBase):
         (py:method::NscfCalculation.use_parameters)
         """
         ichrg_d = 0 if self._need_wavecar() else 2
-        icharg = self._parameters['code'].get('icharg', ichrg_d)
+        icharg = self._parameters.get('icharg', ichrg_d)
         return bool(icharg in [1, 11])
 
     def _need_wavecar(self):
@@ -237,7 +241,7 @@ class VaspCalculation(VaspCalcBase):
         (py:method::NscfCalculation.use_parameters)
         """
         istrt_d = 1 if self.inputs.get('wavefunctions') else 0
-        istart = self._parameters['code'].get('istart', istrt_d)
+        istart = self._parameters.get('istart', istrt_d)
         return bool(istart in [1, 2, 3])
 
     def _structure(self):
@@ -284,8 +288,7 @@ class VaspCalculation(VaspCalcBase):
 
         :param dst: absolute path of the file to write to
         """
-        dict_data = DataFactory('dict')
-        incar_parser = IncarParser(data=dict_data(dict=self.inputs.parameters.dict.code))
+        incar_parser = IncarParser(data=self.inputs.parameters)
         incar_parser.write(dst)
 
     def write_poscar(self, dst):  # pylint: disable=unused-argument
@@ -300,8 +303,11 @@ class VaspCalculation(VaspCalcBase):
         settings = self.inputs.get('settings')
         settings = settings.get_dict() if settings else {}
         poscar_precision = settings.get('poscar_precision', 10)
-        options = self.inputs.parameters.get_dict().get('dynamics', None)
-        print(options)
+        positions_dof = self.inputs.get('dynamics', {}).get('positions_dof')
+        if positions_dof is not None:
+            options = {'positions_dof': positions_dof}
+        else:
+            options = None
         poscar_parser = PoscarParser(data=self._structure(), precision=poscar_precision, options=options)
         poscar_parser.write(dst)
 

--- a/aiida_vasp/calcs/vasp2w90.py
+++ b/aiida_vasp/calcs/vasp2w90.py
@@ -38,7 +38,7 @@ class Vasp2w90Calculation(VaspCalculation):
         # that the Wannier90 files are created. Execution of Wannier90 itself is to be done after the execution
         # of this calculation with the aiida-wannier90 plugins calculation.
         parameters = self.inputs.parameters.get_dict()
-        parameters['code'].update({'lwannier90': True})
+        parameters.update({'lwannier90': True})
         self.inputs.parameters = DataFactory('dict')(dict=parameters)
         # Check if any Wannier90 parameters are given
         try:

--- a/aiida_vasp/utils/fixtures/calcs.py
+++ b/aiida_vasp/utils/fixtures/calcs.py
@@ -116,7 +116,7 @@ def vasp_calc_and_ref(vasp_calc, vasp_kpoints, ref_incar):
     calc = vasp_calc(settings={'parser_settings': {'add_bands': True, 'add_dos': True}})
     _, ref_kpoints = vasp_kpoints
 
-    return calc, {'kpoints': ref_kpoints, 'code': ref_incar}
+    return calc, {'kpoints': ref_kpoints, 'incar': ref_incar}
 
 
 @pytest.fixture
@@ -128,7 +128,7 @@ def vasp2w90_calc_and_ref(vasp2w90_calc, vasp_kpoints, vasp2w90_inputs, ref_inca
     calc = vasp2w90_calc(inputs=inputs)
     _, ref_kpoints = vasp_kpoints
 
-    return calc, {'kpoints': ref_kpoints, 'code': ref_incar_vasp2w90, 'win': ref_win}
+    return calc, {'kpoints': ref_kpoints, 'incar': ref_incar_vasp2w90, 'win': ref_win}
 
 
 @pytest.fixture()
@@ -157,7 +157,7 @@ def run_vasp_calc(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_s
         create_authinfo(computer=mock_vasp.computer, store=True)
         kpoints, _ = vasp_kpoints
         parameters = AttributeDict()
-        parameters.code = vasp_params.get_dict()
+        parameters = vasp_params.get_dict()
         inpts = AttributeDict()
         inpts.code = Code.get_from_string('mock-vasp@localhost')
         inpts.structure = vasp_structure

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -209,8 +209,7 @@ def vasp_inputs(fresh_aiida_env, vasp_params, vasp_kpoints, vasp_structure, pote
             parameters = get_data_class('dict')(dict=parameters)
 
         if parameters is None:
-            parameters = AttributeDict()
-            parameters.code = vasp_params.get_dict()
+            parameters = AttributeDict(vasp_params.get_dict())
             parameters = get_data_class('dict')(dict=parameters)
         inputs.code = vasp_code
         inputs.metadata = metadata
@@ -251,8 +250,7 @@ def vasp2w90_inputs(
             parameters = get_data_class('dict')(dict=parameters)
 
         if parameters is None:
-            parameters = AttributeDict()
-            parameters.code = vasp_params.get_dict()
+            parameters = AttributeDict(vasp_params.get_dict())
             parameters = get_data_class('dict')(dict=parameters)
 
         inputs.code = vasp_code

--- a/aiida_vasp/workchains/converge.py
+++ b/aiida_vasp/workchains/converge.py
@@ -663,7 +663,7 @@ class ConvergeWorkChain(WorkChain):
                 else:
                     location = 'test-case:test_converge_wc/both/' + str(int(settings.pwcutoff)) + '_' + str(settings.kgrid[0]) + '_' + str(
                         settings.kgrid[1]) + '_' + str(settings.kgrid[2])
-            param_dict['code'] = {'system': location}
+            param_dict['incar'] = {'system': location}
             self.ctx.converge.parameters = param_dict
 
         # Set input nodes
@@ -723,7 +723,7 @@ class ConvergeWorkChain(WorkChain):
         pwcutoff = self.ctx.converge.pwcutoff_sampling[self.ctx.converge.pw_iteration]
         self.ctx.converge.settings.pwcutoff = pwcutoff
         parameters_dict = self.ctx.converge.parameters
-        parameters_dict.update({'pwcutoff': self.ctx.converge.settings.pwcutoff})
+        parameters_dict['electronic'] = {'pwcutoff': self.ctx.converge.settings.pwcutoff}
         self.ctx.running_pw = True
         self.ctx.running_kpoints = False
         inform_details = self.ctx.converge.settings.get('inform_details')

--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -10,6 +10,7 @@ parameters instead of the code dependent variables.
 import numpy as np
 
 from aiida.common.extendeddicts import AttributeDict
+from aiida.common.exceptions import NotExistent
 from aiida.engine import WorkChain, append_, while_, if_
 from aiida.plugins import WorkflowFactory
 
@@ -313,9 +314,12 @@ class RelaxWorkChain(WorkChain):
             self.ctx.exit_code = compose_exit_code(next_workchain_exit_status, next_workchain_exit_message)
             self.report('The called {}<{}> returned a non-zero exit status. '
                         'The exit status {} is inherited'.format(workchain.__class__.__name__, workchain.pk, self.ctx.exit_code))
-            # Make sure at the very minimum we attach the misc node that contains notifications and other
+            # Make sure at the very minimum we attach the misc node (if it exists) that contains notifications and other
             # quantities that can be salvaged
-            self.out('misc', workchain.outputs['misc'])
+            try:
+                self.out('misc', workchain.outputs['misc'])
+            except NotExistent:
+                pass
 
         return self.ctx.exit_code
 

--- a/aiida_vasp/workchains/tests/test_bands_wc.py
+++ b/aiida_vasp/workchains/tests/test_bands_wc.py
@@ -38,7 +38,7 @@ def test_bands_wc(fresh_aiida_env, potentials, mock_vasp):
     parameters['system'] = 'test-case:test_bands_wc'
     # Make sure we replace encut with pwcutoff
     del parameters['encut']
-    parameters = {'code': parameters}
+    parameters = {'incar': parameters}
     parameters['electronic'] = {'pwcutoff': 200}
 
     inputs = AttributeDict()

--- a/aiida_vasp/workchains/tests/test_converge_wc.py
+++ b/aiida_vasp/workchains/tests/test_converge_wc.py
@@ -35,7 +35,7 @@ def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
     structure = PoscarParser(file_path=data_path('test_converge_wc', 'inp', 'POSCAR')).structure
     parameters = IncarParser(file_path=data_path('test_converge_wc', 'inp', 'INCAR')).incar
     parameters['system'] = 'test-case:test_converge_wc'
-    parameters = {'code': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}}
+    parameters = {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}
 
     restart_clean_workdir = get_data_node('bool', False)
     restart_clean_workdir.store()
@@ -43,7 +43,7 @@ def test_converge_wc(fresh_aiida_env, potentials, mock_vasp):
     inputs = AttributeDict()
     inputs.code = Code.get_from_string('mock-vasp@localhost')
     inputs.structure = structure
-    inputs.parameters = get_data_node('dict', dict=parameters)
+    inputs.parameters = get_data_node('dict', dict={'incar': parameters})
     inputs.potential_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potential_mapping = get_data_node('dict', dict=POTCAR_MAP)
     inputs.options = get_data_node('dict',
@@ -99,7 +99,7 @@ def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     structure = PoscarParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'POSCAR')).structure
     parameters = IncarParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'INCAR')).incar
     parameters['system'] = 'test-case:test_converge_wc'
-    parameters = {'code': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}}
+    parameters = {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'encut', 'nsw']}
     kpoints = KpointsParser(file_path=data_path('test_converge_wc/pw/200', 'inp', 'KPOINTS')).kpoints
 
     restart_clean_workdir = get_data_node('bool', False)
@@ -109,7 +109,7 @@ def test_converge_wc_pw(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     inputs.code = Code.get_from_string('mock-vasp@localhost')
     inputs.structure = structure
     inputs.kpoints = kpoints
-    inputs.parameters = get_data_node('dict', dict=parameters)
+    inputs.parameters = get_data_node('dict', dict={'incar': parameters})
     inputs.potential_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potential_mapping = get_data_node('dict', dict=POTCAR_MAP)
     inputs.options = get_data_node('dict',

--- a/aiida_vasp/workchains/tests/test_relax_wc.py
+++ b/aiida_vasp/workchains/tests/test_relax_wc.py
@@ -35,7 +35,7 @@ def test_relax_wc(fresh_aiida_env, vasp_params, potentials, mock_vasp):
     kpoints = KpointsParser(file_path=data_path('test_relax_wc', 'inp', 'KPOINTS')).kpoints
     parameters = IncarParser(file_path=data_path('test_relax_wc', 'inp', 'INCAR')).incar
     parameters['system'] = 'test-case:test_relax_wc'
-    parameters = {'code': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'nsw', 'ediffg']}}
+    parameters = {'incar': {k: v for k, v in parameters.items() if k not in ['isif', 'ibrion', 'nsw', 'ediffg']}}
     parameters['relax'] = {}
     parameters['relax']['perform'] = True
     parameters['relax']['algo'] = 'cg'

--- a/aiida_vasp/workchains/tests/test_vasp_wc.py
+++ b/aiida_vasp/workchains/tests/test_vasp_wc.py
@@ -31,7 +31,7 @@ def test_vasp_wc(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_st
     inputs = AttributeDict()
     inputs.code = Code.get_from_string('mock-vasp@localhost')
     inputs.structure = vasp_structure
-    inputs.parameters = vasp_params
+    inputs.parameters = get_data_node('dict', dict={'incar': vasp_params.get_dict()})
     inputs.kpoints = kpoints
     inputs.potential_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potential_mapping = get_data_node('dict', dict=POTCAR_MAP)
@@ -75,7 +75,7 @@ def test_vasp_wc_chgcar(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, 
     inputs = AttributeDict()
     inputs.code = Code.get_from_string('mock-vasp@localhost')
     inputs.structure = vasp_structure
-    inputs.parameters = vasp_params
+    inputs.parameters = get_data_node('dict', dict={'incar': vasp_params.get_dict()})
     inputs.kpoints = kpoints
     inputs.potential_family = get_data_node('str', POTCAR_FAMILY_NAME)
     inputs.potential_mapping = get_data_node('dict', dict=POTCAR_MAP)

--- a/aiida_vasp/workchains/verify.py
+++ b/aiida_vasp/workchains/verify.py
@@ -9,8 +9,10 @@ or not currently checked in it. This workchain does currently nothing.
 
 # pylint: disable=attribute-defined-outside-init
 from aiida.common.extendeddicts import AttributeDict
+from aiida.common.exceptions import NotExistent
 from aiida.engine import WorkChain, while_, append_
 from aiida.plugins import WorkflowFactory
+
 from aiida_vasp.utils.aiida_utils import get_data_class, get_data_node
 from aiida_vasp.utils.workchains import prepare_process_inputs, compose_exit_code
 
@@ -129,9 +131,12 @@ class VerifyWorkChain(WorkChain):
             self.ctx.exit_code = compose_exit_code(next_workchain_exit_status, next_workchain_exit_message)
             self.report('The called {}<{}> returned a non-zero exit status. '
                         'The exit status {} is inherited'.format(workchain.__class__.__name__, workchain.pk, self.ctx.exit_code))
-            # Make sure at the very minimum we attach the misc node that contains notifications and other
+            # Make sure at the very minimum we attach the misc node (if it exists) that contains notifications and other
             # quantities that can be salvaged
-            self.out('misc', workchain.outputs['misc'])
+            try:
+                self.out('misc', workchain.outputs['misc'])
+            except NotExistent:
+                pass
 
         return self.ctx.exit_code
 

--- a/examples/run_bands.py
+++ b/examples/run_bands.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'code': {'prec': 'NORMAL', 'pwcutoff': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
+    INCAR = {'incar': {'prec': 'NORMAL', 'pwcutoff': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_converge.py
+++ b/examples/run_converge.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     # INCAR equivalent
     # Set input parameters (make sure we do not set ENCUT in order to run convergence tests
     # on the plane wave cutoff)
-    INCAR = {'code': {'prec': 'NORMAL', 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
+    INCAR = {'incar': {'prec': 'NORMAL', 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_relax.py
+++ b/examples/run_relax.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'code': {'encut': 240, 'ismear': 0, 'sigma': 0.1, 'system': 'test system'}}
+    INCAR = {'incar': {'encut': 240, 'ismear': 0, 'sigma': 0.1, 'system': 'test system'}}
 
     # KPOINTS equivalent
     # Set kpoint mesh

--- a/examples/run_vasp_lean.py
+++ b/examples/run_vasp_lean.py
@@ -84,7 +84,7 @@ def main(code_string, incar, kmesh, structure, potential_family, potential_mappi
 
 if __name__ == '__main__':
     # Code_string is chosen among the list given by 'verdi code list'
-    CODE_STRING = 'vasp5@localhost'
+    CODE_STRING = 'vasp@mycluster'
 
     # POSCAR equivalent
     # Set the silicon structure
@@ -92,7 +92,7 @@ if __name__ == '__main__':
 
     # INCAR equivalent
     # Set input parameters
-    INCAR = {'code': {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
+    INCAR = {'incar': {'prec': 'NORMAL', 'encut': 200, 'ediff': 1E-4, 'ialgo': 38, 'ismear': -5, 'sigma': 0.1}}
 
     # KPOINTS equivalent
     # Set kpoint mesh


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
When allowing selective dynamics flags in PR #408 some bugs were introduced which caused e.g. the flags to be not put correctly in the code namespace. This is fixed and in addition we introduce the following specification: the namespaces allowed on the input parameters are restricted. This means that if the user want sto override a parameter (send it straight to VASP) it needs to be put in the code namespace. If any parameter is detected on the input parameter root and it is not in the allowed namespace, an exception will be raised. While updating we also disconnected the massager from the workchain, which was previously supplied to get access to the exit codes. Now, we instead raise exceptions with a sensible text and then catch this in the VASP workchain and customize an exit code there that incorporates the exception message.