### PR TITLE
Sanitize nan and inf values before storing `Dict` nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: pip install coveralls
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
-        run: pip install aiida-core==1.5.2
+        run: pip install 'aiida-core>=1.6.1,<2'
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: pip install coveralls
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
-        run: pip install aiida-core
+        run: pip install aiida-core==1.5.2
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from aiida_vasp.utils.fixtures import *
 from aiida_vasp.utils.aiida_utils import get_data_class
-from aiida_vasp.parsers.node_composer import NodeComposer, get_node_composer_inputs_from_file_parser
+from aiida_vasp.parsers.node_composer import NodeComposer, get_node_composer_inputs_from_file_parser, clean_nan_values
 
 
 def test_version(fresh_aiida_env, vasprun_parser):
@@ -762,3 +762,16 @@ def test_dynmat(fresh_aiida_env, vasprun_parser):
     ]))
     assert dyneig[0] == -1.36621537e+00
     assert dyneig[4] == -8.48939361e-01
+
+
+def test_nan_inf_cleaning():
+    """
+    Test cleaning nan/inf values
+    """
+
+    example = {'a': 1.0, 'b': {'c': 2.0, 'd': np.inf, 'e': np.nan}, 'd': {'e': {'g': np.inf}}}
+    clean_nan_values(example)
+    assert example['a'] == 1.0
+    assert example['b']['d'] == 'inf'
+    assert example['b']['e'] == 'nan'
+    assert example['d']['e']['g'] == 'inf'

--- a/aiida_vasp/parsers/node_composer.py
+++ b/aiida_vasp/parsers/node_composer.py
@@ -5,6 +5,9 @@ Node composer.
 A composer that composes different quantities onto AiiDA data nodes.
 """
 
+from warnings import warn
+import numpy as np
+
 from aiida_vasp.utils.aiida_utils import get_data_class
 
 NODES_TYPES = {
@@ -77,6 +80,7 @@ class NodeComposer:
     def _compose_dict(node_type, inputs):
         """Compose the dictionary node."""
         node = get_data_class(node_type)()
+        inputs = clean_nan_values(inputs)
         node.update_dict(inputs)
         return node
 
@@ -184,3 +188,20 @@ class NodeComposer:
                 else:
                     node.set_array(key, value)
         return node
+
+
+def clean_nan_values(inputs: dict) -> dict:
+    """
+    Recursively replace NaN, Inf values (np.float) into None in place.
+
+    This is because AiiDA does not support serializing these values
+    as node attributes.
+    """
+    for key, value in inputs.items():
+        if isinstance(value, dict):
+            clean_nan_values(value)
+        elif isinstance(value, np.float):
+            if np.isnan(value) or np.isinf(value):
+                warn('Key <{}> has value <{}> replaced by <None>'.format(key, value))
+                inputs[key] = None
+    return inputs

--- a/aiida_vasp/parsers/node_composer.py
+++ b/aiida_vasp/parsers/node_composer.py
@@ -6,7 +6,8 @@ A composer that composes different quantities onto AiiDA data nodes.
 """
 
 from warnings import warn
-import numpy as np
+import math
+import numbers
 
 from aiida_vasp.utils.aiida_utils import get_data_class
 
@@ -200,8 +201,7 @@ def clean_nan_values(inputs: dict) -> dict:
     for key, value in inputs.items():
         if isinstance(value, dict):
             clean_nan_values(value)
-        elif isinstance(value, np.float):
-            if np.isnan(value) or np.isinf(value):
-                warn('Key <{}> has value <{}> replaced by <None>'.format(key, value))
-                inputs[key] = None
+        if isinstance(value, numbers.Real) and (math.isnan(value) or math.isinf(value)):
+            warn('Key <{}> has value <{}> replaced by <{}>'.format(key, value, str(value)))
+            inputs[key] = str(value)
     return inputs

--- a/setup.json
+++ b/setup.json
@@ -82,6 +82,7 @@
     "install_requires": [
 	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
 	"subprocess32",
+	"sqlalchemy~=1.3.10",
 	"pymatgen<=2020.12.3",
 	"lxml",
 	"packaging",

--- a/setup.json
+++ b/setup.json
@@ -82,7 +82,6 @@
     "install_requires": [
 	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
 	"subprocess32",
-	"sqlalchemy~=1.3.10",
 	"pymatgen<=2020.12.3",
 	"lxml",
 	"packaging",


### PR DESCRIPTION
In some cases, VASP can generate numerical results with NaN. For example, having `maximum_force` equal to NaN in some hybrid functional band structure calculations that involve a regular grid + zero-weighted kpoints. 

However, `aiida-core` is not able to store these numerical values as attributes due to the limitation of the underlying SQL engine, resulting in exceptions. This PR adds and additional cleaning steps before composing the `Node` for storage. The problematic numerical values are represented by string instead. 

