### PR TITLE
Fix a bug where standout/err redirection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
         if: ${{ matrix.python }} == '3.8'
         run: pip install coveralls
       - name: Install AiiDA
-        run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
+        #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
+        run: pip install aiida-core
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -93,6 +93,7 @@ def test_incar_validate(vasp_calc, vasp_inputs, localhost_dir):
 def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_dir):
     """Check that preparing creates all necessary files."""
     from aiida.common.folders import Folder
+    from aiida_vasp.calcs.vasp import VaspCalculation
     wavecar, _ = vasp_wavecar
     chgcar, _ = vasp_chgcar
 
@@ -113,6 +114,9 @@ def test_prepare(vasp_calc, vasp_chgcar, vasp_wavecar, vasp_inputs, localhost_di
     assert 'EIGENVAL' in calcinfo.retrieve_list
     assert 'DOSCAR' in calcinfo.retrieve_list
     assert 'wannier90*' in calcinfo.retrieve_list
+
+    assert calcinfo.codes_info[0].stdout_name == VaspCalculation._VASP_OUTPUT
+    assert calcinfo.codes_info[0].join_files is True
 
     inputs_dict.update({'icharg': 2})
 

--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -149,8 +149,8 @@ class VaspCalculation(VaspCalcBase):
         calcinfo = super(VaspCalculation, self).prepare_for_submission(tempfolder)
 
         # Combine stdout and stderr into vasp_output so that the stream parser can parse it later.
-        calcinfo.stdout_name = self._VASP_OUTPUT
-        calcinfo.join_files = True
+        calcinfo.codes_info[0].stdout_name = self._VASP_OUTPUT
+        calcinfo.codes_info[0].join_files = True
 
         # Still need the exceptions in case settings is not defined on inputs
         # Check if we want to store all always retrieve files

--- a/aiida_vasp/utils/bands.py
+++ b/aiida_vasp/utils/bands.py
@@ -153,6 +153,6 @@ def plot_bands(bands_node, **kwargs):
         import itertools
         colors = itertools.cycle(kwargs.pop('colors'))
         for b_idx in range(bands.shape[1]):
-            plt.plot(bands[:, b_idx], color=colors.next(), **kwargs)  # pylint: disable=no-member
+            plt.plot(bands[:, b_idx], color=colors.next(), **kwargs)  # pylint: disable=no-member, not-callable
     else:
         plt.plot(bands, **kwargs)


### PR DESCRIPTION
The entry `stdout_name` and `join_files` should be placed under
`CodeInfo` rather than `CalcInfo` in order the activate redirection
of STDOUT and STDERR which is needed for parsing notifications.

This fixes the warnings: 
> | The quantity notifications has been requested for parsing, however the following files required for parsing it have not been retrieved: vasp_output.

and missing notifications output of the `VaspCalculation`. 

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
