### PR TITLE
CI: Use `postgres` since update to Ubuntu Focal 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     services:
-      postgres:
-        image: postgres:10
-        ports:
-          - 5432:5432
       rabbitmq:
         image: rabbitmq:latest
         ports:
@@ -56,7 +52,7 @@ jobs:
           sudo .ci/enable_ssh_localhost.sh
           sudo apt install locate
           sudo updatedb
-          sudo apt install postgresql-10
+          sudo apt install postgresql
       - name: Upgrade pip
         run: |
           pip install --upgrade pip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     services:
-      postgres:
-        image: postgres:10
-        ports:
-          - 5432:5432
       rabbitmq:
         image: rabbitmq:latest
         ports:
@@ -33,7 +29,7 @@ jobs:
           sudo .ci/enable_ssh_localhost.sh
           sudo apt install locate
           sudo updatedb
-          sudo apt install postgresql-10
+          sudo apt install postgresql
       - name: Upgrade pip
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
The CI configuration uses `ubuntu-latest` which recently became Ubuntu
Focal Fossa (20.04) which no longer has `postgres-10` available, but
instead provides `postgres-12`. The simplest solution is to just install
`postgres` without specifying an explicit version since we should
support all existing versions.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
