### PR TITLE
Fix a the fresh_aiida_env fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: pip install coveralls
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
-        run: pip install aiida-core>=1.6.1,<2
+        run: pip install "aiida-core>=1.6.1,<2"
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: pip install coveralls
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
-        run: pip install aiida-core
+        run: pip install aiida-core>=1.6.1,<2
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -21,6 +21,8 @@ from pymatgen.io.vasp import Poscar
 from aiida.orm import Computer, FolderData
 from aiida.common.exceptions import NotExistent
 from aiida.common.extendeddicts import AttributeDict
+from aiida.manage.tests import TemporaryProfileManager
+
 from aiida_vasp.utils.aiida_utils import get_data_node, get_data_class
 from aiida_vasp.utils.fixtures.testdata import data_path
 from aiida_vasp.parsers.file_parsers.incar import IncarParser
@@ -304,7 +306,10 @@ def mock_vasp(fresh_aiida_env, localhost):
         code.description = 'Mock VASP for tests'
         code.set_remote_computer_exec((localhost, mock_vasp_path))
         code.set_input_plugin_name('vasp.vasp')
-        aiidapath = Path(fresh_aiida_env._manager.root_dir) / '.aiida'
+        if isinstance(fresh_aiida_env._manager, TemporaryProfileManager):
+            aiidapath = Path(fresh_aiida_env._manager.root_dir) / '.aiida'
+        else:
+            aiidapath = Path(os.environ.get('AIIDA_PATH', os.environ.get('HOME'))) / '/.aiida'
         code.set_prepend_text('export AIIDA_PATH={}'.format(aiidapath))
 
     return code

--- a/aiida_vasp/utils/fixtures/environment.py
+++ b/aiida_vasp/utils/fixtures/environment.py
@@ -7,15 +7,20 @@ to run our tests. In particular, the fresh_aiida_env is crucial in order
 to set up a dummy database and configuration that can be used during
 testing. AiiDA contributes with its own fixture manager, which we use.
 """
-# pylint: disable=unused-import,unused-argument,redefined-outer-name
+# pylint: disable=unused-import,unused-argument,redefined-outer-name, protected-access
 from __future__ import absolute_import
 from __future__ import print_function
 import pytest
+
+from aiida.manage.tests import TemporaryProfileManager
 
 
 @pytest.fixture()
 def fresh_aiida_env(aiida_profile):
     """Reset the database before and after the test function."""
-    print('The root directory of the fixture manager is: {}'.format(aiida_profile._manager.root_dir))  # pylint: disable=protected-access
+    if isinstance(aiida_profile._manager, TemporaryProfileManager):
+        print('The root directory of the fixture manager is: {}'.format(aiida_profile._manager.root_dir))  # pylint: disable=protected-access
+    else:
+        print('Using existing profile: {}'.format(aiida_profile._manager._profile.name))
     yield aiida_profile
     aiida_profile.reset_db()


### PR DESCRIPTION
This PR fixes plugin tests using an existing test profile.

The test profile manager can be a barebone `ProfileManger` if running
with an existing profile. It does not have a root directory defined.
If that is the case, just print the profile name instead.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#471 