### PR TITLE
Revise the default misc output - remove fermi_level and symmetries

### DIFF
--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -75,8 +75,7 @@ NODES = {
         'type':
             'dict',
         'quantities': [
-            'total_energies', 'maximum_stress', 'maximum_force', 'symmetries', 'magnetization', 'notifications', 'run_status',
-            'band_properties', 'fermi_level', 'run_stats', 'version'
+            'total_energies', 'maximum_stress', 'maximum_force', 'magnetization', 'notifications', 'run_status', 'run_stats', 'version'
         ]
     },
     'kpoints': {


### PR DESCRIPTION
The key fermi_level and symmetries are removed from the list of
default misc output quantities. The former is not always present
if DOS calculation is not performed. The latter is rarely useful
and causes confusions.

This should make the relaxation workchain run fine.