### PR TITLE
Remove `with_dbenv` decorator from `get_data_class`

### DIFF
--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -161,6 +161,7 @@ def managed_temp_file():
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
+@pytest.mark.usefixtures('fresh_aiida_env')
 def test_vasp_calc(run_vasp_calc):
     """Test a run of a basic VASP calculation and its details."""
     from aiida_vasp.calcs.vasp import VaspCalculation

--- a/aiida_vasp/commands/mock_vasp.py
+++ b/aiida_vasp/commands/mock_vasp.py
@@ -9,6 +9,7 @@ import shutil
 from pathlib import Path
 import click
 
+from aiida.cmdline.utils.decorators import with_dbenv
 from aiida_vasp.utils.fixtures.testdata import data_path
 from aiida_vasp.parsers.file_parsers.incar import IncarParser
 from aiida_vasp.parsers.file_parsers.potcar import PotcarIo
@@ -21,6 +22,7 @@ def output_file(*args):
 
 
 @click.command('mock-vasp')
+@with_dbenv()
 def mock_vasp():
     """Verify input files are parseable and copy in output files."""
     from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER  # pylint: disable=import-outside-toplevel
@@ -45,6 +47,7 @@ def mock_vasp():
     assert kpoints.is_file(), 'KPOINTS input file not found.'
     incar_parser = IncarParser(file_path=str(incar))
     assert incar_parser, 'INCAR could not be parsed.'
+
     assert PotcarIo(path=str(potcar)), 'POTCAR could not be parsed.'
     assert PoscarParser(file_path=str(poscar)), 'POSCAR could not be parsed.'
     assert KpointsParser(file_path=str(kpoints)), 'KPOINTS could not be parsed.'

--- a/aiida_vasp/utils/aiida_utils.py
+++ b/aiida_vasp/utils/aiida_utils.py
@@ -12,8 +12,6 @@ from packaging import version
 
 from aiida.orm import User
 
-from aiida.cmdline.utils.decorators import with_dbenv
-
 BASIC_DATA_TYPES = ['bool', 'float', 'int', 'list', 'str', 'dict']
 
 
@@ -44,7 +42,6 @@ def querybuild(cls, **kwargs):
     return query_builder
 
 
-@with_dbenv()
 def get_data_class(data_type):
     """Provide access to the orm.data classes with deferred dbenv loading."""
     from aiida.plugins import DataFactory


### PR DESCRIPTION
The `get_data_class` utility was decorated with `with_dbenv`. This
function is supposed to load the database environment if it is not
already loaded. However, a bug in that function causes it to load the
database to be loaded everytime. This causes a simple call like:

     RelaxWorkChain.get_builder()

to last 10 seconds, instead of being almost instantaneous.

Now, the bug should of course be addressed in `aiida-core` but the
database really doesn't have to be loaded to load the data classes, so
it is best to remove the decorator entirely. The correct profile will be
instantiated automatically as soon as an instance is created of any of
the loaded data classes.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)
