### PR TITLE
check for critical missing files and fix the NELM breach by-pass

### DIFF
--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -36,12 +36,12 @@ FILE_PARSER_SETS = {
         },
         'OUTCAR': {
             'parser_class': OutcarParser,
-            'is_critical': False,
+            'is_critical': True,
             'status': 'Unknown'
         },
         'vasprun.xml': {
             'parser_class': VasprunParser,
-            'is_critical': False,
+            'is_critical': True,
             'status': 'Unknown'
         },
         'CHGCAR': {

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -198,8 +198,11 @@ def test_parser_nodes(request, calc_with_retrieved):
 
     node = calc_with_retrieved(file_path, settings_dict)
 
-    parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
+    parser = ParserFactory('vasp.vasp')(node)
+    # The test data does not contain OUTCAR - make sure that is allowed
+    parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
+    parser.parse(retrieved_temporary_folder=file_path)
+    result = parser.outputs
 
     misc = result['misc']
     bands = result['bands']
@@ -280,8 +283,11 @@ def test_structure(request, calc_with_retrieved):
 
     node = calc_with_retrieved(file_path, settings_dict)
 
-    parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
+    parser = ParserFactory('vasp.vasp')(node)
+    # The test data does not contain OUTCAR - make sure that is allowed
+    parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
+    parser.parse(retrieved_temporary_folder=file_path)
+    result = parser.outputs
 
     # First fetch structure from vasprun
 
@@ -293,8 +299,12 @@ def test_structure(request, calc_with_retrieved):
 
     node = calc_with_retrieved(file_path, settings_dict)
 
-    parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
+    parser = ParserFactory('vasp.vasp')(node)
+    # The test data does not contain OUTCAR - make sure that is allowed
+    parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
+    parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
+    parser.parse(retrieved_temporary_folder=file_path)
+    result = parser.outputs
 
     structure_poscar = result['structure']
 
@@ -408,8 +418,11 @@ def test_stream(misc_input, config, request, calc_with_retrieved):
 
     node = calc_with_retrieved(file_path, settings_dict)
 
-    parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
+    parser = ParserFactory('vasp.vasp')(node)
+    parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
+    parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
+    parser.parse(retrieved_temporary_folder=file_path)
+    result = parser.outputs
 
     if misc_input == []:
         # Test empty misc specification, yields no misc output node
@@ -480,8 +493,12 @@ def test_stream_history(request, calc_with_retrieved):
 
     node = calc_with_retrieved(file_path, settings_dict)
 
-    parser_cls = ParserFactory('vasp.vasp')
-    result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
+    parser = ParserFactory('vasp.vasp')(node)
+    # The test data does not contain OUTCAR - make sure that is allowed
+    parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
+    parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
+    parser.parse(retrieved_temporary_folder=file_path)
+    result = parser.outputs
 
     misc = result['misc']
     misc_dict = misc.get_dict()

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -537,13 +537,7 @@ class VaspWorkChain(BaseRestartWorkChain):
         self.ctx.last_calc_was_unfinished = True
         return ProcessHandlerReport(do_break=True)
 
-    @process_handler(priority=850,
-                     exit_codes=[
-                         VaspCalculation.exit_codes.ERROR_ELECTRONIC_NOT_CONVERGED,
-                         VaspCalculation.exit_codes.ERROR_IONIC_NOT_CONVERGED,
-                         VaspCalculation.exit_codes.ERROR_DID_NOT_FINISH,
-                     ],
-                     enabled=False)
+    @process_handler(priority=850, enabled=False)
     def ignore_nelm_breach_relax(self, node):
         """
         Not a actual handler but works as a switch to bypass checks for NELM breaches in the middle of an ionic relaxation.


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #497 #498 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Active the check for critical files (OUTCAR and vasprun.xml). A calculation that does not have these two files will behave the corresponding return code `ERROR_CRITICAL_MISSING_FILE`. 

This also fixes the by-pass for ignore the transient NELM breach, it should be applied in all cases, not just for specific return codes. Otherwise, a finished calculation with transient breaches may still result in an exit code, even if the user requested to by pass it. 