### PR TITLE
[WIP] Simple fix for deprecate warnings and Group implementation

### DIFF
--- a/aiida_vasp/commands/potcar.py
+++ b/aiida_vasp/commands/potcar.py
@@ -4,9 +4,12 @@ Commands for the potential interface.
 -------------------------------------
 Commandline util for dealing with potcar files.
 """
+# pylint: disable=import-outside-toplevel
 import click
 from click_spinner import spinner as cli_spinner
 import tabulate
+
+from aiida.cmdline.utils.decorators import with_dbenv
 
 from aiida_vasp.utils.aiida_utils import get_data_class, cmp_load_verdi_data
 from aiida_vasp.commands import options
@@ -36,6 +39,26 @@ def try_grab_description(ctx, param, value):
     return value
 
 
+def detect_old_style_groups():
+    """Check for the existence of old style groups and prompt the user"""
+    from aiida_vasp.data.potcar import OLD_POTCAR_FAMILY_TYPE, PotcarGroup
+    from aiida.orm import QueryBuilder, Group
+    qdb = QueryBuilder()
+    qdb.append(Group, filters={'type_string': OLD_POTCAR_FAMILY_TYPE}, project=['label'])
+    all_old_groups = [qres[0] for qres in qdb.all()]
+    not_migrated = []
+    for group_label in all_old_groups:
+        qdb = QueryBuilder()
+        qdb.append(PotcarGroup, filters={'label': {'==': group_label}})
+        count = qdb.count()
+        if count == 0:
+            not_migrated.append(group_label)
+    if any(not_migrated):
+        click.echo(
+            ("Some of the old style POTCAR family groups are not migrated. Please run command 'verdi data vasp-potcar migratefamilies.\n'",
+             f'The missing groups are: {not_migrated}.'))
+
+
 @potcar.command()
 @options.PATH(help='Path to a folder or archive containing the POTCAR files. '
               'You can supply the archive that you downloaded from the VASP server. '
@@ -44,6 +67,7 @@ def try_grab_description(ctx, param, value):
 @options.DESCRIPTION(help='A description for the family.', callback=try_grab_description)
 @click.option('--stop-if-existing', is_flag=True, help='An option to abort when encountering a previously uploaded POTCAR file.')
 @options.DRY_RUN()
+@with_dbenv
 def uploadfamily(path, name, description, stop_if_existing, dry_run):
     """Upload a family of VASP potcar files."""
 
@@ -64,8 +88,10 @@ def uploadfamily(path, name, description, stop_if_existing, dry_run):
 @click.option('-e', '--element', multiple=True, help='Filter for families containing potentials for all given elements.')
 @click.option('-s', '--symbol', multiple=True, help='Filter for families containing potentials for all given symbols.')
 @click.option('-d', '--description', is_flag=True, help='Also show the description.')
+@with_dbenv
 def listfamilies(element, symbol, description):
     """List available families of VASP potcar files."""
+    detect_old_style_groups()
 
     potcar_data_cls = get_data_class('vasp.potcar')
     groups = potcar_data_cls.get_potcar_groups(filter_elements=element, filter_symbols=symbol)
@@ -93,6 +119,7 @@ def listfamilies(element, symbol, description):
 @options.DRY_RUN(help='Only display what would be exported.')
 @click.option('-z', '--as-archive', is_flag=True, help='Create a compressed archive (.tar.gz) instead of a folder.')
 @click.option('-v', '--verbose', is_flag=True, help='Print the names of all created files.')
+@with_dbenv
 def exportfamily(path, name, dry_run, as_archive, verbose):
     """Export a POTCAR family into a compressed tar archive or folder."""
     potcar_data_cls = get_data_class('vasp.potcar')
@@ -109,3 +136,17 @@ def exportfamily(path, name, dry_run, as_archive, verbose):
     click.echo('{} POTCAR files exported.'.format(len(files)))
     if dry_run:
         click.echo('Nothing written due to "--dry-run"')
+
+
+@potcar.command()
+@with_dbenv
+def migratefamilies():
+    """
+    Migrate the type_string associated with the potcar family groups.
+
+    Previously, these groups has type_string: data.vasp.potcar.family.
+    Since AiiDA 1.2, groups used by plugins should be defined by subclass and entrypoint names.
+    This commands recreates the old style group using the ``PotcarGroup`` class.
+    """
+    from aiida_vasp.data.potcar import migrate_potcar_group
+    migrate_potcar_group()

--- a/aiida_vasp/commands/potcar.py
+++ b/aiida_vasp/commands/potcar.py
@@ -67,7 +67,7 @@ def detect_old_style_groups():
 @options.DESCRIPTION(help='A description for the family.', callback=try_grab_description)
 @click.option('--stop-if-existing', is_flag=True, help='An option to abort when encountering a previously uploaded POTCAR file.')
 @options.DRY_RUN()
-@with_dbenv
+@with_dbenv()
 def uploadfamily(path, name, description, stop_if_existing, dry_run):
     """Upload a family of VASP potcar files."""
 
@@ -88,7 +88,7 @@ def uploadfamily(path, name, description, stop_if_existing, dry_run):
 @click.option('-e', '--element', multiple=True, help='Filter for families containing potentials for all given elements.')
 @click.option('-s', '--symbol', multiple=True, help='Filter for families containing potentials for all given symbols.')
 @click.option('-d', '--description', is_flag=True, help='Also show the description.')
-@with_dbenv
+@with_dbenv()
 def listfamilies(element, symbol, description):
     """List available families of VASP potcar files."""
     detect_old_style_groups()
@@ -119,7 +119,7 @@ def listfamilies(element, symbol, description):
 @options.DRY_RUN(help='Only display what would be exported.')
 @click.option('-z', '--as-archive', is_flag=True, help='Create a compressed archive (.tar.gz) instead of a folder.')
 @click.option('-v', '--verbose', is_flag=True, help='Print the names of all created files.')
-@with_dbenv
+@with_dbenv()
 def exportfamily(path, name, dry_run, as_archive, verbose):
     """Export a POTCAR family into a compressed tar archive or folder."""
     potcar_data_cls = get_data_class('vasp.potcar')
@@ -139,7 +139,7 @@ def exportfamily(path, name, dry_run, as_archive, verbose):
 
 
 @potcar.command()
-@with_dbenv
+@with_dbenv()
 def migratefamilies():
     """
     Migrate the type_string associated with the potcar family groups.

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -149,7 +149,7 @@ def migrate_potcar_group():
     Migrate existing potcar family groups to new specification.
     This creates copies of the old potcar family groups using the new `PotcarGroup` class.
 
