### PR TITLE
Use `expose_outputs` for VaspWorkChain

### DIFF
--- a/aiida_vasp/workchains/immigrant.py
+++ b/aiida_vasp/workchains/immigrant.py
@@ -75,7 +75,8 @@ class VaspImmigrantWorkChain(BaseRestartWorkChain):
             ),
             cls.results,
         )  # yapf: disable
-        spec.expose_outputs(cls._next_workchain)
+        # Expose the outputs from the _process_class (vasp.immigrate)
+        spec.expose_outputs(cls._process_class)
 
     def init_inputs(self):  # pylint: disable=too-many-branches, too-many-statements
         """Set inputs of VaspImmigrant calculation

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -155,26 +155,8 @@ class VaspWorkChain(BaseRestartWorkChain):
             cls.results,
         )  # yapf: disable
 
-        spec.output('misc', valid_type=get_data_class('dict'))
-        spec.output('remote_folder', valid_type=get_data_class('remote'))
-        spec.output('retrieved', valid_type=get_data_class('folder'))
-        spec.output('structure', valid_type=get_data_class('structure'), required=False)
-        spec.output('kpoints', valid_type=get_data_class('array.kpoints'), required=False)
-        spec.output('trajectory', valid_type=get_data_class('array.trajectory'), required=False)
-        spec.output('chgcar', valid_type=get_data_class('vasp.chargedensity'), required=False)
-        spec.output('wavecar', valid_type=get_data_class('vasp.wavefun'), required=False)
-        spec.output('bands', valid_type=get_data_class('array.bands'), required=False)
-        spec.output('forces', valid_type=get_data_class('array'), required=False)
-        spec.output('stress', valid_type=get_data_class('array'), required=False)
-        spec.output('dos', valid_type=get_data_class('array'), required=False)
-        spec.output('occupancies', valid_type=get_data_class('array'), required=False)
-        spec.output('energies', valid_type=get_data_class('array'), required=False)
-        spec.output('projectors', valid_type=get_data_class('array'), required=False)
-        spec.output('dielectrics', valid_type=get_data_class('array'), required=False)
-        spec.output('born_charges', valid_type=get_data_class('array'), required=False)
-        spec.output('hessian', valid_type=get_data_class('array'), required=False)
-        spec.output('dynmat', valid_type=get_data_class('array'), required=False)
-        spec.output('site_magnetization', valid_type=get_data_class('dict'), required=False)
+        spec.expose_outputs(cls._process_class)
+
         spec.exit_code(0, 'NO_ERROR', message='the sun is shining')
         spec.exit_code(700, 'ERROR_NO_POTENTIAL_FAMILY_NAME', message='the user did not supply a potential family name')
         spec.exit_code(701, 'ERROR_POTENTIAL_VALUE_ERROR', message='ValueError was returned from get_potcars_from_structure')


### PR DESCRIPTION
This fixes an accidental issue with aiida-core 1.6.5. Previously, the outputs are repeated explicitly, which is now replaced by
a `expose_outputs` call.
 
On aiida-core > 1.6.5, the nested outputs are now handled correctly, and `BaseRestartWorkChain` uses this to check for
required outputs for the underlying calculation node. This implies that the outputs should be added with the `expose_outputs` method.

Fixes:
#518 