### PR TITLE
Implemented `skip_parameters_validation` option

### DIFF
--- a/aiida_vasp/assistant/tests/test_parameters.py
+++ b/aiida_vasp/assistant/tests/test_parameters.py
@@ -366,6 +366,15 @@ def test_unsupported_parameters_in_unsupported_namespace():  # pylint: disable=i
     assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid == 200
 
 
+def test_skip_parameters_validate():  # pylint: disable=invalid-name
+    """Test that it is possibly to completely by-pass parameters checking."""
+    parameters = AttributeDict()
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid = 200
+    massager = ParametersMassage(parameters, skip_parameters_validation=True)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].not_valid == 200
+
+
 def test_pwcutoff_to_encut():
     """Test that the pwcutoff is converted to encut."""
     parameters = AttributeDict()

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -176,18 +176,19 @@ class VaspWorkChain(BaseRestartWorkChain):
 
         # Set settings
         unsupported_parameters = None
+        skip_parameters_validation = False
         if 'settings' in self.inputs:
             self.ctx.inputs.settings = self.inputs.settings
             # Also check if the user supplied additional tags that is not in the supported file.
-            try:
-                unsupported_parameters = self.ctx.inputs.settings.unsupported_parameters
-            except AttributeError:
-                pass
+            unsupported_parameters = self.ctx.inputs.settings.get('unsupported_parameters', unsupported_parameters)
+            skip_parameters_validation = self.ctx.inputs.settings.get('skip_parameters_validation', skip_parameters_validation)
 
         # Perform inputs massage to accommodate generalization in higher lying workchains
         # and set parameters.
         try:
-            parameters_massager = ParametersMassage(self.ctx.inputs.parameters, unsupported_parameters)
+            parameters_massager = ParametersMassage(self.ctx.inputs.parameters,
+                                                    unsupported_parameters,
+                                                    skip_parameters_validation=skip_parameters_validation)
         except Exception as exception:  # pylint: disable=broad-except
             return self.exit_codes.ERROR_IN_PARAMETER_MASSAGER.format(exception=exception)  # pylint: disable=no-member
         try:


### PR DESCRIPTION
When this option is supplied the check of supplied tags is disabled in the override namespace. This can be activated by setting the key of the same name in the `settings` input of `VaspWorkChain` to True.

I also included some code refactoring to remove the unnecessary `try...except...` blocks and break clause.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#440
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
