### PR TITLE
Remove _init_with_somevalue (issue #434)

### DIFF
--- a/aiida_vasp/parsers/file_parsers/chgcar.py
+++ b/aiida_vasp/parsers/file_parsers/chgcar.py
@@ -23,7 +23,6 @@ class ChgcarParser(BaseFileParser):
     def __init__(self, *args, **kwargs):
         super(ChgcarParser, self).__init__(*args, **kwargs)
         self._chgcar = None
-        self.init_with_kwargs(**kwargs)
 
     def _parse_file(self, inputs):
         """Create a DB Node for the CHGCAR file."""

--- a/aiida_vasp/parsers/file_parsers/doscar.py
+++ b/aiida_vasp/parsers/file_parsers/doscar.py
@@ -42,7 +42,6 @@ class DosParser(BaseFileParser):
     def __init__(self, *args, **kwargs):
         super(DosParser, self).__init__(*args, **kwargs)
         self._dos = None
-        self.init_with_kwargs(**kwargs)
 
     def _parse_file(self, inputs):
         """Read a VASP DOSCAR file and extract metadata and a density of states data array."""

--- a/aiida_vasp/parsers/file_parsers/eigenval.py
+++ b/aiida_vasp/parsers/file_parsers/eigenval.py
@@ -30,7 +30,6 @@ class EigParser(BaseFileParser):
 
     def __init__(self, *args, **kwargs):
         super(EigParser, self).__init__(*args, **kwargs)
-        self.init_with_kwargs(**kwargs)
 
     @property
     def _parsed_object(self):

--- a/aiida_vasp/parsers/file_parsers/eigenval.py
+++ b/aiida_vasp/parsers/file_parsers/eigenval.py
@@ -28,9 +28,6 @@ class EigParser(BaseFileParser):
         },
     }
 
-    def __init__(self, *args, **kwargs):
-        super(EigParser, self).__init__(*args, **kwargs)
-
     @property
     def _parsed_object(self):
         return self._data_obj

--- a/aiida_vasp/parsers/file_parsers/incar.py
+++ b/aiida_vasp/parsers/file_parsers/incar.py
@@ -31,10 +31,17 @@ class IncarParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
-        super(IncarParser, self).__init__(*args, **kwargs)
-        self.init_with_kwargs(**kwargs)
+        """
+        Initialize INCAR parser
 
-    def _init_with_data(self, data):
+        data : Dict
+
+        """
+        super(IncarParser, self).__init__(*args, **kwargs)
+        if 'data' in kwargs:
+            self._init_incar(kwargs['data'])
+
+    def _init_incar(self, data):
         """Initialize with a given AiiDA Dict instance."""
         if isinstance(data, get_data_class('dict')):
             self._data_obj = data

--- a/aiida_vasp/parsers/file_parsers/kpoints.py
+++ b/aiida_vasp/parsers/file_parsers/kpoints.py
@@ -33,11 +33,18 @@ class KpointsParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize INCAR parser
+
+        data : KpointsArray
+
+        """
         super(KpointsParser, self).__init__(*args, **kwargs)
         self._kpoints = None
-        self.init_with_kwargs(**kwargs)
+        if 'data' in kwargs:
+            self._init_kpoints(kwargs['data'])
 
-    def _init_with_data(self, data):
+    def _init_kpoints(self, data):
         """Initialize with a given AiiDA KpointsData instance."""
         if isinstance(data, get_data_class('array.kpoints')):
             self._data_obj = data

--- a/aiida_vasp/parsers/file_parsers/outcar.py
+++ b/aiida_vasp/parsers/file_parsers/outcar.py
@@ -56,11 +56,26 @@ class OutcarParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize OUTCAR parser
+
+        file_path : str
+            File path.
+        data : SingleFileData
+            AiiDA Data class install to store a single file.
+        settings : ParserSettings
+
+        """
+
         super(OutcarParser, self).__init__(*args, **kwargs)
         self._outcar = None
-        self.init_with_kwargs(**kwargs)
+        self._settings = kwargs.get('settings', None)
+        if 'file_path' in kwargs:
+            self._init_outcar(kwargs['file_path'])
+        if 'data' in kwargs:
+            self._init_outcar(kwargs['data'].get_file_abs_path())
 
-    def _init_with_file_path(self, path):
+    def _init_outcar(self, path):
         """Init with a filepath."""
         self._parsed_data = {}
         self._parsable_items = self.__class__.PARSABLE_ITEMS
@@ -73,11 +88,6 @@ class OutcarParser(BaseFileParser):
         except SystemExit:
             self._logger.warning('Parsevasp exited abruptly. Returning None.')
             self._outcar = None
-
-    def _init_with_data(self, data):
-        """Init with SingleFileData."""
-        self._parsable_items = self.__class__.PARSABLE_ITEMS
-        self._init_with_file_path(data.get_file_abs_path())
 
     def _parse_file(self, inputs):
 

