### PR TITLE
Allowing final structural relaxation in the converge workchain 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - 5672:5672
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
           - 5672:5672
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Ensuring that the final relaxation is performed if the user wishes so. Addresses #466

Fixing an issue in which the convergence will be performed even if pwcutoff was given in the electronic parameter space.

Fixing an issue in which the structure was not being exposed as an input due to #301.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #466 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