-    Despite the name 'migrate', the potcar family gorups created are in fact left as they are.
+    Despite the name 'migrate', the potcar family group created are in fact left as they are.
     """
     qdb = QueryBuilder()
     qdb.append(Group, filters={'type_string': OLD_POTCAR_FAMILY_TYPE})
@@ -162,9 +162,9 @@ def migrate_potcar_group():
         new_group.store()
         migrated.append(new_group.label)
         if created:
-            print('Created new style Group for <{}>'.format(old_group.label))
+            print('Created new style Group <{}> for <{}>'.format(new_group, old_group.label))
         else:
-            print(('Adding nodes to existing group <{}>'.format(old_group.label)))
+            print('Adding nodes to existing new style Group <{}> from <{}>'.format(new_group, old_group.label))
 
 
 def normalize_potcar_contents(potcar_contents):

--- a/aiida_vasp/data/potcar.py
+++ b/aiida_vasp/data/potcar.py
@@ -109,7 +109,7 @@ The mechanism for writing one or more PotcarData to file (from a calculation)::
             use Potcar.write_file
 
 """
-# pylint: disable=import-outside-toplevel
+# pylint: disable=import-outside-toplevel, too-many-lines
 from __future__ import print_function
 
 import re
@@ -124,7 +124,6 @@ from collections import namedtuple
 from pathlib import Path
 from pymatgen.io.vasp import PotcarSingle
 from aiida.common import AIIDA_LOGGER as aiidalogger
-from aiida.common.utils import classproperty
 from aiida.common.exceptions import UniquenessError, NotExistent
 from aiida.orm import Group
 from aiida.orm import Data
@@ -133,6 +132,39 @@ from aiida.orm import QueryBuilder
 from aiida_vasp.data.archive import ArchiveData
 from aiida_vasp.utils.aiida_utils import get_current_user, querybuild
 from aiida_vasp.utils.delegates import delegate_method_kwargs