--- a/aiida_vasp/parsers/file_parsers/outcar.py
+++ b/aiida_vasp/parsers/file_parsers/outcar.py
@@ -191,7 +191,6 @@ class LegacyOutcarParser(BaseFileParser):
     def __init__(self, *args, **kwargs):
         super(LegacyOutcarParser, self).__init__(*args, **kwargs)
         self._parameter = None
-        self.init_with_kwargs(**kwargs)
 
     def _parse_file(self, inputs):
         """Add all quantities parsed from OUTCAR to _parsed_data."""

--- a/aiida_vasp/parsers/file_parsers/parser.py
+++ b/aiida_vasp/parsers/file_parsers/parser.py
@@ -74,47 +74,16 @@ class BaseFileParser(BaseParser):
 
     def __init__(self, **kwargs):  # pylint: disable=unused-argument
         super(BaseFileParser, self).__init__()
-        self._settings = kwargs.get('settings', None)
-        self._exit_codes = kwargs.get('exit_codes', None)
         self._logger = aiidalogger.getChild(self.__class__.__name__)
         self._exit_code = None
         self._parsable_items = self.PARSABLE_ITEMS
         self._parsed_data = {}
-        self._data_obj = None
-
-    @delegate_method_kwargs(prefix='_init_with_')
-    def init_with_kwargs(self, **kwargs):
-        """Delegate initialization to _init_with - methods."""
-
-    def _init_with_settings(self, settings):
-        """
-        Dummy method to be called for doing nothing
-
-        self._settings is set at __init__(). But this is needed because of
-        two reasons:
-
-        1) This method is called by init_with_kwargs in each file parser.
-        2) self._settings is used in some _init_with_something_.
-           So this has to be set before init_with_kwargs is called.
-
-        """
-
-    def _init_with_exit_codes(self, exit_codes):
-        """See docstring of _init_with_settings."""
-
-    def _init_with_file_path(self, path):
-        """Init with a file path."""
-        self._data_obj = SingleFile(path=path)
-
-    def _init_with_data(self, data):
-        """
-        Init with aiida-data.
-
-        This has to be overriden by every FileParser, which deals with an
-        Aiida data class other than SingleFileData.
-        """
-
-        self._data_obj = SingleFile(data=data)
+        if 'file_path' in kwargs:
+            self._data_obj = SingleFile(path=kwargs['file_path'])
+        elif 'data' in kwargs:
+            self._data_obj = SingleFile(data=kwargs['data'])
+        else:
+            self._data_obj = None
 
     @property
     def parsable_items(self):

--- a/aiida_vasp/parsers/file_parsers/poscar.py
+++ b/aiida_vasp/parsers/file_parsers/poscar.py
@@ -45,19 +45,21 @@ class PoscarParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize POSCAR parser
+
+        data : StructureData
+
+        """
+
         super(PoscarParser, self).__init__(*args, **kwargs)
-        self.precision = 12
         self._structure = None
-        self.options = None
-        self.init_with_kwargs(**kwargs)
+        self._options = kwargs.get('options', None)
+        self._precision = kwargs.get('precision', 12)
+        if 'data' in kwargs:
+            self._init_structure(kwargs['data'])
 
-    def _init_with_precision(self, precision):
-        self.precision = precision
-
-    def _init_with_options(self, options):
-        self.options = options
-
-    def _init_with_data(self, data):
+    def _init_structure(self, data):
         """Initialize with an AiiDA StructureData instance."""
         if isinstance(data, get_data_class('structure')):
             self._data_obj = data
@@ -75,8 +77,8 @@ class PoscarParser(BaseFileParser):
         if isinstance(self._data_obj, get_data_class('structure')):
             # _data_obj is StructureData, return the parsed version if possible.
             try:
-                return Poscar(poscar_dict=self.aiida_to_parsevasp(self._data_obj, options=self.options),
-                              prec=self.precision,
+                return Poscar(poscar_dict=self.aiida_to_parsevasp(self._data_obj, options=self._options),
+                              prec=self._precision,
                               conserve_order=True,
                               logger=self._logger)
             except SystemExit:
@@ -93,7 +95,7 @@ class PoscarParser(BaseFileParser):
 
         # pass file path to parsevasp and try to load file
         try:
-            poscar = Poscar(file_path=self._data_obj.path, prec=self.precision, conserve_order=True, logger=self._logger)
+            poscar = Poscar(file_path=self._data_obj.path, prec=self._precision, conserve_order=True, logger=self._logger)
         except SystemExit:
             self._logger.warning('Parsevasp exited abnormally. ' 'Returning None.')
             return {'poscar-structure': None}

--- a/aiida_vasp/parsers/file_parsers/stream.py
+++ b/aiida_vasp/parsers/file_parsers/stream.py
@@ -25,11 +25,27 @@ class StreamParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize stream parser
+
+        file_path : str
+            File path.
+        data : SingleFileData
+            AiiDA Data class install to store a single file.
+        settings : ParserSettings
+            Do not touch. BaseFileParser takes care of initialization.
+
+        """
+
         super(StreamParser, self).__init__(*args, **kwargs)
         self._stream = None
-        self.init_with_kwargs(**kwargs)
+        self._settings = kwargs.get('settings', None)
+        if 'file_path' in kwargs:
+            self._init_stream(kwargs['file_path'])
+        if 'data' in kwargs:
+            self._init_stream(kwargs['data'].get_file_abs_path())
 
