### PR TITLE
[WIP] Immigrant refactor

### DIFF
--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -6,9 +6,13 @@ Enables the immigration of  externally run VASP calculations into AiiDA.
 """
 # pylint: disable=abstract-method, import-outside-toplevel, cyclic-import
 # explanation: pylint wrongly complains about (aiida) Node not implementing query
+from pathlib import Path
+
 from aiida.common import InputValidationError
 from aiida.common.lang import override
 from aiida.common.links import LinkType
+from aiida.common.folders import SandboxFolder
+from aiida.common.extendeddicts import AttributeDict
 
 from aiida_vasp.calcs.vasp import VaspCalculation
 from aiida_vasp.data.potcar import PotcarData
@@ -19,6 +23,16 @@ from aiida_vasp.parsers.file_parsers.potcar import MultiPotcarIo
 from aiida_vasp.parsers.file_parsers.chgcar import ChgcarParser
 from aiida_vasp.parsers.file_parsers.wavecar import WavecarParser
 from aiida_vasp.utils.aiida_utils import get_data_node
+from aiida_vasp.utils.aiida_utils import cmp_get_transport
+
+# _IMMIGRANT_EXTRA_KWARGS = """
+# vasp.vasp specific kwargs:
+
+# :param use_chgcar: bool, if True, read the CHGCAR file (has to exist) and convert it to an input node.
+# :param use_wavecar: bool, if True, read the WAVECAR file (has to exist) and convert it to an input node.
+# """
+
+# @update_docstring('immigrant', _IMMIGRANT_EXTRA_KWARGS, append=True)
 
 
 class VaspImmigrant(VaspCalculation):
@@ -33,7 +47,6 @@ class VaspImmigrant(VaspCalculation):
     def run(self):
         import plumpy
         from aiida.engine.processes.calcjobs.tasks import RETRIEVE_COMMAND
-        from aiida.common.folders import SandboxFolder
 
         _ = super(VaspImmigrant, self).run()
 
@@ -52,6 +65,85 @@ class VaspImmigrant(VaspCalculation):
         remotedata.store()
 
         return plumpy.Wait(msg='Waiting to retrieve', data=RETRIEVE_COMMAND)