+
+# Records for the group type strings old and new
+POTCAR_FAMILY_TYPE = 'vasp.potcar'
+OLD_POTCAR_FAMILY_TYPE = 'data.vasp.potcar.family'
+
+
+class PotcarGroup(Group):
+    """
+    A group for holding PotcarData objects that maps to various collections of POTCARs.
+    """
+
+
+def migrate_potcar_group():
+    """
+    Migrate existing potcar family groups to new specification.
+    This creates copies of the old potcar family groups using the new `PotcarGroup` class.
+
+    Despite the name 'migrate', the potcar family gorups created are in fact left as they are.
+    """
+    qdb = QueryBuilder()
+    qdb.append(Group, filters={'type_string': OLD_POTCAR_FAMILY_TYPE})
+
+    migrated = []
+    created = []
+    for (old_group,) in qdb.iterall():
+        new_group, created = PotcarGroup.objects.get_or_create(label=old_group.label, description=old_group.description)
+        new_group.add_nodes(list(old_group.nodes))
+        new_group.store()
+        migrated.append(new_group.label)
+        if created:
+            print('Created new style Group for <{}>'.format(old_group.label))
+        else:
+            print(('Adding nodes to existing group <{}>'.format(old_group.label)))
 
 
 def normalize_potcar_contents(potcar_contents):
@@ -568,8 +600,6 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
     _plugin_type_string = 'data.vasp.potcar.PotcarData.'
     _VERSION = 1
 
-    GROUP_TYPE = 'data.vasp.potcar.family'
-
     def __init__(self, **kwargs):
         potcar_file_node = kwargs.pop('potcar_file_node', None)
         super(PotcarData, self).__init__(**kwargs)
@@ -629,17 +659,13 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
 
     def get_family_names(self):
         """List potcar families to which this instance belongs."""
-        return [group.label for group in Group.query(nodes=self, type_string=self.potcar_family_type_string)]
-
-    @classproperty
-    def potcar_family_type_string(cls):  # pylint: disable=no-self-argument
-        return cls.GROUP_TYPE
+        return [group.label for group in PotcarGroup.query(nodes=self)]
 
     @classmethod
     def get_potcar_group(cls, group_name):
         """Return the PotcarFamily group with the given name."""
         try:
-            group = Group.get(label=group_name, type_string=cls.potcar_family_type_string)
+            group = PotcarGroup.get(label=group_name)
         except NotExistent:
             group = None
         return group
@@ -656,13 +682,7 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
         :param filter_symbols: list of strings with symbols to filter for.
         """
         group_query = QueryBuilder()
-        group_query.append(Group,
-                           with_node='potcar_data',
-                           tag='potcar_data',
-                           filters={'type_string': {
-                               '==': cls.potcar_family_type_string
-                           }},
-                           project='*')
+        group_query.append(PotcarGroup, with_node='potcar_data', tag='potcar_data', project='*')
 
         groups = [group_list[0] for group_list in group_query.all()]
 
@@ -670,11 +690,9 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
             for element in filter_elements:
                 idx_has_element = []
                 for i, group in enumerate(groups):
-                    group_filters = {'label': {'==': group.label}, 'type_string': {'==': cls.potcar_family_type_string}}
-                    element_filters = {'attributes.element': {'==': element}}
                     elem_query = QueryBuilder()
-                    elem_query.append(Group, tag='family', filters=group_filters)
-                    elem_query.append(cls, tag='potcar', with_group='family', filters=element_filters)
+                    elem_query.append(PotcarGroup, tag='family', filters={'label': {'==': group.label}})
+                    elem_query.append(cls, tag='potcar', with_group='family', filters={'attributes.element': {'==': element}})
                     if elem_query.count() > 0:
                         idx_has_element.append(i)
                 groups = [groups[i] for i in range(len(groups)) if i in idx_has_element]
@@ -683,11 +701,9 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
             for symbol in filter_symbols:
                 idx_has_symbol = []
                 for i, group in enumerate(groups):
-                    group_filters = {'label': {'==': group.label}, 'type_string': {'==': cls.potcar_family_type_string}}
-                    symbol_filters = {'attributes.symbol': {'==': symbol}}
                     symbol_query = QueryBuilder()
-                    symbol_query.append(Group, tag='family', filters=group_filters)
-                    symbol_query.append(cls, tag='potcar', with_group='family', filters=symbol_filters)
+                    symbol_query.append(PotcarGroup, tag='family', filters={'label': {'==': group.label}})
+                    symbol_query.append(cls, tag='potcar', with_group='family', filters={'attributes.symbol': {'==': symbol}})
                     if symbol_query.count() > 0:
                         idx_has_symbol.append(i)
                 groups = [groups[i] for i in range(len(groups)) if i in idx_has_symbol]
@@ -713,10 +729,10 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
         """
         if not mapping:
             mapping = {element: element for element in elements}