-    def _init_with_file_path(self, path):
+    def _init_stream(self, path):
         """Init with a file path."""
         self._parsed_data = {}
         self._parsable_items = self.__class__.PARSABLE_ITEMS
@@ -48,11 +64,6 @@ class StreamParser(BaseFileParser):
         except SystemExit:
             self._logger.warning('Parsevasp exited abruptly when parsing the standard stream. Returning None.')
             self._stream = None
-
-    def _init_with_data(self, data):
-        """Init with SingleFileData."""
-        self._parsable_items = self.__class__.PARSABLE_ITEMS
-        self._init_with_file_path(data.get_file_abs_path())
 
     def _parse_file(self, inputs):
         """Parse the standard streams."""

--- a/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
@@ -2,7 +2,6 @@
 # pylint: disable=redefined-outer-name, unused-wildcard-import, unused-argument, wildcard-import
 
 import pytest
-from pytest import raises
 from aiida.common import InputValidationError
 
 from aiida_vasp.utils.fixtures import *
@@ -69,7 +68,7 @@ def test_parser_dict(fresh_aiida_env, incar_dict_example):
 #     """
 
 #     test_string = 'LOPTICS = .True.\nAddgrid=.false.'
-#     with raises(AttributeError):
+#     with pytest.raises(AttributeError):
 #         IncarParser(incar_string=test_string)
 
 

--- a/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
@@ -59,18 +59,18 @@ def test_parser_dict(fresh_aiida_env, incar_dict_example):
     assert isinstance(parser.incar, get_data_class('dict'))
 
 
-def test_parser_string():
-    """
-    Pass a string to the INCAR parser.
+# def test_parser_string():
+#     """
+#     Pass a string to the INCAR parser.
 
-    Should fail, since passing of string in
-    the interface is not implemented yet.
+#     Should fail, since passing of string in
+#     the interface is not implemented yet.
 
-    """
+#     """
 
-    test_string = 'LOPTICS = .True.\nAddgrid=.false.'
-    with raises(AttributeError):
-        IncarParser(incar_string=test_string)
+#     test_string = 'LOPTICS = .True.\nAddgrid=.false.'
+#     with raises(AttributeError):
+#         IncarParser(incar_string=test_string)
 
 
 def test_write_parser(fresh_aiida_env, tmpdir, incar_dict_example):

--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -129,13 +129,29 @@ class VasprunParser(BaseFileParser):
     }
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize vasprun.xml parser
+
+        file_path : str
+            File path.
+        data : SingleFileData
+            AiiDA Data class install to store a single file.
+        settings : ParserSettings
+        exit_codes : CalcJobNode.process_class.exit_codes
+
+        """
+
         super(VasprunParser, self).__init__(*args, **kwargs)
         self._xml = None
         self._xml_truncated = False
-        self.init_with_kwargs(**kwargs)
+        self._settings = kwargs.get('settings', None)
+        self._exit_codes = kwargs.get('exit_codes', None)
+        if 'file_path' in kwargs:
+            self._init_xml(kwargs['file_path'])
+        if 'data' in kwargs:
+            self._init_xml(kwargs['data'].get_file_abs_path())
 
-    def _init_with_file_path(self, path):
-        """Init with a filepath."""
+    def _init_xml(self, path):
         self._data_obj = SingleFile(path=path)
 
         # Since vasprun.xml can be fairly large, we will parse it only
@@ -148,10 +164,6 @@ class VasprunParser(BaseFileParser):
         except SystemExit:
             self._logger.warning('Parsevasp exited abruptly. Returning None.')
             self._xml = None
-
-    def _init_with_data(self, data):
-        """Init with SingleFileData."""
-        self._init_with_file_path(data.get_file_abs_path())
 
     def _parse_file(self, inputs):
         """Parse the quantities related to this file parser."""

--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -152,6 +152,7 @@ class VasprunParser(BaseFileParser):
             self._init_xml(kwargs['data'].get_file_abs_path())
 
     def _init_xml(self, path):
+        """Create parsevasp Xml instance"""
         self._data_obj = SingleFile(path=path)
 
         # Since vasprun.xml can be fairly large, we will parse it only

--- a/aiida_vasp/parsers/file_parsers/wavecar.py
+++ b/aiida_vasp/parsers/file_parsers/wavecar.py
@@ -22,7 +22,6 @@ class WavecarParser(BaseFileParser):
     def __init__(self, *args, **kwargs):
         super(WavecarParser, self).__init__(*args, **kwargs)
         self._wavecar = None
-        self.init_with_kwargs(**kwargs)
 
     def _parse_file(self, inputs):
         """Create a DB Node for the WAVECAR file."""


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

issue #434

## Description

I rewrote with explicit checks of keyward arguments and corresponding actions in the `__init__` method of each specific file parser.

The following test is commented out.
 https://github.com/aiida-vasp/aiida-vasp/blob/2d0dc046b4dcb635ca09fd9163c59284925e0e77/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py#L62-L73

