### PR TITLE
allow some critical notifications (errors) to be ignored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: pip install coveralls
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
-        run: pip install 'aiida-core>=1.6.1,<2'
+        run: pip install 'psycopg2-binary~=2.8.3' 'aiida-core>=1.6.1,<2'
       - name: Install AiiDA-Wannier90
         run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP

--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -315,3 +315,50 @@ def test_vasp_calc_exit_codes(run_vasp_process, test_case, expected, has_notific
     misc = results['misc'].get_dict()
     assert node.exit_status == expected
     assert bool(misc['notifications']) is has_notification
+
+
+@pytest.mark.parametrize([
+    'vasp_structure',
+    'vasp_kpoints',
+], [('str', 'mesh')], indirect=True)
+def test_vasp_calc_error_suppress(run_vasp_process):
+    """
+    Test running a VASP calculation with electronic/ionic convergence problems and
+    check if the exit_codes are set accordingly.
+    """
+    results, node = run_vasp_process(test_case='exit_codes/converged-with-error',
+                                     settings={'parser_settings': {
+                                         'critical_errors': {
+                                             'add_brmix': False
+                                         }
+                                     }})
+
+    # Check that the standard output is there
+    assert 'retrieved' in results
+    assert 'misc' in results
+    assert 'remote_folder' in results
+
+    misc = results['misc'].get_dict()
+    assert node.exit_status == 0
+    assert bool(misc['notifications'])
+
+
+@pytest.mark.parametrize([
+    'vasp_structure',
+    'vasp_kpoints',
+], [('str', 'mesh')], indirect=True)
+def test_vasp_calc_error_ignore_all(run_vasp_process):
+    """
+    Test running a VASP calculation with electronic/ionic convergence problems and
+    check if the exit_codes are set accordingly.
+    """
+    results, node = run_vasp_process(test_case='exit_codes/converged-with-error', settings={'parser_settings': {'ignore_all_errors': True}})
+
+    # Check that the standard output is there
+    assert 'retrieved' in results
+    assert 'misc' in results
+    assert 'remote_folder' in results
+
+    misc = results['misc'].get_dict()
+    assert node.exit_status == 0
+    assert bool(misc['notifications'])

--- a/aiida_vasp/calcs/tests/test_vasp.py
+++ b/aiida_vasp/calcs/tests/test_vasp.py
@@ -328,7 +328,7 @@ def test_vasp_calc_error_suppress(run_vasp_process):
     """
     results, node = run_vasp_process(test_case='exit_codes/converged-with-error',
                                      settings={'parser_settings': {
-                                         'critical_errors': {
+                                         'critical_notifications': {
                                              'add_brmix': False
                                          }
                                      }})

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -17,6 +17,8 @@ from aiida_vasp.parsers.file_parsers.wavecar import WavecarParser
 from aiida_vasp.parsers.file_parsers.poscar import PoscarParser
 from aiida_vasp.parsers.file_parsers.stream import StreamParser
 
+from aiida_vasp.utils.extended_dicts import update_nested_dict
+
 FILE_PARSER_SETS = {
     'default': {
         'DOSCAR': {
@@ -216,11 +218,16 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
             self._settings = {}
         else:
             self._settings = settings
+
+        # If the default is supplied use it as the base and update with the explicity settings
         if default_settings is not None:
-            self._update_with(default_settings)
+            self._settings = deepcopy(default_settings)
+            update_nested_dict(self._settings, settings)
 
         self._output_nodes_dict = {}
+        self._critical_error_list = []
         self._init_output_nodes_dict()
+        self._init_critical_error_list()
 
     @property
     def output_nodes_dict(self):
@@ -236,6 +243,11 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
                     continue
                 quantity_names_to_parse.append(quantity_key)
         return quantity_names_to_parse
+
+    @property
+    def critical_errors_to_check(self):
+        """Return the list of critical notification names to be checked"""
+        return self._critical_error_list
 
     def add_output_node(self, node_name, node_dict=None):
         """Add a definition of node to the nodes dictionary."""
@@ -300,8 +312,26 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
 
             self.add_output_node(node_name, node_dict)
 
-    def _update_with(self, update_dict):
-        """Selectively update keys from one Dictionary to another."""
-        for key, value in update_dict.items():
-            if key not in self._settings:
-                self._settings[key] = value
+    def _init_critical_error_list(self):
+        """
+        Set the critical error list to be checked from a settings object.
+
+        Name of critical notifications can be added by setting:
+
+            'add_name' : True
+
+        in ``parser_settings``'s ``critical_errors`` field.
+        The the notifications can be removed by setting:
+
+            'add_name' : False
+
+        from the default set defined by CRITICAL_NOTIFICATIONS.
+        """
+        self._critical_error_list = []
+
+        # First, find all the nodes, that should be added.
+        for key, value in self._settings.get('critical_errors', {}).items():
+            if key.startswith('add_'):
+                # only keys starting with 'add_' are relevant as nodes.
+                if value:
+                    self._critical_error_list.append(key[4:])

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -221,8 +221,9 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
 
         # If the default is supplied use it as the base and update with the explicity settings
         if default_settings is not None:
-            self._settings = deepcopy(default_settings)
-            update_nested_dict(self._settings, settings)
+            new_settings = deepcopy(default_settings)
+            update_nested_dict(new_settings, self._settings)
+            self._settings = new_settings
 
         self._output_nodes_dict = {}
         self._critical_error_list = []

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -246,7 +246,7 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
         return quantity_names_to_parse
 
     @property
-    def critical_errors_to_check(self):
+    def critical_notifications_to_check(self):
         """Return the list of critical notification names to be checked"""
         return self._critical_error_list
 
@@ -321,7 +321,7 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
 
             'add_name' : True
 
-        in ``parser_settings``'s ``critical_errors`` field.
+        in ``parser_settings``'s ``critical_notifications`` field.
         The the notifications can be removed by setting:
 
             'add_name' : False
@@ -331,7 +331,7 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
         self._critical_error_list = []
 
         # First, find all the nodes, that should be added.
-        for key, value in self._settings.get('critical_errors', {}).items():
+        for key, value in self._settings.get('critical_notifications', {}).items():
             if key.startswith('add_'):
                 # only keys starting with 'add_' are relevant as nodes.
                 if value:

--- a/aiida_vasp/parsers/tests/test_parser_settings.py
+++ b/aiida_vasp/parsers/tests/test_parser_settings.py
@@ -4,7 +4,7 @@
 from aiida_vasp.parsers.settings import ParserSettings
 from aiida_vasp.parsers.vasp import DEFAULT_OPTIONS
 
-SETTINGS = {'add_wavecar': True, 'critical_errors': {'add_brmix': False}}
+SETTINGS = {'add_wavecar': True, 'critical_notifications': {'add_brmix': False}}
 
 
 def test_settings_utils():
@@ -16,7 +16,7 @@ def test_settings_utils():
     assert 'kpoints' not in settings.output_nodes_dict
     assert 'misc' in settings.output_nodes_dict
 
-    assert 'psmaxn' not in settings.critical_errors_to_check
-    assert 'brmix' not in settings.critical_errors_to_check
-    assert 'fock_acc' in settings.critical_errors_to_check
-    assert 'rhosyg' in settings.critical_errors_to_check
+    assert 'psmaxn' not in settings.critical_notifications_to_check
+    assert 'brmix' not in settings.critical_notifications_to_check
+    assert 'fock_acc' in settings.critical_notifications_to_check
+    assert 'rhosyg' in settings.critical_notifications_to_check

--- a/aiida_vasp/parsers/tests/test_parser_settings.py
+++ b/aiida_vasp/parsers/tests/test_parser_settings.py
@@ -4,9 +4,7 @@
 from aiida_vasp.parsers.settings import ParserSettings
 from aiida_vasp.parsers.vasp import DEFAULT_OPTIONS
 
-SETTINGS = {
-    'add_wavecar': True,
-}
+SETTINGS = {'add_wavecar': True, 'critical_errors': {'add_brmix': False}}
 
 
 def test_settings_utils():
@@ -15,3 +13,10 @@ def test_settings_utils():
     assert len(settings.output_nodes_dict) == 1 and 'wavecar' in settings.output_nodes_dict
     settings = ParserSettings(SETTINGS, DEFAULT_OPTIONS)
     assert 'wavecar' in settings.output_nodes_dict
+    assert 'kpoints' not in settings.output_nodes_dict
+    assert 'misc' in settings.output_nodes_dict
+
+    assert 'psmaxn' not in settings.critical_errors_to_check
+    assert 'brmix' not in settings.critical_errors_to_check
+    assert 'fock_acc' in settings.critical_errors_to_check
+    assert 'rhosyg' in settings.critical_errors_to_check

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -520,18 +520,28 @@ def test_notification_composer(vasp_parser_without_parsing):
     """Test the NotificationComposer class"""
     parser, file_path = vasp_parser_without_parsing
     notifications = [{'name': 'edwav', 'kind': 'ERROR', 'message': 'Error in EDWAV'}]
-    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={'nelect': 10})}, parser.exit_codes)
+    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={
+        'nelect': 10
+    })},
+                                    parser.exit_codes,
+                                    parser_settings=parser._settings)
     exit_code = composer.compose()
     assert exit_code.status == 703
 
     # BRMIX error but has NELECT defined in the input
     notifications = [{'name': 'brmix', 'kind': 'ERROR', 'message': 'Error in BRMIX'}]
-    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={'nelect': 10})}, parser.exit_codes)
+    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={
+        'nelect': 10
+    })},
+                                    parser.exit_codes,
+                                    parser_settings=parser._settings)
     exit_code = composer.compose()
     assert exit_code is None
 
     # BRMIX error but no NELECT tag
-    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={})}, parser.exit_codes)
+    composer = NotificationComposer(notifications, {}, {'parameters': get_data_class('dict')(dict={})},
+                                    parser.exit_codes,
+                                    parser_settings=parser._settings)
     exit_code = composer.compose()
     assert exit_code.status == 703
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -348,11 +348,13 @@ class VaspParser(BaseParser):
         # Check for the existence of critical warnings
         if 'notifications' in quantities:
             notifications = quantities['notifications']
-            ignored = self.parser_settings.get('ignored_notifications')
-            composer = NotificationComposer(notifications, quantities, self.node.inputs, self.exit_codes, ignored=ignored)
-            exit_code = composer.compose()
-            if exit_code is not None:
-                return exit_code
+            ignored = self.parser_settings.get('ignored_notifications', [])
+            ignore_all = self.parser_settings.get('ignore_all_notifications', False)
+            if not ignore_all:
+                composer = NotificationComposer(notifications, quantities, self.node.inputs, self.exit_codes, ignored=ignored)
+                exit_code = composer.compose()
+                if exit_code is not None:
+                    return exit_code
         else:
             self.logger.warning('WARNING: missing notification output for VASP warnings and errors.')
 

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -38,7 +38,7 @@ DEFAULT_OPTIONS = {
     'add_forces': False,
     'add_stress': False,
     'add_site_magnetization': False,
-    'critical_errors': {
+    'critical_notifications': {
         'add_brmix': True,
         'add_cnormn': True,
         'add_denmp': True,
@@ -95,7 +95,7 @@ class VaspParser(BaseParser):
         'chgcar':     FileData node containing the CHGCAR file.
        If the value is set to ``False`` the quantity will not be returned.
 
-    * `critical_errors`: A dictionary of critical errors to be checked with items like `'add_<key>': True`, similiar
+    * `critical_notifications`: A dictionary of critical errors to be checked with items like `'add_<key>': True`, similiar
       to the `add_<quantity>` syntax described above.
 
     * `output_params`: A list of quantities, that should be added to the 'misc' node.
@@ -399,7 +399,7 @@ class NotificationComposer:
 
         Retruns None if no exit code should be emitted, otherwise emit the error code.
         """
-        for critical in self.parser_settings.critical_errors_to_check:
+        for critical in self.parser_settings.critical_notifications_to_check:
             # Check for any special handling
             if hasattr(self, critical):
                 output = getattr(self, critical)

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -729,9 +729,9 @@ class VaspWorkChain(BaseRestartWorkChain):
         Check if the calculation contain any critical error.
         """
         notification = node.outputs.misc['notifications']
-        self.report('Critical notifications detected: {} - aborting'.format(notification))
-        return ProcessHandlerReport(do_break=True,
-                                    exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(message=', '.join(notification)))
+        message = 'Critical error detected in the notifications: {}'.format(', '.join([item.get('name') for item in notification]))
+        self.report(message + ' - aborting.')
+        return ProcessHandlerReport(do_break=True, exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(message=message))
 
     @process_handler(priority=5)
     def check_misc_output(self, node):

--- a/doc/source/concepts/parsing.rst
+++ b/doc/source/concepts/parsing.rst
@@ -63,11 +63,11 @@ There are four ways to interact and set the parser properties.
 The parser will check for any error detected for the underlying VASP calculation.
 This information is stored in the `notification` quantity, which contains a list of error/warnings detected.
 By default, a non-zero exit state is returned if any critical error is found.  
-The default list of critical errors is defined under the `critical_errors` key inside :py:data:`~aiida_vasp.parsers.vasp.DEFAULT_OPTIONS`.
+The default list of critical errors is defined under the `critical_notifications` key inside :py:data:`~aiida_vasp.parsers.vasp.DEFAULT_OPTIONS`.
 Additional settings may also be supplied under ``parser_settings`` to modify the behaviours:
 
 * ``ignore_all_errors``: a boolen value to control whether all notifications should be ignored, defaults to ``False``.
-* ``critical_errors``: a dictionary with items like ``'add_<error>': True`` for controlling which errors to be regarded as `critical` or not.
+* ``critical_notifications``: a dictionary with items like ``'add_<error>': True`` for controlling which errors to be regarded as `critical` or not.
 
 Composing the quantities into an output node
 --------------------------------------------

--- a/doc/source/concepts/parsing.rst
+++ b/doc/source/concepts/parsing.rst
@@ -63,11 +63,11 @@ There are four ways to interact and set the parser properties.
 The parser will check for any error detected for the underlying VASP calculation.
 This information is stored in the `notification` quantity, which contains a list of error/warnings detected.
 By default, a non-zero exit state is returned if any critical error is found.  
-The default list of critical errors is defined by :py:data:`~aiida_vasp.parsers.vasp.CRITCIAL_NOTIFICATIONS`.
-Additional settings may also be supplied under ``parser_settings`` to modify this behaviour:
+The default list of critical errors is defined under the `critical_errors` key inside :py:data:`~aiida_vasp.parsers.vasp.DEFAULT_OPTIONS`.
+Additional settings may also be supplied under ``parser_settings`` to modify the behaviours:
 
-* ``ignored_notifications``: a list of notifications to be ignored for deciding if a critical error has occured and the calculation should have a non-zero exit status. 
-* ``ignore_all_noficiations``: a boolen value to control whether all notifications should be ignored, defaults to ``False``.
+* ``ignore_all_errors``: a boolen value to control whether all notifications should be ignored, defaults to ``False``.
+* ``critical_errors``: a dictionary with items like ``'add_<error>': True`` for controlling which errors to be regarded as `critical` or not.
 
 Composing the quantities into an output node
 --------------------------------------------

--- a/doc/source/concepts/parsing.rst
+++ b/doc/source/concepts/parsing.rst
@@ -60,6 +60,15 @@ There are four ways to interact and set the parser properties.
 
    where the format for the ``node_definition`` is as in the previous example with the custom nodes.
 
+The parser will check for any error detected for the underlying VASP calculation.
+This information is stored in the `notification` quantity, which contains a list of error/warnings detected.
+By default, a non-zero exit state is returned if any critical error is found.  
+The default list of critical errors is defined by :py:data:`~aiida_vasp.parsers.vasp.CRITCIAL_NOTIFICATIONS`.
+Additional settings may also be supplied under ``parser_settings`` to modify this behaviour:
+
+* ``ignored_notifications``: a list of notifications to be ignored for deciding if a critical error has occured and the calculation should have a non-zero exit status. 
+* ``ignore_all_noficiations``: a boolen value to control whether all notifications should be ignored, defaults to ``False``.
+
 Composing the quantities into an output node
 --------------------------------------------
 

--- a/setup.json
+++ b/setup.json
@@ -86,7 +86,8 @@
     },
     "include_package_data": true,
     "install_requires": [
-	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1",
+	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1,<2",
+	"psycopg2-binary~=2.8.3",
 	"subprocess32",
 	"pymatgen<=2020.12.3",
 	"lxml",


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#483
blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Allow the user to pass a list of notifications to be ignored, or ignore all notifications that make the calculation end up in `ERROR_VASP_CRITICAL_ERROR`. These are passed under the `parser_settings` of the `settings` input port.

Note that fine-tuned per-case treatment can be defined as a method of the `NotificationComposer`. 