### PR TITLE
Changing the way in which the selective dynamics are passed to the vasp calculation

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -5,7 +5,7 @@ VASP calculation.
 The calculation class that prepares a specific VASP calculation.
 """
 #encoding: utf-8
-# pylint: disable=abstract-method
+# pylint: disable=abstract-method, super-with-arguments
 # explanation: pylint wrongly complains about (aiida) Node not implementing query
 import os
 from aiida.plugins import DataFactory
@@ -303,8 +303,10 @@ class VaspCalculation(VaspCalcBase):
         settings = self.inputs.get('settings')
         settings = settings.get_dict() if settings else {}
         poscar_precision = settings.get('poscar_precision', 10)
-        positions_dof = self.inputs.get('dynamics', {}).get('positions_dof')
-        if positions_dof is not None:
+        dynamics = self.inputs.get('dynamics')
+        if dynamics is not None:
+            dynamics = dynamics.get_dict() if dynamics else {}
+            positions_dof = dynamics.get('positions_dof')
             options = {'positions_dof': positions_dof}
         else:
             options = None

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -5,7 +5,7 @@ VASP calculation.
 The calculation class that prepares a specific VASP calculation.
 """
 #encoding: utf-8
-# pylint: disable=abstract-method, super-with-arguments
+# pylint: disable=abstract-method
 # explanation: pylint wrongly complains about (aiida) Node not implementing query
 import os
 from aiida.plugins import DataFactory
@@ -304,12 +304,12 @@ class VaspCalculation(VaspCalcBase):
         settings = settings.get_dict() if settings else {}
         poscar_precision = settings.get('poscar_precision', 10)
         dynamics = self.inputs.get('dynamics')
+        options = None
         if dynamics is not None:
-            dynamics = dynamics.get_dict() if dynamics else {}
+            dynamics = dynamics.get_dict()
             positions_dof = dynamics.get('positions_dof')
-            options = {'positions_dof': positions_dof}
-        else:
-            options = None
+            if positions_dof is not None:
+                options = {'positions_dof': positions_dof}
         poscar_parser = PoscarParser(data=self._structure(), precision=poscar_precision, options=options)
         poscar_parser.write(dst)
 


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)


In PR #428 a bug was introduced in which the calculation would fail when trying to set selective dynamics.
This makes the passing more explicit to eliminate any possible issues.
