### PR TITLE
Compare floats with pytest.approx in tests

### DIFF
--- a/aiida_vasp/assistant/tests/test_parameters.py
+++ b/aiida_vasp/assistant/tests/test_parameters.py
@@ -64,7 +64,7 @@ def test_relax_parameters_all_set(init_relax_parameters):
     """Test all standard relaxation parameters are set."""
     massager = ParametersMassage(init_relax_parameters)
     parameters = massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE]
-    assert parameters.ediffg == -0.01
+    assert parameters.ediffg == pytest.approx(-0.01)
     assert parameters.ibrion == 2
     assert parameters.nsw == 60
     assert parameters.isif == 3

--- a/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_incar_parser.py
@@ -26,7 +26,7 @@ def test_parser_read(fresh_aiida_env):
     incar = parser.incar
     assert incar['prec'] == 'Accurate'
     assert incar['ibrion'] == -1
-    assert incar['encut'] == 359.7399
+    assert incar['encut'] == pytest.approx(359.7399)
     assert incar['lreal'] is False
 
 

--- a/aiida_vasp/parsers/file_parsers/tests/test_outcar_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_outcar_parser.py
@@ -97,8 +97,8 @@ def test_parameter_results(fresh_aiida_env, outcar_parser):
     np.testing.assert_allclose(data_dict['elastic_moduli']['total'][3], test)
 
     assert data_dict['run_stats']
-    assert data_dict['run_stats']['total_cpu_time_used'] == 89.795
-    assert data_dict['run_stats']['average_memory_used'] == 0.0
+    assert data_dict['run_stats']['total_cpu_time_used'] == pytest.approx(89.795)
+    assert data_dict['run_stats']['average_memory_used'] == pytest.approx(0.0)
 
     assert data_dict['run_status']['last_iteration_index'] == [15, 5]
     assert data_dict['run_status']['finished']

--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -66,8 +66,8 @@ def test_kpoints(fresh_aiida_env, vasprun_parser):
 
     ref_class = get_data_class('array.kpoints')
     assert isinstance(data_obj, ref_class)
-    assert np.all(data_obj.get_kpoints()[0] == np.array([0.0, 0.0, 0.0]))
-    assert np.all(data_obj.get_kpoints()[-1] == np.array([0.42857143, -0.42857143, 0.42857143]))
+    assert np.allclose(data_obj.get_kpoints()[0], np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(data_obj.get_kpoints()[-1], np.array([0.42857143, -0.42857143, 0.42857143]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -86,12 +86,12 @@ def test_structure(fresh_aiida_env, vasprun_parser):
     assert isinstance(data_obj, ref_obj)
     # check cell
     unitcell = data_obj.cell
-    assert np.all(unitcell[0] == np.array([5.46503124, 0.0, 0.0]))
-    assert np.all(unitcell[1] == np.array([0.0, 5.46503124, 0.0]))
-    assert np.all(unitcell[2] == np.array([0.0, 0.0, 5.46503124]))
+    assert np.allclose(unitcell[0], np.array([5.46503124, 0.0, 0.0]))
+    assert np.allclose(unitcell[1], np.array([0.0, 5.46503124, 0.0]))
+    assert np.allclose(unitcell[2], np.array([0.0, 0.0, 5.46503124]))
     # check first and last position
-    assert np.all(data_obj.sites[0].position == np.array([0.0, 0.0, 0.0]))
-    assert np.all(data_obj.sites[7].position == np.array([4.09877343, 4.09877343, 1.36625781]))
+    assert np.allclose(data_obj.sites[0].position, np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(data_obj.sites[7].position, np.array([4.09877343, 4.09877343, 1.36625781]))
     # check volume
     assert data_obj.get_cell_volume() == np.float(163.22171870360754)
 
@@ -111,9 +111,9 @@ def test_final_force(fresh_aiida_env, vasprun_parser):
 
     forces = data_obj.get_array('final')
     # check first, third and last position
-    assert np.all(forces[0] == forces_check[0])
-    assert np.all(forces[2] == forces_check[2])
-    assert np.all(forces[7] == forces_check[7])
+    assert np.allclose(forces[0], forces_check[0])
+    assert np.allclose(forces[2], forces_check[2])
+    assert np.allclose(forces[7], forces_check[7])
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -129,9 +129,9 @@ def test_final_stress(fresh_aiida_env, vasprun_parser):
                              [0.00000000, -25.93894358, 12.52362644]])
     stress = data_obj.get_array('final')
     # check entries
-    assert np.all(stress[0] == stress_check[0])
-    assert np.all(stress[1] == stress_check[1])
-    assert np.all(stress[2] == stress_check[2])
+    assert np.allclose(stress[0], stress_check[0])
+    assert np.allclose(stress[1], stress_check[1])
+    assert np.allclose(stress[2], stress_check[2])
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -152,17 +152,17 @@ def test_traj_forces(fresh_aiida_env, vasprun_parser):
     assert isinstance(data_obj, ref_obj)
     data_obj_arr = data_obj.get_array('forces')
     # test entries
-    assert np.all(data_obj_arr[0][0] == np.array([-0.24286901, 0.0, 0.0]))
-    assert np.all(data_obj_arr[0][-1] == np.array([-0.73887169, -0.43727184, -0.43727184]))
+    assert np.allclose(data_obj_arr[0][0], np.array([-0.24286901, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]))
     # test object
     ref_obj = get_data_class('array.trajectory')
     assert isinstance(data_obj, ref_obj)
     data_obj = data_obj.get_array('forces')
     # test entries
-    assert np.all(data_obj[0][0] == np.array([-0.24286901, 0.0, 0.0]))
-    assert np.all(data_obj[0][-1] == np.array([-0.73887169, -0.43727184, -0.43727184]))
-    assert np.all(data_obj[0][-1] == data_obj[1][-1])
-    assert np.all(data_obj[0][0] == data_obj[1][0])
+    assert np.allclose(data_obj[0][0], np.array([-0.24286901, 0.0, 0.0]))
+    assert np.allclose(data_obj[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]))
+    assert np.allclose(data_obj[0][-1], data_obj[1][-1])
+    assert np.allclose(data_obj[0][0], data_obj[1][0])
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -184,10 +184,10 @@ def test_traj_forces_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 8, 3)
     # test a few entries (first and last atom)
