### PR TITLE
Attach all avalaible output for `VaspCalculation` with non-zero exit codes for `VaspWorkChain`

### DIFF
--- a/aiida_vasp/workchains/restart.py
+++ b/aiida_vasp/workchains/restart.py
@@ -146,9 +146,11 @@ class BaseRestartWorkChain(WorkChain):
             exit_code = compose_exit_code(calculation.exit_status, calculation.exit_message)
             self.report('The called {}<{}> returned a non-zero exit status. '  # pylint: disable=not-callable
                         'The exit status {} is inherited'.format(calculation.__class__.__name__, calculation.pk, exit_code))
-            # Make sure at the very minimum we attach the misc node that contains notifications and other
-            # quantities that can be salvaged
-            self.out('misc', calculation.outputs['misc'])
+            # We attach the all output quantities in case they can still be savaged
+            for key in calculation.outputs:
+                if key in self.spec().outputs:
+                    self.out(key, calculation.outputs[key])
+
             return exit_code
 
         # Set default exit status to an unknown failure

--- a/setup.json
+++ b/setup.json
@@ -81,6 +81,7 @@
     "include_package_data": true,
     "install_requires": [
 	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
+	"sqlalchemy~=1.3.10",
 	"subprocess32",
 	"pymatgen<=2020.12.3",
 	"lxml",


### PR DESCRIPTION
Previously, only the misc node is attached for a calculation with a non-zero exit code. This is very limiting and can affect cases where calculation can actually be safely restarted. Especially now, a 1003 exit code is likely to occur for calculations that do not terminate gracefully, for example, unfinished geometry optimisations. 

This PR makes all outputs are attached as the output of VaspCalculation so upper stream workchains can handle
them properly. Since the `exit_code` itself is inherited from the `VaspCalculation`, I don't see any reason why other outputs should not be attached. 

