### PR TITLE
Added documentation on how to use parameters

### DIFF
--- a/doc/source/calculations/vasp.rst
+++ b/doc/source/calculations/vasp.rst
@@ -8,6 +8,7 @@ Inputs
 ------
 
 * :ref:`parameters <vasp-input-parameters>`
+* :ref:`dynamics <vasp-input-dynamics>`
 * :ref:`structure <vasp-input-structure>`
 * :ref:`potential <vasp-input-potential>`
 * :ref:`kpoints <vasp-input-kpoints>`
@@ -30,7 +31,19 @@ The input parameters (the content of the INCAR file). This is of the `AiiDA`_ da
 
 Key names are case-insensitive, which should be considered when querying the database. Values can be given in their python representation or as strings (strings also may include unit specifications).
 
-.. _vasp-input-kpoints:
+.. _vasp-input-dynamics:
+
+dynamics
+^^^^^^^^
+A dictionary containing information about how the calculation should obey the dynamics of the system. Currently only one flag is respected, that is the ``positions_dof`` which contains a list, one entry per position which contains another list, e.g. ``[True, True, False]`` that describes the flags to set in ``POSCAR`` after each position in order to control the selective dynamics. Example::
+
+  dynamics = Dict(dict={'positions_dof':
+    [[True, True, True],
+     [False, True, False]
+    ]}
+  )
+
+.. _vasp-input-kpoint:
 
 kpoints
 ^^^^^^^
@@ -98,15 +111,15 @@ The structure of the atomic layout. This is of the `AiiDA`_ data type :py:class:
 
 .. _vasp-input-potential:
 
-potcar
-^^^^^^
-The potential to use for each element (the POTCAR files). This is of the AiiDA-VASP data type :py:class:`PotcarData<aiida_vasp.data.potcar.PotcarData>`. How to upload `VASP`_ POTCAR files can be found at :ref:`potentials`. Once uploaded they can be obtained as follows::
+potential
+^^^^^^^^^
+A namespace containing the potentials to use for each element (the POTCAR files). This is of the AiiDA-VASP data type :py:class:`PotcarData<aiida_vasp.data.potcar.PotcarData>`. How to upload `VASP`_ POTCAR files can be found at :ref:`potentials`. Once uploaded they can be obtained as follows::
 
-   # input_structure is InAs
+   # input_structure is for instance InAs
    potcar_mapping = {'In': 'In_d', 'As': 'As'}
    potcars = PotcarData.get_potcars_from_structure(structure=input_structure, family_name='PBE.54', mapping=potcar_mapping)
 
-One POTCAR input node must be given to the calculations for each element in the system.
+One POTCAR node must be given to the calculations for each element in the system.
 The calculations take responsibility for ordering the elements consistently between POSCAR and POTCAR.
 
 .. _vasp-input-charge:

