### PR TITLE
Avoid converting `dynamics` to a Dict

### DIFF
--- a/aiida_vasp/utils/workchains.py
+++ b/aiida_vasp/utils/workchains.py
@@ -34,7 +34,7 @@ def prepare_process_inputs(inputs, namespaces=None, exclude_parameters=None):
     if exclude_parameters is None:
         exclude_parameters = []
 
-    no_dict = ['options', 'metadata', 'potential', 'parameters']
+    no_dict = ['options', 'metadata', 'potential', 'parameters', 'dynamics']
     no_dict = no_dict + namespaces
     # Copy and convert dict
     for key, val in inputs.items():


### PR DESCRIPTION
The `dynamics` should be included in the default exclusion list as it is a port namespace
for `VaspCalculation` rather than a port accepting a `Dict`.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#509 

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

This should this kind of problem once for all. As `dynamics` is a port namespace for `VaspCalculation`, it makes sense to have it in the default list of namespaces to be excluded from being converted to `Dict`. 