### PR TITLE
Make PotcatData -> PotcarFileData only match sha512

### DIFF
--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -584,7 +584,7 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
 
     def find_file_node(self):
         """Find and return the matching PotcarFileData node."""
-        return PotcarFileData.find_one(**self.attributes)
+        return PotcarFileData.find_one(sha512=self.sha512)
 
     # pylint: disable=arguments-differ,signature-differs
     def store(self, *args, **kwargs):


### PR DESCRIPTION
Now getting the PotcarFileData from PotcarData is only through matching SHA512. Since the SHA512 is only computed from the file content, matching a PotcarFileData with different other attributes does not change the end result. This fixes inconsistency when uploading family containing POTCAR that does not exist in the database but a PotcarData does exist (#417), giving rise to stale `PotcarData` nodes. 

This PR also makes it possible to use imported `PotcarData` nodes in new calculations as long as the actual POTCAR file has been deposited in the database. 

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#417
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