+
+    @classmethod
+    def get_inputs_from_folder(cls, code, remote_path, **kwargs):
+        """
+        Create an immigrant with appropriate inputs from a code and a remote path on the associated computer.
+
+        More inputs are required to pass resources information, if the POTCAR file is missing from the folder
+        or if additional settings need to be passed, e.g. parser instructions.
+
+        :param code: a Code instance for the code originally used.
+        :param remote_path: The directory on the code's computer in which the simulation was run.
+        :param resources: dict. The resources used during the run (defaults to 1 machine, 1 process).
+        :param potcar_spec: dict. If the POTCAR file is not present anymore, this allows to pass a family and
+            mapping to find the right POTCARs.
+        :param settings: dict. Used for non-default parsing instructions, etc.
+        """
+
+        inputs = AttributeDict()
+        remote_path = Path(remote_path)
+        inputs.code = code
+        options = {'max_wallclock_seconds': 1, 'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}}
+        inputs.metadata = {'options': options}
+        settings = {'import_from_path': str(remote_path)}
+        inputs.settings = get_data_node('dict', dict=settings)
+        with cmp_get_transport(code.computer) as transport:
+            with SandboxFolder() as sandbox:
+                sandbox_path = Path(sandbox.abspath)
+                transport.get(str(remote_path / 'INCAR'), str(sandbox_path))
+                transport.get(str(remote_path / 'POSCAR'), str(sandbox_path))
+                transport.get(str(remote_path / 'POTCAR'), str(sandbox_path), ignore_nonexisting=True)
+                transport.get(str(remote_path / 'KPOINTS'), str(sandbox_path))
+                inputs.parameters = get_incar_input(sandbox_path)
+                inputs.structure = get_poscar_input(sandbox_path)
+                try:
+                    inputs.potential = get_potcar_input(sandbox_path)
+                except InputValidationError:
+                    pass
+                inputs.kpoints = get_kpoints_input(sandbox_path)
+                cls._add_inputs(transport, remote_path, sandbox_path, inputs, **kwargs)
+        return inputs
+
+    @classmethod
+    def get_builder_from_folder(cls, code, remote_path, **kwargs):
+        """
+        Create an immigrant with appropriate inputs from a code and a remote path on the associated computer.
+
+        More inputs are required to pass resources information, if the POTCAR file is missing from the folder
+        or if additional settings need to be passed, e.g. parser instructions.
+
+        :param code: a Code instance for the code originally used.
+        :param remote_path: The directory on the code's computer in which the simulation was run.
+        :param resources: dict. The resources used during the run (defaults to 1 machine, 1 process).
+        :param potcar_spec: dict. If the POTCAR file is not present anymore, this allows to pass a family and
+            mapping to find the right POTCARs.
+        :param settings: dict. Used for non-default parsing instructions, etc.
+        """
+
+        inputs = cls.get_inputs_from_folder(code, remote_path, **kwargs)
+        builder = cls.get_builder()
+        builder.code = inputs.code
+        builder.parameters = inputs.parameters
+        builder.structure = inputs.structure
+        builder.potential = inputs.potential
+        builder.kpoints = inputs.kpoints
+        builder.settings = inputs.settings
+        builder.metadata = inputs.metadata
+        return builder
+
+    @classmethod
+    def _add_inputs(cls, transport, remote_path, sandbox_path, inputs, **kwargs):
+        """Add some more inputs"""
+        add_wavecar = kwargs.get('use_wavecar') or bool(inputs.parameters.get_dict().get('istart', 0))
+        add_chgcar = kwargs.get('use_chgcar') or inputs.parameters.get_dict().get('icharg', -1) in [1, 11]
+        if add_chgcar:
+            transport.get(str(remote_path / 'CHGCAR'), str(sandbox_path))
+            inputs.charge_density = get_chgcar_input(sandbox_path)
+        if add_wavecar:
+            transport.get(str(remote_path / 'WAVECAR'), str(sandbox_path))
+            inputs.wavefunctions = get_wavecar_input(sandbox_path)
 
 
 def get_incar_input(dir_path):

--- a/aiida_vasp/calcs/immigrant.py
+++ b/aiida_vasp/calcs/immigrant.py
@@ -127,7 +127,8 @@ class VaspImmigrant(VaspCalculation):
         builder.code = inputs.code
         builder.parameters = inputs.parameters
         builder.structure = inputs.structure
-        builder.potential = inputs.potential
+        if 'potential' in inputs and inputs.potential:
+            builder.potential = inputs.potential
         builder.kpoints = inputs.kpoints
         builder.settings = inputs.settings
         builder.metadata = inputs.metadata

--- a/aiida_vasp/calcs/tests/test_immigrant.py
+++ b/aiida_vasp/calcs/tests/test_immigrant.py
@@ -11,37 +11,37 @@ from aiida_vasp.utils.aiida_utils import create_authinfo
 @pytest.fixture
 def immigrant_with_builder(fresh_aiida_env, potcar_family, phonondb_run, localhost, mock_vasp):
     """Provide process class and inputs for importing a AiiDA-external VASP run."""
-    from aiida_vasp.calcs.vasp import VaspCalculation
+    from aiida_vasp.calcs.immigrant import VaspImmigrant
+    from aiida_vasp.data.potcar import PotcarData
 
     create_authinfo(localhost, store=True)
+    builder = VaspImmigrant.get_builder_from_folder(code=mock_vasp, remote_path=phonondb_run)
     potential_family = POTCAR_FAMILY_NAME
     potential_mapping = POTCAR_MAP
-    proc, builder = VaspCalculation.immigrant(code=mock_vasp,
-                                              remote_path=phonondb_run,
-                                              potential_family=potential_family,
-                                              potential_mapping=potential_mapping)
+    builder.potential = PotcarData.get_potcars_from_structure(builder.structure, potential_family, mapping=potential_mapping)
+
     # Make sure clean_workdir is not done for the immigrant (we do not want to remove the imported data)
     expected_inputs = {'parameters', 'structure', 'kpoints', 'potential'}
     for input_link in expected_inputs:
         assert builder.get(input_link, None) is not None
-    return proc, builder
+    return builder
 
 
 def test_immigrant_additional(fresh_aiida_env, potcar_family, phonondb_run, localhost, mock_vasp):
     """Provide process class and inputs for importing a AiiDA-external VASP run."""
-    from aiida_vasp.calcs.vasp import VaspCalculation
+    from aiida_vasp.calcs.immigrant import VaspImmigrant
+    from aiida_vasp.data.potcar import PotcarData
+
     create_authinfo(localhost, store=True)
-    proc, builder = VaspCalculation.immigrant(code=mock_vasp,
-                                              remote_path=phonondb_run,
-                                              potential_family=POTCAR_FAMILY_NAME,
-                                              potential_mapping=POTCAR_MAP,
-                                              use_chgcar=True,
-                                              use_wavecar=True)
+    inputs = VaspImmigrant.get_inputs_from_folder(code=mock_vasp, remote_path=phonondb_run, use_chgcar=True, use_wavecar=True)
+    potential_family = POTCAR_FAMILY_NAME
+    potential_mapping = POTCAR_MAP
+    inputs.potential = PotcarData.get_potcars_from_structure(inputs.structure, potential_family, mapping=potential_mapping)
     expected_inputs = {'parameters', 'structure', 'kpoints', 'potential', 'charge_density', 'wavefunctions'}
     for input_link in expected_inputs:
-        assert builder.get(input_link, None) is not None, 'input link "{}" was not set!'.format(input_link)
+        assert inputs.get(input_link, None) is not None, 'input link "{}" was not set!'.format(input_link)
 
-    result, node = run.get_node(proc, **builder)
+    result, node = run.get_node(VaspImmigrant, **inputs)
     assert node.exit_status == 0
 
     # We should not have any POTCAR here
@@ -52,11 +52,11 @@ def test_immigrant_additional(fresh_aiida_env, potcar_family, phonondb_run, loca
 
 def test_vasp_immigrant(immigrant_with_builder):
     """Test importing a calculation from the folder of a completed VASP run."""
-    immigrant, inputs = immigrant_with_builder
+    builder = immigrant_with_builder
 
     # We need to set the parser explicitly
-    inputs.metadata['options']['parser_name'] = 'vasp.vasp'
-    result, node = run.get_node(immigrant, **inputs)
+    # builder.metadata['options']['parser_name'] = 'vasp.vasp'
+    result, node = run.get_node(builder)
     assert node.exit_status == 0
 
     expected_output_nodes = {'misc', 'remote_folder', 'retrieved'}

--- a/setup.json
+++ b/setup.json
@@ -25,7 +25,8 @@
     "entry_points": {
 	"aiida.calculations": [
 	    "vasp.vasp = aiida_vasp.calcs.vasp:VaspCalculation",
-	    "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation"
+	    "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation",
+	    "vasp.immigrant = aiida_vasp.calcs.immigrant:VaspImmigrant"
 	],
 	"aiida.cmdline.data": [
 	    "vasp-potcar = aiida_vasp.commands.potcar:potcar"


### PR DESCRIPTION
This PR is to discuss about the code and UI design, but ready to be merged.
I would like to hear your comments.

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

Related to issues #445.

## Description
This refactors the vasp-immigrant code. The codes were divided into three files. Now they are all merged to `immigrant.py`.

To improve UI, I changed the design and current one is not backward compatible though it can be made to be backward compatible with some effort.

The usage is as follows:
1) `VaspImmigrant = CalculationFactory('vasp.immigrant')`
2) `builder = VaspImmigrant.get_builder_from_folder(code, calculation_folder)`
3) Set additional inputs.
4) `submit(builder)`