-    assert np.all(data_obj_arr[0][0] == np.array([-2.42632080e-01, 0.0, 0.0]))
-    assert np.all(data_obj_arr[0][-1] == np.array([-7.38879520e-01, -4.37063010e-01, -4.37063010e-01]))
-    assert np.all(data_obj_arr[-1][0] == np.array([1.55852000e-03, 0.0, 0.0]))
-    assert np.all(data_obj_arr[-1][-1] == np.array([-1.75970000e-03, 1.12150000e-04, 1.12150000e-04]))
+    assert np.allclose(data_obj_arr[0][0], np.array([-2.42632080e-01, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[0][-1], np.array([-7.38879520e-01, -4.37063010e-01, -4.37063010e-01]))
+    assert np.allclose(data_obj_arr[-1][0], np.array([1.55852000e-03, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[-1][-1], np.array([-1.75970000e-03, 1.12150000e-04, 1.12150000e-04]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -209,10 +209,10 @@ def test_unitcells_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 3, 3)
     # test a few entries (first and last vector)
-    assert np.all(data_obj_arr[0][0] == np.array([5.46503124e+00, 0.0, 0.0]))
-    assert np.all(data_obj_arr[0][-1] == np.array([0.0, 0.0, 5.46503124e+00]))
-    assert np.all(data_obj_arr[-1][0] == np.array([5.46702248e+00, 0.0, 0.0]))
-    assert np.all(data_obj_arr[-1][-1] == np.array([0.0, 2.19104000e-03, 5.46705225e+00]))
+    assert np.allclose(data_obj_arr[0][0], np.array([5.46503124e+00, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[0][-1], np.array([0.0, 0.0, 5.46503124e+00]))
+    assert np.allclose(data_obj_arr[-1][0], np.array([5.46702248e+00, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[-1][-1], np.array([0.0, 2.19104000e-03, 5.46705225e+00]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -234,10 +234,10 @@ def test_positions_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 8, 3)
     # test a few entries (first and last atom)
-    assert np.all(data_obj_arr[0][0] == np.array([0.0, 0.0, 0.0]))
-    assert np.all(data_obj_arr[0][-1] == np.array([0.75, 0.75, 0.25]))
-    assert np.all(data_obj_arr[-1][0] == np.array([-0.00621692, 0.0, 0.0]))
-    assert np.all(data_obj_arr[-1][-1] == np.array([0.7437189, 0.74989833, 0.24989833]))
+    assert np.allclose(data_obj_arr[0][0], np.array([0.0, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[0][-1], np.array([0.75, 0.75, 0.25]))
+    assert np.allclose(data_obj_arr[-1][0], np.array([-0.00621692, 0.0, 0.0]))
+    assert np.allclose(data_obj_arr[-1][-1], np.array([0.7437189, 0.74989833, 0.24989833]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('dielectric', {})], indirect=True)
@@ -262,13 +262,13 @@ def test_dielectrics(fresh_aiida_env, vasprun_parser):
     assert real.shape == (1000, 6)
     assert energy.shape == (1000,)
     # test a few entries
-    assert np.all(imag[0] == np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.all(imag[500] == np.array([0.0933, 0.0924, 0.0924, 0.0, 0.0082, 0.0]))
+    assert np.allclose(imag[0], np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(imag[500], np.array([0.0933, 0.0924, 0.0924, 0.0, 0.0082, 0.0]))
 
-    assert np.all(imag[999] == np.array([0.0035, 0.0035, 0.0035, 0.0, 0.0, 0.0]))
-    assert np.all(real[0] == np.array([12.0757, 11.4969, 11.4969, 0.0, 0.6477, 0.0]))
-    assert np.all(real[500] == np.array([-0.5237, -0.5366, -0.5366, 0.0, 0.0134, 0.0]))
-    assert np.all(real[999] == np.array([6.57100000e-01, 6.55100000e-01, 6.55100000e-01, 0.0, -1.00000000e-04, 0.0]))
+    assert np.allclose(imag[999], np.array([0.0035, 0.0035, 0.0035, 0.0, 0.0, 0.0]))
+    assert np.allclose(real[0], np.array([12.0757, 11.4969, 11.4969, 0.0, 0.6477, 0.0]))
+    assert np.allclose(real[500], np.array([-0.5237, -0.5366, -0.5366, 0.0, 0.0134, 0.0]))
+    assert np.allclose(real[999], np.array([6.57100000e-01, 6.55100000e-01, 6.55100000e-01, 0.0, -1.00000000e-04, 0.0]))
     assert energy[500] == pytest.approx(10.2933)
 
 
@@ -316,9 +316,9 @@ def test_born(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert born.shape == (8, 3, 3)
     # test a few entries
-    assert np.all(born[0][0] == np.array([6.37225000e-03, 0.0, 0.0]))
-    assert np.all(born[0][-1] == np.array([-4.21760000e-04, -2.19570210e-01, 3.20709600e-02]))
-    assert np.all(born[4][0] == np.array([1.68565200e-01, -2.92058000e-02, -2.92058000e-02]))
+    assert np.allclose(born[0][0], np.array([6.37225000e-03, 0.0, 0.0]))
+    assert np.allclose(born[0][-1], np.array([-4.21760000e-04, -2.19570210e-01, 3.20709600e-02]))
+    assert np.allclose(born[4][0], np.array([1.68565200e-01, -2.92058000e-02, -2.92058000e-02]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -392,8 +392,8 @@ def test_pdos(fresh_aiida_env, vasprun_parser):
     assert dos.shape == (8, 1000, 9)
     assert energy.shape == (1000,)
     # test a few entries
-    assert np.all(dos[3, 500] == np.array([0.0770, 0.0146, 0.0109, 0.0155, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.all(dos[7, 500] == np.array([0.0747, 0.0121, 0.0092, 0.0116, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(dos[3, 500], np.array([0.0770, 0.0146, 0.0109, 0.0155, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(dos[7, 500], np.array([0.0747, 0.0121, 0.0092, 0.0116, 0.0, 0.0, 0.0, 0.0, 0.0]))
     assert energy[500] == pytest.approx(0.01)
 
 
@@ -415,9 +415,9 @@ def test_projectors(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert proj.shape == (8, 64, 21, 9)
     # test a few entries
-    assert np.all(proj[0, 0, 5] == np.array([0.0, 0.012, 0.0123, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.all(proj[7, 0, 5] == np.array([0.1909, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.all(proj[4, 3, 5] == np.array([0.2033, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(proj[0, 0, 5], np.array([0.0, 0.012, 0.0123, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(proj[7, 0, 5], np.array([0.1909, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    assert np.allclose(proj[4, 3, 5], np.array([0.2033, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -689,16 +689,22 @@ def test_hessian(fresh_aiida_env, vasprun_parser):
     # test shape
     assert hessian.shape == (24, 24)
     # test a few entries
-    assert np.all(hessian[0] == np.array([
-        -4.63550410e-01, 0.00000000e+00, 0.00000000e+00, -5.91774100e-02, 0.00000000e+00, 0.00000000e+00, 3.09711000e-02, 0.00000000e+00,
-        0.00000000e+00, 3.20435400e-02, 0.00000000e+00, 0.00000000e+00, 1.15129840e-01, -8.16138200e-02, 8.17234700e-02, 1.14879520e-01,
-        8.11324800e-02, 8.27409500e-02, 1.14879520e-01, -8.11324800e-02, -8.27409500e-02, 1.15129840e-01, 8.16138200e-02, -8.17234700e-02
-    ]))
-    assert np.all(hessian[-2] == np.array([
-        8.16138200e-02, 1.15195590e-01, -8.38411100e-02, -8.17234700e-02, 1.14875090e-01, -8.53388100e-02, 3.46686900e-02, 7.00672700e-02,
-        2.54288300e-02, -8.26222700e-02, 1.16185510e-01, 7.95575600e-02, -3.05970000e-04, 3.16827300e-02, 2.86379000e-03, 5.42080000e-04,
-        3.27613500e-02, 1.12576000e-03, -1.34305000e-03, -5.86811100e-02, 2.83374000e-03, 4.91688400e-02, -4.22101090e-01, 5.73736900e-02
-    ]))
+    assert np.allclose(
+        hessian[0],
+        np.array([
+            -4.63550410e-01, 0.00000000e+00, 0.00000000e+00, -5.91774100e-02, 0.00000000e+00, 0.00000000e+00, 3.09711000e-02,
+            0.00000000e+00, 0.00000000e+00, 3.20435400e-02, 0.00000000e+00, 0.00000000e+00, 1.15129840e-01, -8.16138200e-02, 8.17234700e-02,
+            1.14879520e-01, 8.11324800e-02, 8.27409500e-02, 1.14879520e-01, -8.11324800e-02, -8.27409500e-02, 1.15129840e-01,
+            8.16138200e-02, -8.17234700e-02
+        ]))
+    assert np.allclose(
+        hessian[-2],
+        np.array([
+            8.16138200e-02, 1.15195590e-01, -8.38411100e-02, -8.17234700e-02, 1.14875090e-01, -8.53388100e-02, 3.46686900e-02,
+            7.00672700e-02, 2.54288300e-02, -8.26222700e-02, 1.16185510e-01, 7.95575600e-02, -3.05970000e-04, 3.16827300e-02,
+            2.86379000e-03, 5.42080000e-04, 3.27613500e-02, 1.12576000e-03, -1.34305000e-03, -5.86811100e-02, 2.83374000e-03,
+            4.91688400e-02, -4.22101090e-01, 5.73736900e-02
+        ]))
 
 
 @pytest.mark.parametrize('vasprun_parser', [('disp', {})], indirect=True)
@@ -721,17 +727,22 @@ def test_dynmat(fresh_aiida_env, vasprun_parser):
     assert dynvec.shape == (24, 24)
     assert dyneig.shape == (24,)
     # test a few entries
-    assert np.all(dynvec[0] == np.array([
-        7.28517310e-17, 7.25431601e-02, -4.51957676e-02, 1.15412776e-16, 4.51957676e-02, -7.25431601e-02, -1.37347223e-16, 5.16257351e-01,
-        -5.16257351e-01, 8.16789156e-17, 8.95098005e-02, -8.95098005e-02, -4.43838008e-17, -6.38031134e-02, 6.38031134e-02, -1.80132830e-01,
-        -2.97969516e-01, 2.97969516e-01, 1.80132830e-01, -2.97969516e-01, 2.97969516e-01, -2.09989969e-16, -6.38031134e-02, 6.38031134e-02
-    ]))
-    assert np.all(dynvec[4] == np.array([
-        -5.29825122e-13, -2.41759046e-01, -3.28913434e-01, -5.30734671e-13, -3.28913434e-01, -2.41759046e-01, 3.26325910e-13,
-        -3.80807441e-02, -3.80807441e-02, -9.22956103e-13, -2.99868012e-01, -2.99868012e-01, 1.64418993e-01, 1.81002749e-01, 1.81002749e-01,
-        3.11984195e-13, 2.73349550e-01, 2.73349550e-01, 2.59853610e-13, 2.73349550e-01, 2.73349550e-01, -1.64418993e-01, 1.81002749e-01,
-        1.81002749e-01
-    ]))
+    assert np.allclose(
+        dynvec[0],
+        np.array([
+            7.28517310e-17, 7.25431601e-02, -4.51957676e-02, 1.15412776e-16, 4.51957676e-02, -7.25431601e-02, -1.37347223e-16,
+            5.16257351e-01, -5.16257351e-01, 8.16789156e-17, 8.95098005e-02, -8.95098005e-02, -4.43838008e-17, -6.38031134e-02,
+            6.38031134e-02, -1.80132830e-01, -2.97969516e-01, 2.97969516e-01, 1.80132830e-01, -2.97969516e-01, 2.97969516e-01,
+            -2.09989969e-16, -6.38031134e-02, 6.38031134e-02
+        ]))
+    assert np.allclose(
+        dynvec[4],
+        np.array([
+            -5.29825122e-13, -2.41759046e-01, -3.28913434e-01, -5.30734671e-13, -3.28913434e-01, -2.41759046e-01, 3.26325910e-13,
+            -3.80807441e-02, -3.80807441e-02, -9.22956103e-13, -2.99868012e-01, -2.99868012e-01, 1.64418993e-01, 1.81002749e-01,
+            1.81002749e-01, 3.11984195e-13, 2.73349550e-01, 2.73349550e-01, 2.59853610e-13, 2.73349550e-01, 2.73349550e-01, -1.64418993e-01,
+            1.81002749e-01, 1.81002749e-01
+        ]))
     assert dyneig[0] == pytest.approx(-1.36621537e+00)
     assert dyneig[4] == pytest.approx(-8.48939361e-01)
 

--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -66,8 +66,8 @@ def test_kpoints(fresh_aiida_env, vasprun_parser):
 
     ref_class = get_data_class('array.kpoints')
     assert isinstance(data_obj, ref_class)
-    assert np.allclose(data_obj.get_kpoints()[0], np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(data_obj.get_kpoints()[-1], np.array([0.42857143, -0.42857143, 0.42857143]))
+    np.testing.assert_allclose(data_obj.get_kpoints()[0], np.array([0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj.get_kpoints()[-1], np.array([0.42857143, -0.42857143, 0.42857143]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -86,12 +86,12 @@ def test_structure(fresh_aiida_env, vasprun_parser):
     assert isinstance(data_obj, ref_obj)
     # check cell
     unitcell = data_obj.cell
-    assert np.allclose(unitcell[0], np.array([5.46503124, 0.0, 0.0]))
-    assert np.allclose(unitcell[1], np.array([0.0, 5.46503124, 0.0]))
-    assert np.allclose(unitcell[2], np.array([0.0, 0.0, 5.46503124]))
+    np.testing.assert_allclose(unitcell[0], np.array([5.46503124, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(unitcell[1], np.array([0.0, 5.46503124, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(unitcell[2], np.array([0.0, 0.0, 5.46503124]), atol=0., rtol=1.0e-7)
     # check first and last position
-    assert np.allclose(data_obj.sites[0].position, np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(data_obj.sites[7].position, np.array([4.09877343, 4.09877343, 1.36625781]))
+    np.testing.assert_allclose(data_obj.sites[0].position, np.array([0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj.sites[7].position, np.array([4.09877343, 4.09877343, 1.36625781]), atol=0., rtol=1.0e-7)
     # check volume
     assert data_obj.get_cell_volume() == np.float(163.22171870360754)
 
@@ -111,9 +111,9 @@ def test_final_force(fresh_aiida_env, vasprun_parser):
 
     forces = data_obj.get_array('final')
     # check first, third and last position
-    assert np.allclose(forces[0], forces_check[0])
-    assert np.allclose(forces[2], forces_check[2])
-    assert np.allclose(forces[7], forces_check[7])
+    np.testing.assert_allclose(forces[0], forces_check[0], atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(forces[2], forces_check[2], atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(forces[7], forces_check[7], atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -129,9 +129,9 @@ def test_final_stress(fresh_aiida_env, vasprun_parser):
                              [0.00000000, -25.93894358, 12.52362644]])
     stress = data_obj.get_array('final')
     # check entries
-    assert np.allclose(stress[0], stress_check[0])
-    assert np.allclose(stress[1], stress_check[1])
-    assert np.allclose(stress[2], stress_check[2])
+    np.testing.assert_allclose(stress[0], stress_check[0], atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(stress[1], stress_check[1], atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(stress[2], stress_check[2], atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -152,17 +152,17 @@ def test_traj_forces(fresh_aiida_env, vasprun_parser):
     assert isinstance(data_obj, ref_obj)
     data_obj_arr = data_obj.get_array('forces')
     # test entries
-    assert np.allclose(data_obj_arr[0][0], np.array([-0.24286901, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]))
+    np.testing.assert_allclose(data_obj_arr[0][0], np.array([-0.24286901, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]), atol=0., rtol=1.0e-7)
     # test object
     ref_obj = get_data_class('array.trajectory')
     assert isinstance(data_obj, ref_obj)
     data_obj = data_obj.get_array('forces')
     # test entries
-    assert np.allclose(data_obj[0][0], np.array([-0.24286901, 0.0, 0.0]))
-    assert np.allclose(data_obj[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]))
-    assert np.allclose(data_obj[0][-1], data_obj[1][-1])
-    assert np.allclose(data_obj[0][0], data_obj[1][0])
+    np.testing.assert_allclose(data_obj[0][0], np.array([-0.24286901, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj[0][-1], np.array([-0.73887169, -0.43727184, -0.43727184]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj[0][-1], data_obj[1][-1], atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj[0][0], data_obj[1][0], atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -184,10 +184,10 @@ def test_traj_forces_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 8, 3)
     # test a few entries (first and last atom)
-    assert np.allclose(data_obj_arr[0][0], np.array([-2.42632080e-01, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[0][-1], np.array([-7.38879520e-01, -4.37063010e-01, -4.37063010e-01]))
-    assert np.allclose(data_obj_arr[-1][0], np.array([1.55852000e-03, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[-1][-1], np.array([-1.75970000e-03, 1.12150000e-04, 1.12150000e-04]))
+    np.testing.assert_allclose(data_obj_arr[0][0], np.array([-2.42632080e-01, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[0][-1], np.array([-7.38879520e-01, -4.37063010e-01, -4.37063010e-01]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][0], np.array([1.55852000e-03, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][-1], np.array([-1.75970000e-03, 1.12150000e-04, 1.12150000e-04]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -209,10 +209,10 @@ def test_unitcells_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 3, 3)
     # test a few entries (first and last vector)
-    assert np.allclose(data_obj_arr[0][0], np.array([5.46503124e+00, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[0][-1], np.array([0.0, 0.0, 5.46503124e+00]))
-    assert np.allclose(data_obj_arr[-1][0], np.array([5.46702248e+00, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[-1][-1], np.array([0.0, 2.19104000e-03, 5.46705225e+00]))
+    np.testing.assert_allclose(data_obj_arr[0][0], np.array([5.46503124e+00, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[0][-1], np.array([0.0, 0.0, 5.46503124e+00]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][0], np.array([5.46702248e+00, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][-1], np.array([0.0, 2.19104000e-03, 5.46705225e+00]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -234,10 +234,10 @@ def test_positions_result_relax(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert data_obj_arr.shape == (19, 8, 3)
     # test a few entries (first and last atom)
-    assert np.allclose(data_obj_arr[0][0], np.array([0.0, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[0][-1], np.array([0.75, 0.75, 0.25]))
-    assert np.allclose(data_obj_arr[-1][0], np.array([-0.00621692, 0.0, 0.0]))
-    assert np.allclose(data_obj_arr[-1][-1], np.array([0.7437189, 0.74989833, 0.24989833]))
+    np.testing.assert_allclose(data_obj_arr[0][0], np.array([0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[0][-1], np.array([0.75, 0.75, 0.25]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][0], np.array([-0.00621692, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(data_obj_arr[-1][-1], np.array([0.7437189, 0.74989833, 0.24989833]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('dielectric', {})], indirect=True)
@@ -262,13 +262,16 @@ def test_dielectrics(fresh_aiida_env, vasprun_parser):
     assert real.shape == (1000, 6)
     assert energy.shape == (1000,)
     # test a few entries
-    assert np.allclose(imag[0], np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(imag[500], np.array([0.0933, 0.0924, 0.0924, 0.0, 0.0082, 0.0]))
+    np.testing.assert_allclose(imag[0], np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(imag[500], np.array([0.0933, 0.0924, 0.0924, 0.0, 0.0082, 0.0]), atol=0., rtol=1.0e-7)
 
-    assert np.allclose(imag[999], np.array([0.0035, 0.0035, 0.0035, 0.0, 0.0, 0.0]))
-    assert np.allclose(real[0], np.array([12.0757, 11.4969, 11.4969, 0.0, 0.6477, 0.0]))
-    assert np.allclose(real[500], np.array([-0.5237, -0.5366, -0.5366, 0.0, 0.0134, 0.0]))
-    assert np.allclose(real[999], np.array([6.57100000e-01, 6.55100000e-01, 6.55100000e-01, 0.0, -1.00000000e-04, 0.0]))
+    np.testing.assert_allclose(imag[999], np.array([0.0035, 0.0035, 0.0035, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(real[0], np.array([12.0757, 11.4969, 11.4969, 0.0, 0.6477, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(real[500], np.array([-0.5237, -0.5366, -0.5366, 0.0, 0.0134, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(real[999],
+                               np.array([6.57100000e-01, 6.55100000e-01, 6.55100000e-01, 0.0, -1.00000000e-04, 0.0]),
+                               atol=0.,
+                               rtol=1.0e-7)
     assert energy[500] == pytest.approx(10.2933)
 
 
@@ -293,9 +296,9 @@ def test_epsilon(fresh_aiida_env, vasprun_parser):
     assert epsilon_ion.shape == (3, 3)
     # test a few entries
     test = np.array([[13.05544887, -0., 0.], [-0., 13.05544887, -0.], [0., 0., 13.05544887]])
-    assert np.allclose(epsilon, test)
+    np.testing.assert_allclose(epsilon, test, atol=0., rtol=1.0e-7)
     test = np.array([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]])
-    assert np.allclose(epsilon_ion, test)
+    np.testing.assert_allclose(epsilon_ion, test, atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('localfield', {})], indirect=True)
@@ -316,9 +319,9 @@ def test_born(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert born.shape == (8, 3, 3)
     # test a few entries
-    assert np.allclose(born[0][0], np.array([6.37225000e-03, 0.0, 0.0]))
-    assert np.allclose(born[0][-1], np.array([-4.21760000e-04, -2.19570210e-01, 3.20709600e-02]))
-    assert np.allclose(born[4][0], np.array([1.68565200e-01, -2.92058000e-02, -2.92058000e-02]))
+    np.testing.assert_allclose(born[0][0], np.array([6.37225000e-03, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(born[0][-1], np.array([-4.21760000e-04, -2.19570210e-01, 3.20709600e-02]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(born[4][0], np.array([1.68565200e-01, -2.92058000e-02, -2.92058000e-02]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -392,8 +395,8 @@ def test_pdos(fresh_aiida_env, vasprun_parser):
     assert dos.shape == (8, 1000, 9)
     assert energy.shape == (1000,)
     # test a few entries
-    assert np.allclose(dos[3, 500], np.array([0.0770, 0.0146, 0.0109, 0.0155, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(dos[7, 500], np.array([0.0747, 0.0121, 0.0092, 0.0116, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_allclose(dos[3, 500], np.array([0.0770, 0.0146, 0.0109, 0.0155, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(dos[7, 500], np.array([0.0747, 0.0121, 0.0092, 0.0116, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
     assert energy[500] == pytest.approx(0.01)
 
 
@@ -415,9 +418,9 @@ def test_projectors(fresh_aiida_env, vasprun_parser):
     # test shape of array
     assert proj.shape == (8, 64, 21, 9)
     # test a few entries
-    assert np.allclose(proj[0, 0, 5], np.array([0.0, 0.012, 0.0123, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(proj[7, 0, 5], np.array([0.1909, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert np.allclose(proj[4, 3, 5], np.array([0.2033, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_allclose(proj[0, 0, 5], np.array([0.0, 0.012, 0.0123, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(proj[7, 0, 5], np.array([0.1909, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(proj[4, 3, 5], np.array([0.2033, 0.0001, 0.0001, 0.0001, 0.0, 0.0, 0.0, 0.0, 0.0]), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -515,15 +518,15 @@ def test_toten(fresh_aiida_env, vasprun_parser):
     assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
     energies = data_obj.get_array('energy_extrapolated')
     test_array = np.array([-42.91113621])
-    assert np.allclose(test_array, energies)
+    np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
     # Test number of entries
     assert energies.shape == (1,)
     # Electronic steps should be one
     test_array = np.array([1])
-    assert np.allclose(test_array, data_obj.get_array('electronic_steps'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
     test_array = np.array([-0.00236711])
-    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {'energy_type': ['energy_free', 'energy_no_entropy']})], indirect=True)
@@ -542,12 +545,12 @@ def test_toten_multiple(fresh_aiida_env, vasprun_parser):
     assert set(data_obj.get_arraynames()) == set(
         ['electronic_steps', 'energy_free', 'energy_free_final', 'energy_no_entropy', 'energy_no_entropy_final'])
     test_array = np.array([-42.91231976])
-    assert np.allclose(test_array, data_obj.get_array('energy_free'))
-    assert np.allclose(test_array, data_obj.get_array('energy_free_final'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_free'), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_free_final'), atol=0., rtol=1.0e-7)
     test_array = np.array([-42.90995265])
-    assert np.allclose(test_array, data_obj.get_array('energy_no_entropy'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_no_entropy'), atol=0., rtol=1.0e-7)
     test_array = np.array([-42.91113621])
-    assert np.allclose(test_array, data_obj.get_array('energy_no_entropy_final'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_no_entropy_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {'electronic_step_energies': True})], indirect=True)
@@ -568,15 +571,15 @@ def test_toten_electronic(fresh_aiida_env, vasprun_parser):
     assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
     energies = data_obj.get_array('energy_extrapolated')
     test_array = np.array([-42.91113666, -42.91113621])
-    assert np.allclose(test_array, energies)
+    np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
     # Test number of entries
     assert energies.shape == (2,)
     # Electronic steps should be two
     test_array = np.array([2])
-    assert np.allclose(test_array, data_obj.get_array('electronic_steps'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
     test_array = np.array([-0.00236711])
-    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -601,17 +604,17 @@ def test_toten_relax(fresh_aiida_env, vasprun_parser):
         -43.39087657
     ])
     # Test energies
-    assert np.allclose(test_array, energies)
+    np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
     # Test number of entries
     assert energies.shape == test_array.shape
     # Electronic steps should be entries times one
-    assert np.allclose(np.ones(19, dtype=int), data_obj.get_array('electronic_steps'))
+    np.testing.assert_allclose(np.ones(19, dtype=int), data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
     test_array = np.array([
         -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
         -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
     ])
-    assert np.allclose(test_array, data_obj.get_array('energy_extrapolated_final'))
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {'electronic_step_energies': True})], indirect=True)
@@ -661,14 +664,14 @@ def test_toten_relax_electronic(fresh_aiida_env, vasprun_parser):
     for ionic_step in test_array_energies:
         test_array_energies_flattened = np.append(test_array_energies_flattened, ionic_step)
     assert energies.shape == test_array_energies_flattened.shape
-    assert np.allclose(test_array_energies_flattened, energies)
-    assert np.allclose(test_array_steps, data_obj.get_array('electronic_steps'))
+    np.testing.assert_allclose(test_array_energies_flattened, energies, atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(test_array_steps, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     test_array_energies = np.array([
         -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
         -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
     ])
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
-    assert np.allclose(test_array_energies, data_obj.get_array('energy_extrapolated_final'))
+    np.testing.assert_allclose(test_array_energies, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('disp', {})], indirect=True)

--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -50,11 +50,11 @@ def test_parameter_results(fresh_aiida_env, vasprun_parser):
     ref_class = get_data_class('dict')
     assert isinstance(data_obj, ref_class)
     data_dict = data_obj.get_dict()
-    assert data_dict['fermi_level'] == 5.96764939
-    assert data_dict['total_energies']['energy_extrapolated'] == -42.91113621
-    assert data_dict['energies']['energy_extrapolated'][0] == -42.91113621
-    assert data_dict['maximum_stress'] == 28.803993008871014
-    assert data_dict['maximum_force'] == 3.41460162
+    assert data_dict['fermi_level'] == pytest.approx(5.96764939)
+    assert data_dict['total_energies']['energy_extrapolated'] == pytest.approx(-42.91113621)
+    assert data_dict['energies']['energy_extrapolated'][0] == pytest.approx(-42.91113621)
+    assert data_dict['maximum_stress'] == pytest.approx(28.803993008871014)
+    assert data_dict['maximum_force'] == pytest.approx(3.41460162)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -269,7 +269,7 @@ def test_dielectrics(fresh_aiida_env, vasprun_parser):
     assert np.all(real[0] == np.array([12.0757, 11.4969, 11.4969, 0.0, 0.6477, 0.0]))
     assert np.all(real[500] == np.array([-0.5237, -0.5366, -0.5366, 0.0, 0.0134, 0.0]))
     assert np.all(real[999] == np.array([6.57100000e-01, 6.55100000e-01, 6.55100000e-01, 0.0, -1.00000000e-04, 0.0]))
-    assert energy[500] == 10.2933
+    assert energy[500] == pytest.approx(10.2933)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('disp_details', {})], indirect=True)
@@ -341,8 +341,8 @@ def test_dos(fresh_aiida_env, vasprun_parser):
     assert dos.shape == (301,)
     assert energy.shape == (301,)
     # test a few entries
-    assert dos[150] == 4.1296
-    assert energy[150] == 2.3373
+    assert dos[150] == pytest.approx(4.1296)
+    assert energy[150] == pytest.approx(2.3373)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('spin', {})], indirect=True)
@@ -368,8 +368,8 @@ def test_dos_spin(fresh_aiida_env, vasprun_parser):
         1000,
     )
     # test a few entries
-    assert dos[0, 500] == 0.9839
-    assert dos[1, 500] == 0.9844
+    assert dos[0, 500] == pytest.approx(0.9839)
+    assert dos[1, 500] == pytest.approx(0.9844)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('partial', {})], indirect=True)
@@ -394,7 +394,7 @@ def test_pdos(fresh_aiida_env, vasprun_parser):
     # test a few entries
     assert np.all(dos[3, 500] == np.array([0.0770, 0.0146, 0.0109, 0.0155, 0.0, 0.0, 0.0, 0.0, 0.0]))
     assert np.all(dos[7, 500] == np.array([0.0747, 0.0121, 0.0092, 0.0116, 0.0, 0.0, 0.0, 0.0, 0.0]))
-    assert energy[500] == 0.01
+    assert energy[500] == pytest.approx(0.01)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('partial', {})], indirect=True)
@@ -442,12 +442,12 @@ def test_bands(fresh_aiida_env, vasprun_parser):
     assert eigen.shape == (1, 64, 21)
     assert occ.shape == (1, 64, 21)
     # test a few entries
-    assert eigen[0, 0, 0] == -6.2348
-    assert eigen[0, 0, 15] == 5.8956
-    assert eigen[0, 6, 4] == -1.7424
-    assert occ[0, 0, 0] == 1.0
-    assert occ[0, 0, 15] == 0.6949
-    assert occ[0, 6, 4] == 1.0
+    assert eigen[0, 0, 0] == pytest.approx(-6.2348)
+    assert eigen[0, 0, 15] == pytest.approx(5.8956)
+    assert eigen[0, 6, 4] == pytest.approx(-1.7424)
+    assert occ[0, 0, 0] == pytest.approx(1.0)
+    assert occ[0, 0, 15] == pytest.approx(0.6949)
+    assert occ[0, 6, 4] == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('spin', {})], indirect=True)
@@ -456,8 +456,8 @@ def test_band_properties_result(fresh_aiida_env, vasprun_parser):
 
     inputs = get_node_composer_inputs_from_file_parser(vasprun_parser, quantity_keys=['band_properties'])
     data = NodeComposer.compose('dict', inputs).get_dict()['band_properties']
-    assert data['cbm'] == 6.5536
-    assert data['vbm'] == 6.5105
+    assert data['cbm'] == pytest.approx(6.5536)
+    assert data['vbm'] == pytest.approx(6.5105)
     assert data['is_direct_gap'] is False
     assert data['band_gap'] == pytest.approx(0.04310, rel=1e-3)
 
@@ -484,18 +484,18 @@ def test_eigenocc_spin_result(fresh_aiida_env, vasprun_parser):
     assert eigen.shape == (2, 64, 25)
     assert occ.shape == (2, 64, 25)
     # test a few entries
-    assert eigen[0, 0, 0] == -6.2363
-    assert eigen[0, 0, 15] == 5.8939
-    assert eigen[0, 6, 4] == -1.7438
-    assert eigen[1, 0, 0] == -6.2357
-    assert eigen[1, 0, 15] == 5.8946
-    assert eigen[1, 6, 4] == -1.7432
-    assert occ[0, 0, 0] == 1.0
-    assert occ[0, 0, 15] == 0.6955
-    assert occ[0, 6, 4] == 1.0
-    assert occ[1, 0, 0] == 1.0
-    assert occ[1, 0, 15] == 0.6938
-    assert occ[1, 6, 4] == 1.0
+    assert eigen[0, 0, 0] == pytest.approx(-6.2363)
+    assert eigen[0, 0, 15] == pytest.approx(5.8939)
+    assert eigen[0, 6, 4] == pytest.approx(-1.7438)
+    assert eigen[1, 0, 0] == pytest.approx(-6.2357)
+    assert eigen[1, 0, 15] == pytest.approx(5.8946)
+    assert eigen[1, 6, 4] == pytest.approx(-1.7432)
+    assert occ[0, 0, 0] == pytest.approx(1.0)
+    assert occ[0, 0, 15] == pytest.approx(0.6955)
+    assert occ[0, 6, 4] == pytest.approx(1.0)
+    assert occ[1, 0, 0] == pytest.approx(1.0)
+    assert occ[1, 0, 15] == pytest.approx(0.6938)
+    assert occ[1, 6, 4] == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {})], indirect=True)
@@ -732,8 +732,8 @@ def test_dynmat(fresh_aiida_env, vasprun_parser):
         3.11984195e-13, 2.73349550e-01, 2.73349550e-01, 2.59853610e-13, 2.73349550e-01, 2.73349550e-01, -1.64418993e-01, 1.81002749e-01,
         1.81002749e-01
     ]))
-    assert dyneig[0] == -1.36621537e+00
-    assert dyneig[4] == -8.48939361e-01
+    assert dyneig[0] == pytest.approx(-1.36621537e+00)
+    assert dyneig[4] == pytest.approx(-8.48939361e-01)
 
 
 def test_nan_inf_cleaning():
@@ -743,7 +743,7 @@ def test_nan_inf_cleaning():
 
     example = {'a': 1.0, 'b': {'c': 2.0, 'd': np.inf, 'e': np.nan}, 'd': {'e': {'g': np.inf}}}
     clean_nan_values(example)
-    assert example['a'] == 1.0
+    assert example['a'] == pytest.approx(1.0)
     assert example['b']['d'] == 'inf'
     assert example['b']['e'] == 'nan'
     assert example['d']['e']['g'] == 'inf'

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -208,7 +208,7 @@ def test_parser_nodes(request, calc_with_retrieved):
     assert isinstance(misc, get_data_class('dict'))
     assert isinstance(bands, get_data_class('array.bands'))
     assert isinstance(kpoints, get_data_class('array.kpoints'))
-    assert misc.get_dict()['fermi_level'] == 5.96764939
+    assert misc.get_dict()['fermi_level'] == pytest.approx(5.96764939)
 
 
 def test_parser_exception(request, calc_with_retrieved):
@@ -238,8 +238,8 @@ def test_parser_exception(request, calc_with_retrieved):
 
     misc = result['misc']
     assert isinstance(misc, get_data_class('dict'))
-    assert misc.get_dict()['maximum_force'] == 0.0
-    assert misc.get_dict()['total_energies']['energy_extrapolated'] == -36.09616894
+    assert misc.get_dict()['maximum_force'] == pytest.approx(0.0)
+    assert misc.get_dict()['total_energies']['energy_extrapolated'] == pytest.approx(-36.09616894)
 
     assert misc['notifications'] == [{
         'name': "<class 'aiida_vasp.parsers.file_parsers.vasprun.VasprunParser'>",
@@ -348,10 +348,10 @@ def test_misc(request, calc_with_retrieved):
     data = misc.get_dict()
     # We already have a test to check if the quantities from the OUTCAR is correct, so
     # only perform rudimentary checks, and the content comming from the xml file.
-    assert data['fermi_level'] == 6.17267267
-    assert data['maximum_stress'] == 42.96872956444064
-    assert data['maximum_force'] == 0.21326679
-    assert data['total_energies']['energy_extrapolated'] == -10.823296
+    assert data['fermi_level'] == pytest.approx(6.17267267)
+    assert data['maximum_stress'] == pytest.approx(42.96872956444064)
+    assert data['maximum_force'] == pytest.approx(0.21326679)
+    assert data['total_energies']['energy_extrapolated'] == pytest.approx(-10.823296)
 
 
 @pytest.mark.parametrize(

--- a/aiida_vasp/utils/tests/test_band_info.py
+++ b/aiida_vasp/utils/tests/test_band_info.py
@@ -37,23 +37,23 @@ def test_bands_info():
     eigen = np.array([[-1, -1, -1, 0, 0, 0]])
     bands_info = get_band_properties(eigen, occ)
     assert bands_info['is_direct_gap'] is True
-    assert bands_info['band_gap'] == 1.0
+    assert bands_info['band_gap'] == pytest.approx(1.0)
 
     occ = np.array([[1, 1, 1, 0, 0, 0], [1, 1, 1, 0, 0, 0]])
     eigen = np.array([[-1, -1, -1, 0, 0, 0], [-0.5, -0.5, -0.5, 0, 0, 0]])
     bands_info = get_band_properties(eigen, occ)
     assert bands_info['is_direct_gap'] is False
-    assert bands_info['band_gap'] == 0.5
+    assert bands_info['band_gap'] == pytest.approx(0.5)
 
 
 def test_bands_info_from_data(example_bands, example_bands_v2):
     """Test getting info from BandsData"""
     bands_info = get_band_properties_from_data(example_bands)
     assert bands_info['is_direct_gap'] is True
-    assert bands_info['band_gap'] == 1.0
+    assert bands_info['band_gap'] == pytest.approx(1.0)
 
     bands_info = get_band_properties_from_data(example_bands_v2)
     assert bands_info['is_direct_gap'] is False
-    assert bands_info['band_gap'] == 0.5
-    assert bands_info['vbm'] == -0.5
-    assert bands_info['cbm'] == 0.0
+    assert bands_info['band_gap'] == pytest.approx(0.5)
+    assert bands_info['vbm'] == pytest.approx(-0.5)
+    assert bands_info['cbm'] == pytest.approx(0.0)

--- a/aiida_vasp/workchains/tests/test_vasp_wc.py
+++ b/aiida_vasp/workchains/tests/test_vasp_wc.py
@@ -56,8 +56,8 @@ def test_vasp_wc(fresh_aiida_env, vasp_params, potentials, vasp_kpoints, vasp_st
     assert 'misc' in results
     assert 'remote_folder' in results
     misc = results['misc'].get_dict()
-    assert misc['maximum_stress'] == 22.8499295
-    assert misc['total_energies']['energy_extrapolated'] == -14.16209692
+    assert misc['maximum_stress'] == pytest.approx(22.8499295)
+    assert misc['total_energies']['energy_extrapolated'] == pytest.approx(-14.16209692)
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
@@ -242,7 +242,7 @@ def test_vasp_wc_nelm(fresh_aiida_env, potentials, mock_vasp_strict):
     assert 'misc' in results
     assert 'remote_folder' in results
 
-    assert results['misc']['total_energies']['energy_extrapolated'] == -4.82467802
+    assert results['misc']['total_energies']['energy_extrapolated'] == pytest.approx(-4.82467802)
 
     # Sort the called nodes by creation time
     called_nodes = list(node.called)


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #493

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

When comparing the floating-point numbers in tests, use the `pytest.approx` method. It has a default relative tolerance of 1e-6, which should be OK for most cases. 