-        group_filters = {'label': {'==': family_name}, 'type_string': {'==': cls.potcar_family_type_string}}
+        group_filters = {'label': {'==': family_name}}
         element_filters = {'attributes.full_name': {'in': [mapping[element] for element in elements]}}
         query = QueryBuilder()
-        query.append(Group, tag='family', filters=group_filters)
+        query.append(PotcarGroup, tag='family', filters=group_filters)
         query.append(cls, tag='potcar', with_group='family', filters=element_filters)
 
         result_potcars = {}
@@ -739,9 +755,9 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
     def query_by_attrs(cls, query=None, **kwargs):
         family_name = kwargs.pop('family_name', None)
         if family_name:
-            group_filters = {'label': {'==': family_name}, 'type_string': {'==': cls.potcar_family_type_string}}
+            group_filters = {'label': {'==': family_name}}
             query = QueryBuilder()
-            query.append(Group, tag='family', filters=group_filters)
+            query.append(PotcarGroup, tag='family', filters=group_filters)
             query.append(cls, tag=cls._query_label, with_group='family')
         return super(PotcarData, cls).query_by_attrs(query=query, **kwargs)
 
@@ -814,7 +830,7 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
     def _prepare_group_for_upload(cls, group_name, group_description=None, dry_run=False):
         """Prepare a (possibly new) group to upload a POTCAR family to."""
         if not dry_run:
-            group, group_created = Group.objects.get_or_create(label=group_name, type_string=cls.potcar_family_type_string)
+            group, group_created = PotcarGroup.objects.get_or_create(label=group_name)
         else:
             group = cls.get_potcar_group(group_name)
             group_created = bool(not group)
@@ -987,8 +1003,8 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
         if not family:
             return super(PotcarData, cls).find(**kwargs)
         query = cls.query_by_attrs(**kwargs)
-        group_filters = {'label': {'==': family}, 'type_string': {'==': cls.potcar_family_type_string}}
-        query.append(Group, tag='family', filters=group_filters, with_node=cls._query_label)
+        group_filters = {'label': {'==': family}}
+        query.append(PotcarGroup, tag='family', filters=group_filters, with_node=cls._query_label)
         query.add_projection(cls._query_label, '*')
         if not query.count():
             raise NotExistent()

--- a/aiida_vasp/utils/extended_dicts.py
+++ b/aiida_vasp/utils/extended_dicts.py
@@ -4,7 +4,7 @@ Extensions of dictionaries.
 ---------------------------
 Extensions of Pythons standard dict as well as Aiida's AttributeDict.
 """
-import collections
+import collections.abc
 from copy import deepcopy
 
 from aiida.common.extendeddicts import AttributeDict
@@ -65,7 +65,7 @@ def update_nested_dict(dict1, dict2):
     """Updated a nested dictionary, where dict1 is updated with values in dict2."""
     for key, value in dict2.items():
         dict1_value = dict1.get(key)
-        if isinstance(value, collections.Mapping) and isinstance(dict1_value, collections.Mapping):
+        if isinstance(value, collections.abc.Mapping) and isinstance(dict1_value, collections.abc.Mapping):
             update_nested_dict(dict1_value, value)
         else:
             dict1[key] = deepcopy(value)

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -31,6 +31,7 @@ from aiida_vasp.parsers.file_parsers.vasprun import VasprunParser
 from aiida_vasp.parsers.file_parsers.outcar import OutcarParser
 from aiida_vasp.utils.general import copytree
 from aiida_vasp.parsers.file_parsers.stream import StreamParser
+from aiida_vasp.data.potcar import OLD_POTCAR_FAMILY_TYPE, PotcarGroup, Group
 
 POTCAR_FAMILY_NAME = 'test_family'
 POTCAR_MAP = {'In': 'In_sv', 'In_d': 'In_d', 'As': 'As', 'Ga': 'Ga', 'Si': 'Si', 'P': 'P', 'S': 'S', 'Zn': 'Zn'}
@@ -123,6 +124,28 @@ def potcar_family(fresh_aiida_env, temp_pot_folder):
     assert 'In_d' in potcar_cls.get_full_names(POTCAR_FAMILY_NAME, 'In')
     assert not potcar_ga.exists()
     return family_name
+
+
+@pytest.fixture
+def legacy_potcar_family(potcar_family):
+    """
+    Fixture from creating an legacy potcar group
+
+    Returns a tuple of group label and the LegacyPotcarGroup with the old type_string
+    """
+
+    class LegacyPotcarGroup(Group):
+        """Old style group with the old type string"""
+
+    # Override the _type_string class property which is supposed to be loaded from the entrypoint.
+    LegacyPotcarGroup._type_string = OLD_POTCAR_FAMILY_TYPE
+    new_group = PotcarGroup.objects.get(label=potcar_family)
+    old_group = LegacyPotcarGroup(label=potcar_family + '_migrate_test')
+    old_group.store()
+
+    # Add the nodes from the new group to the old group
+    old_group.add_nodes(list(new_group.nodes))
+    return old_group.label, LegacyPotcarGroup
 
 
 @pytest.fixture

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -45,9 +45,9 @@ def localhost_dir(tmp_path_factory):
 def localhost(fresh_aiida_env, localhost_dir):
     """Fixture for a local computer called localhost. This is currently not in the AiiDA fixtures."""
     try:
-        computer = Computer.objects.get(name='localhost')
+        computer = Computer.objects.get(label='localhost')
     except NotExistent:
-        computer = Computer(name='localhost',
+        computer = Computer(label='localhost',
                             hostname='localhost',
                             transport_type='local',
                             scheduler_type='direct',

--- a/aiida_vasp/utils/workchains.py
+++ b/aiida_vasp/utils/workchains.py
@@ -26,7 +26,6 @@ def prepare_process_inputs(inputs, namespaces=None, exclude_parameters=None):
     namespaces. They all should remain a standard dictionary. Another exception are dictionaries
     whose keys are not strings but for example tuples.
     """
