### PR TITLE
An error 'TypeError: port namespace `inputs.dynamics` received `<clas…

### DIFF
--- a/aiida_vasp/workchains/master.py
+++ b/aiida_vasp/workchains/master.py
@@ -219,7 +219,7 @@ class MasterWorkChain(WorkChain):
         self.ctx.inputs.update(self.exposed_inputs(self._next_workchain))
 
         # Make sure we do not have any floating dict (convert to Dict)
-        self.ctx.inputs = prepare_process_inputs(self.ctx.inputs, namespaces=['relax', 'converge', 'verify'])
+        self.ctx.inputs = prepare_process_inputs(self.ctx.inputs, namespaces=['dynamics', 'relax', 'converge', 'verify'])
 
     def run_next_workchain(self):
         """Run the next workchain."""


### PR DESCRIPTION
…s 'aiida.orm.nodes.data.dict.Dict'>` instead of a dictionary'

This fix is required to fix the error

"""
File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/plumpy/process_states.py", line 230, in execute
    result = self.run_fn(*self.args, **self.kwargs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/workchains/workchain.py", line 214, in _do_step
    finished, stepper_result = self._stepper.step()
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/plumpy/workchains.py", line 299, in step
    finished, result = self._child_stepper.step()
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/plumpy/workchains.py", line 250, in step
    return True, self._fn(self._workchain)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida_vasp/workchains/master.py", line 227, in run_next_workchain
    running = self.submit(self._next_workchain, **inputs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/process.py", line 498, in submit
    return self.runner.submit(process, *args, **kwargs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/runners.py", line 184, in submit
    process_inited = self.instantiate_process(process, *args, **inputs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/runners.py", line 170, in instantiate_process
    return instantiate_process(self, process, *args, **inputs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/utils.py", line 65, in instantiate_process
    process = process_class(runner=runner, inputs=inputs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/plumpy/base/state_machine.py", line 192, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/workchains/workchain.py", line 70, in __init__
    super().__init__(inputs, logger, runner, enable_persistence=enable_persistence)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/process.py", line 145, in __init__
    inputs=self.spec().inputs.serialize(inputs),
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/ports.py", line 220, in serialize
    result[name] = port.serialize(value, breadcrumbs)
  File "/Users/vladislavnikolaev/Desktop/aiida/aiida-vasp/lib/python3.8/site-packages/aiida/engine/processes/ports.py", line 211, in serialize
    raise TypeError(f'port namespace `{port_name}` received `{type(mapping)}` instead of a dictionary')
TypeError: port namespace `inputs.dynamics` received `<class 'aiida.orm.nodes.data.dict.Dict'>` instead of a dictionary
"""

when running example "run_bands.py"

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