`'import_from_path': calculation_folder` in `settings` is necessary when we want to replace `settings`.

`VaspImmigrant.get_inputs_from_folder(...)` can be used to get inputs in `AttributeDict` instead of `get_builder_from_folder`.

The launch script looks like below.
```python
from aiida.orm import Code
from aiida.plugins import CalculationFactory, DataFactory
from aiida.engine import submit
from aiida import load_profile
load_profile()


Dict = DataFactory('dict')


def main():
    parser_settings = {'add_energies': True, 'electronic_step_energies': True}
    code_string = 'vasp544mpi@nancy'  # For remote computer
    potential_family = 'PBE.54'
    potential_mapping = {'Si': 'Si'}
    resources = {'parallel_env': 'mpi*', 'tot_num_mpiprocs': 24}  # For sge scheduler
    calculation_folder = r"/home/togo/aiida/bd/44/b58b-12ef-49b4-8ae6-037434c5cebf"  # remote data
    metadata = {'options': {'resources': resources}}
    settings = {'parser_settings': parser_settings,
                'import_from_path': calculation_folder}
    VaspImmigrant = CalculationFactory('vasp.immigrant')
    code = Code.get_from_string(code_string)
    builder = VaspImmigrant.get_builder_from_folder(code, calculation_folder)
    builder.metadata = metadata
    builder.settings = Dict(dict=settings)
    PotcarData = DataFactory('vasp.potcar')
    potentials = PotcarData.get_potcars_from_structure(
        builder.structure, potential_family, mapping=potential_mapping)
    builder.potential = potentials
    print(submit(builder))


if __name__ == "__main__":
    main()
```