-    from past.builtins import basestring
     prepared_inputs = AttributeDict()
 
     if namespaces is None:
@@ -39,7 +38,7 @@ def prepare_process_inputs(inputs, namespaces=None, exclude_parameters=None):
     no_dict = no_dict + namespaces
     # Copy and convert dict
     for key, val in inputs.items():
-        if (key not in no_dict and isinstance(val, dict) and all([isinstance(k, (basestring)) for k in val.keys()])):
+        if (key not in no_dict and isinstance(val, dict) and all([isinstance(k, str) for k in val.keys()])):
             prepared_inputs[key] = Dict(dict=val)
         else:
             prepared_inputs[key] = val

--- a/aiida_vasp/workchains/tests/test_bands_wc.py
+++ b/aiida_vasp/workchains/tests/test_bands_wc.py
@@ -21,7 +21,7 @@ from aiida_vasp.utils.aiida_utils import create_authinfo
 
 
 # @pytest.mark.skip(reason='Currently fails, need to find a better way to eject logs etc.')
-@pytest.mark.wc
+#@pytest.mark.wc
 def test_bands_wc(fresh_aiida_env, potentials, mock_vasp):
     """Test with mocked vasp code."""
     from aiida.orm import Code, Log, RemoteData

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,16 @@
 [pytest]
 testpaths = aiida_vasp
+filterwarnings =
+    ignore:POTCAR data with symbol .* does not match any VASP
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' in deprecated
+    ignore::DeprecationWarning:babel:
+    ignore::DeprecationWarning:django:
+    ignore::DeprecationWarning:frozendict:
+    ignore::DeprecationWarning:sqlalchemy:
+    ignore::DeprecationWarning:yaml:
+    ignore::DeprecationWarning:pymatgen:
+    ignore::DeprecationWarning:jsonbackend:
+    ignore::DeprecationWarning:reentry:
+    ignore::DeprecationWarning:past:
+    ignore::DeprecationWarning:pkg_resources:
+    ignore::pytest.PytestCollectionWarning

--- a/setup.json
+++ b/setup.json
@@ -50,6 +50,9 @@
 	    "vasp.master = aiida_vasp.workchains.master:MasterWorkChain",
 	    "vasp.relax = aiida_vasp.workchains.relax:RelaxWorkChain"
 	],
+	"aiida.groups": [
+		"vasp.potcar = aiida_vasp.data.potcar:PotcarGroup"
+	],
 	"console_scripts": [
 	    "mock-vasp = aiida_vasp.commands.mock_vasp:mock_vasp"
 	]


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

This is still a work in progress. I have made code changes to remove various deprecation warnings that were issued by aiida-core 1.x. 

The major change is the implementation of the pseudopotential family - correct use of the new (not anymore!) `Group` class will break the backward compatibility, but this can be fixed easily by performing a migration on the existing groups. 