--- a/doc/source/concepts/parameters.rst
+++ b/doc/source/concepts/parameters.rst
@@ -1,0 +1,46 @@
+.. _parameters:
+
+Parameters
+==========
+Before describing how parameter passing works in this plugin it is worthwhile to restate that the design principle is that all higher lying workchains ultimately call the ``VaspWorkChain`` (:ref:`vasp_workchain`) which should handle `VASP`_ specific translations and setups in order to execute your problem with `VASP`_. The higher lying workchains should in principle also be executable with e.g. Quantum Espresso or Abinit as long as one replaces the ``VaspWorkChain`` with a dedicated code specific translation and setup workchain for those codes. In order to facilitate this we designed what we call a ``ParameterMassager`` which translates certain parameters from AiiDA to `VASP`_ specific ones. This would also have to be written for the replacement code.
+
+We now describe how parameters can be passed in the plugin. We separate between passing parameters directly to the ``VaspCalculation`` (:ref:`vasp_calculation`), the ``VaspWorkChain`` (or any workchain ultimately calling ``VaspWorkChain``).
+
+When supplying parameters to ``VaspWorkChain``
+----------------------------------------------
+Also valid for any workchain (:ref:`workchains`) ultimately ending up calling ``VaspWorkChain`` and forwarding parameters to it. This is the recommended way of interacting and performing `VASP`_ calculations. Here, one can supply `VASP`_ input parameters (``INCAR`` tags) in ``inputs.parameters.incar``. Any key value combination put into this ``incar`` namespace bypasses the ``ParameterMassager`` (except the check if it is valid `VASP`_ tags). Remember that this is the only way to supply `VASP`_ parameters, or ``INCAR`` tags directly to `VASP`_ through the workchain stack. In the ``ParameterMassager`` other namespaces can also be supplied. For instance from higher lying workchains like the ``RelaxWorkChain``, the parameters pertaining to this workchain that would be relevant for `VASP`_ are passed to the ``VaspWorkChain`` in a namespace called ``relax`` and in there parameters like ``force_cutoff`` is supplied which controls the size of the force cutoff when performing relaxations. This parameter is translated to a suitable ``EDIFFG`` by the ``ParameterMassager``. To the workchains, e.g. the ``RelaxWorkChain`` it is also possible to supply these namespaces in the ``inputs.parameters``, e.g. ``inputs.parameters.relax.force_cutoff`` and this would override any parameter that has been supplied (or set as default ) in ``input.relax.force_cutoff`` (an input node of the ``RelaxWorkChain``). In a workchain, the ``inherit_and_merge_parameters`` is called, which before the next workchain is called merges the workchain input nodes (``inputs.somenamespace.something``) with the content of ``inputs.parameters.somenamespace.something`` and performs the correct prioritization as described below.
+
+When supplying parameters directly to the ``VaspCalculation``
+-------------------------------------------------------------
+The ``VaspCalculation`` expects the input of the `VASP`_ ``INCAR`` tags to be supplied using ``inputs.parameters``. E.g. the tags should be places accordingly, like ``inputs.parameters.icharg``, ``inputs.parameters.sigma`` etc. This is also what is provided from the ``parameters.incar`` output of the ``ParameterMassager``. In addition, the ``VaspCalculation`` accepts as a separate input node, the ``inputs.dynamics`` which can be supplied and contain e.g. the ``positions_dof`` flag which contains the selective dynamics flags used in ``POSCAR``.
+
+Supported namespaces
+--------------------
+The supported namespaces are set using concatenation of the content of ``_BASE_NAMESPACES`` variable (currently containing ``['electronic', 'smearing', 'charge', 'dynamics', 'bands', 'relax', 'converge']``), any additional override namespace added by supplying the ``inputs.settings.additional_override_namespaces`` variable, which should be a list of strings to the ``VaspWorkChain`` and finally the override namespace ``incar``. 
+
+How parameters are prioritized and set
+--------------------------------------
+Since there are basically three ways to supply parameters (for the most general ones ultimately ending up as tags in the ``INCAR``),
+the following prioritization is performed:
+
+1. Parameters supplied in the ovveride namespace ``inputs.parameters.incar`` are always respected as long as it is a valid `VASP`_ tag.
+2. Parameters supplied in ``inputs.parameters``, e.g. ``inputs.parameters.relax.force_cutoff`` (for the ``RelaxWorkChain``).
+3. Parameters supplied as workchain input nodes, e.g. ``inputs.relax.force_cutoff`` (for the ``RelaxWorkChain``).
+
+The parameter massager
+----------------------
+The ``ParameterMassager`` translates parameters in the plugin to `VASP`_ specific ones, ensures that the prioritization is respected.
+The input would be composed ``inputs.parameters`` containing elements from the workchain input nodes and the previously set ``inputs.parameters``, depending on the prioritization described above. The output would be a new ``parameters.incar`` which should only contain valid `VASP`_ flags, in addition to ``parameters.dynamics`` which should contain parameters to control the dynamics of the system (currently this only houses ``positions_dof`` to set the selective dynamics flags in ``POSCAR``. This is typically what is supplied to the ``VaspCalculation``.
+
+Allowing custom `VASP`_ tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In case you for instance perform developments in the `VASP`_ code, sometimes it makes sense to add a new `VASP`_ tag. This can be supplied in ``settings.inputs.unsupported_parameters`` as dict with the following specifications::
+
+  unsupported_parameters = {'my_unsupported_parameters': {
+  'default': 1.0,
+  'description': 'Some description',
+  'type': float,
+  'values': [1.0, 2.0]
+  }
+
+.. _VASP: https://www.vasp.at

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,7 @@ the Postgresql interactive terminal (``psql``) should be similar between the two
    :caption: Concepts
    :hidden:
 
+   concepts/parameters
    concepts/potentials
    concepts/calculations
    concepts/workchains

--- a/doc/source/workchains/vasp.rst
+++ b/doc/source/workchains/vasp.rst
@@ -14,7 +14,7 @@ Required inputs
 * ``kpoints``: an `AiiDA`_ :py:class:`aiida.orm.nodes.data.KpointsData` instance, describing the kpoints mesh or path.
 * ``potential_family``: an `AiiDA`_ :py:class:`aiida.orm.nodes.data.Str` instance, the name given to a set of uploaded POTCAR files.
 * ``potential_mapping``: an `AiiDA`_ :py:class:`aiida.orm.nodes.data.Dict` instance, containing an entry for at least every kind name in the ``structure`` input with the full name of the POTCAR from the ``potential_family``. Example: ``{'In1': 'In_d', 'In2': 'In_h'}``.
-* ``parameters``: an `AiiDA`_ :py:class:`aiida.orm.nodes.data.Dict` instance, containing key/value pairs that is later written to an INCAR file as ``KEY =VALUE``. Keys and values can be lower case and the standard built-in Python data types should be used for values.
+* ``parameters``: an `AiiDA`_ :py:class:`aiida.orm.nodes.data.Dict` instance. Please consult the documentation on how parameters are handled (:ref `parameters`) for details, particularly the section pertaining to the ``VaspWorkChain``.
 * ``options``, an `AiiDA`_ :py:class:`aiida.orm.nodes.data.Dict` instance, containing at least the keys ``resources``. More information about the options is available in the `AiiDA documentation`_.
 
 .. _AiiDA: https://www.aiida.net


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Here we add documentation on how the parameter passing works and how to control it. In addition we add documentation for the input node change on the VASP calculation.