### PR TITLE
make sure total energies returned include pressure and other terms

### DIFF
--- a/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
+++ b/aiida_vasp/parsers/file_parsers/tests/test_vasprun_parser.py
@@ -515,8 +515,8 @@ def test_toten(fresh_aiida_env, vasprun_parser):
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
     # Test that the default arrays are present
-    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
-    energies = data_obj.get_array('energy_extrapolated')
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_electronic', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated_electronic')
     test_array = np.array([-42.91113621])
     np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
     # Test number of entries
@@ -525,8 +525,8 @@ def test_toten(fresh_aiida_env, vasprun_parser):
     test_array = np.array([1])
     np.testing.assert_allclose(test_array, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
-    test_array = np.array([-0.00236711])
-    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
+    test_array = np.array([-42.91113621])
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {'energy_type': ['energy_free', 'energy_no_entropy']})], indirect=True)
@@ -543,14 +543,13 @@ def test_toten_multiple(fresh_aiida_env, vasprun_parser):
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
     assert set(data_obj.get_arraynames()) == set(
-        ['electronic_steps', 'energy_free', 'energy_free_final', 'energy_no_entropy', 'energy_no_entropy_final'])
+        ['electronic_steps', 'energy_free', 'energy_free_electronic', 'energy_no_entropy', 'energy_no_entropy_electronic'])
     test_array = np.array([-42.91231976])
     np.testing.assert_allclose(test_array, data_obj.get_array('energy_free'), atol=0., rtol=1.0e-7)
-    np.testing.assert_allclose(test_array, data_obj.get_array('energy_free_final'), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_free_electronic'), atol=0., rtol=1.0e-7)
     test_array = np.array([-42.90995265])
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_no_entropy_electronic'), atol=0., rtol=1.0e-7)
     np.testing.assert_allclose(test_array, data_obj.get_array('energy_no_entropy'), atol=0., rtol=1.0e-7)
-    test_array = np.array([-42.91113621])
-    np.testing.assert_allclose(test_array, data_obj.get_array('energy_no_entropy_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('basic', {'electronic_step_energies': True})], indirect=True)
@@ -568,8 +567,8 @@ def test_toten_electronic(fresh_aiida_env, vasprun_parser):
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
     # Test that the default arrays are present
-    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
-    energies = data_obj.get_array('energy_extrapolated')
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_electronic', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated_electronic')
     test_array = np.array([-42.91113666, -42.91113621])
     np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
     # Test number of entries
@@ -578,8 +577,8 @@ def test_toten_electronic(fresh_aiida_env, vasprun_parser):
     test_array = np.array([2])
     np.testing.assert_allclose(test_array, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
-    test_array = np.array([-0.00236711])
-    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
+    test_array = np.array([-42.91113621])
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {})], indirect=True)
@@ -596,8 +595,8 @@ def test_toten_relax(fresh_aiida_env, vasprun_parser):
     # Test that the object is of the right type
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
-    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
-    energies = data_obj.get_array('energy_extrapolated')
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_electronic', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated_electronic')
     test_array = np.array([
         -42.91113348, -43.27757545, -43.36648855, -43.37734069, -43.38062479, -43.38334165, -43.38753003, -43.38708193, -43.38641449,
         -43.38701639, -43.38699488, -43.38773717, -43.38988315, -43.3898822, -43.39011239, -43.39020751, -43.39034244, -43.39044584,
@@ -605,16 +604,12 @@ def test_toten_relax(fresh_aiida_env, vasprun_parser):
     ])
     # Test energies
     np.testing.assert_allclose(test_array, energies, atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated'), atol=0., rtol=1.0e-7)
     # Test number of entries
     assert energies.shape == test_array.shape
     # Electronic steps should be entries times one
     np.testing.assert_allclose(np.ones(19, dtype=int), data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
-    test_array = np.array([
-        -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
-        -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
-    ])
-    np.testing.assert_allclose(test_array, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('relax', {'electronic_step_energies': True})], indirect=True)
@@ -631,9 +626,9 @@ def test_toten_relax_electronic(fresh_aiida_env, vasprun_parser):
     # Test that the object is of the right type
     ref_obj = get_data_class('array')
     assert isinstance(data_obj, ref_obj)
-    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_final', 'energy_extrapolated', 'electronic_steps'])
-    energies = data_obj.get_array('energy_extrapolated')
-    test_array_energies = [
+    assert set(data_obj.get_arraynames()) == set(['energy_extrapolated_electronic', 'energy_extrapolated', 'electronic_steps'])
+    energies = data_obj.get_array('energy_extrapolated_electronic')
+    test_array_energies_electronic = [
         np.array([
             163.37398579, 14.26925896, -23.05190509, -34.91615104, -40.20080347, -42.18390876, -42.97469852, -43.31556073, -43.60169068,
             -43.61723125, -43.61871511, -43.61879751, -43.12548175, -42.90647187, -42.91031846, -42.91099027, -42.91111107, -42.91113348
@@ -661,17 +656,14 @@ def test_toten_relax_electronic(fresh_aiida_env, vasprun_parser):
     # Build a flattened array (not using flatten from NumPy as the content is staggered) and
     # test number of electronic steps per ionic step
     test_array_energies_flattened = np.array([])
-    for ionic_step in test_array_energies:
+    for ionic_step in test_array_energies_electronic:
         test_array_energies_flattened = np.append(test_array_energies_flattened, ionic_step)
     assert energies.shape == test_array_energies_flattened.shape
     np.testing.assert_allclose(test_array_energies_flattened, energies, atol=0., rtol=1.0e-7)
     np.testing.assert_allclose(test_array_steps, data_obj.get_array('electronic_steps'), atol=0., rtol=1.0e-7)
-    test_array_energies = np.array([
-        -0.00236637, -0.00048614, -0.00047201, -0.00043261, -0.00041668, -0.00042584, -0.00043637, -0.00042806, -0.00042762, -0.00043875,
-        -0.00042731, -0.00042705, -0.00043064, -0.00043051, -0.00043161, -0.00043078, -0.00043053, -0.00043149, -0.00043417
-    ])
+    test_array_energies = np.array([x[-1] for x in test_array_energies_electronic])
     # Testing on VASP 5 so final total energy should not be the same as the last electronic step total energy.
-    np.testing.assert_allclose(test_array_energies, data_obj.get_array('energy_extrapolated_final'), atol=0., rtol=1.0e-7)
+    np.testing.assert_allclose(test_array_energies, data_obj.get_array('energy_extrapolated'), atol=0., rtol=1.0e-7)
 
 
 @pytest.mark.parametrize('vasprun_parser', [('disp', {})], indirect=True)

--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -598,10 +598,15 @@ class VasprunParser(BaseFileParser):
         # Apply mapping - those with `_final` has the suffix removed and those without has `_electronic` added
         mapped_energies = {}
         mapping = ENERGY_MAPPING_VASP5 if self.version.startswith('5') else ENERGY_MAPPING
-        for key, value in mapping.items():
-            # Only include those originally requested
-            if value in energies and key.replace('_electronic', '') in etype_orig:
-                mapped_energies[key] = energies[value]
+        # Reverse the mapping - now key is the name of the original energies output
+        revmapping = {value: key for key, value in mapping.items()}
+        for key, value in energies.items():
+            # Apply mapping if needed
+            if key in revmapping:
+                if revmapping[key].replace('_electronic', '') in etype_orig:
+                    mapped_energies[revmapping[key]] = value
+            else:
+                mapped_energies[key] = value
 
         return mapped_energies
 

--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -42,6 +42,26 @@ DEFAULT_OPTIONS = {
     'electronic_step_energies': False
 }
 
+# Mapping of the energy names to those returned by parsevasp.vasprunl.Xml
+ENERGY_MAPPING = {
+    'energy_extrapolated': 'energy_extrapolated_final',
+    'energy_free': 'energy_free_final',
+    'energy_no_entropy': 'energy_no_entropy_final',
+    'energy_extrapolated_electronic': 'energy_extrapolated',
+    'energy_free_electronic': 'energy_free',
+    'energy_no_entropy_electronic': 'energy_no_entropy',
+}
+
+ENERGY_MAPPING_VASP5 = {
+    'energy_extrapolated': 'energy_no_entropy_final',
+    'energy_free': 'energy_free_final',
+    # Not that energy_extrapolated_final parsed is the entropy term
+    'energy_no_entropy': 'energy_extrapolated_final',
+    'energy_extrapolated_electronic': 'energy_extrapolated',
+    'energy_free_electronic': 'energy_free',
+    'energy_no_entropy_electronic': 'energy_no_entropy',
+}
+
 
 class VasprunParser(BaseFileParser):
     """Interface to parsevasp's xml parser."""
@@ -514,6 +534,8 @@ class VasprunParser(BaseFileParser):
         energies_dict = {}
         for etype in self._settings.get('energy_type', DEFAULT_OPTIONS['energy_type']):
             energies_dict[etype] = energies[etype][-1]
+            # Also return the raw electronic steps energy
+            energies_dict[etype + '_electronic'] = energies[etype + '_electronic'][-1]
 
         return energies_dict
 
@@ -534,14 +556,54 @@ class VasprunParser(BaseFileParser):
         be found in the flattened ndarray where the key `electronic_steps` indicate how many electronic steps
         there is per ionic step. Using the combination, one can rebuild the electronic step energy per ionic step etc.
 
+        Because the VASPrun parser returns both the electronic step energies (at the end of each cycles) and the ionic step
+        energies (_final), we apply a mapping to recovery the naming such that the ionic step energies do not have the suffix,
+        but the electronic step energies do.
         """
+
         etype = self._settings.get('energy_type', DEFAULT_OPTIONS['energy_type'])
-        energies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
+        # Create a copy
+        etype = list(etype)
+        etype_orig = list(etype)
+
+        # Apply mapping and request the correct energies from the parsing results
+        # VASP 5 has a bug where the energy_no_entropy is not included in the XML output - we have to calculate it here
+        if self.version.startswith('5'):
+            # For energy_no_entropy needs to be calculated here
+            if 'energy_no_entropy' in etype_orig:
+                etype.append('energy_free')
+                etype.append('energy_extrapolated')
+
+            # energy extrapolated is stored as energy_no_entropy for the ionic steps
+            if 'energy_extrapolated' in etype_orig:
+                etype.append('energy_no_entropy')
+
+            # Remove duplicates
+            etype = list(set(etype))
+            energies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
+            # Here we must calculate the true `energy_no_entropy`
+            if 'energy_no_entropy' in etype_orig:
+                # The energy_extrapolated_final is the entropy term itself in VASP 5
+                # Store the calculated energy_no_entropy under 'energy_extrapolated_final',
+                # which is then recovered as `energy_no_entropy` later
+                energies['energy_extrapolated_final'] = energies['energy_free_final'] - energies['energy_extrapolated_final']
+        else:
+            etype = [ENERGY_MAPPING[key] for key in etype.items()]
+            energies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
+
         if energies is None:
             self._exit_code = self._exit_codes.ERROR_NOT_ABLE_TO_PARSE_QUANTITY.format(quantity=str(sys._getframe().f_code.co_name))
             return None
 
-        return energies
+        # Apply mapping - those with `_final` has the suffix removed and those without has `_electronic` added
+        mapped_energies = {}
+        mapping = ENERGY_MAPPING_VASP5 if self.version.startswith('5') else ENERGY_MAPPING
+        for key, value in mapping.items():
+            # Only include those originally requested
+            if value in energies and key.replace('_electronic', '') in etype_orig:
+                mapped_energies[key] = energies[value]
+
+        return mapped_energies
 
     @property
     def projectors(self):


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [] ready to be reviewed and merged (as soon as tests have passed)
 - [x ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #524 

## Description

Previously, the total energies returned are those calculated by the
electronic routine. They do not include any additions added in the
ionic loop, such as those from dispersion corrections and external
pressure.
This commit makes sure the energies are those returned by the ionic
routine and those from the electronic routines are named with
`_electronic` suffixes, this ensures backward compatibility - so the
total energy is still accessible under the same item stored in `total_energies`.


## Mapping between energies and those returned by `parsevasp`

The key is what we call it in the plugin here, the values is the name in `parsevasp`
Note that for VASP5 the `energy_no_entropy` mapped to`energy_extrapolated_final`, in the calculation it is in fact the entropy term itself. However, we can recovery the true `energy_no_entrop` by subtracting the entropy term (-TS) from the free energy. This result is temporarily stored under `energy_extrapolated_final` internally, and finally becomes `energy_no_entropy`. 

```python
ENERGY_MAPPING = {
    'energy_extrapolated': 'energy_extrapolated_final',
    'energy_free': 'energy_free_final',
    'energy_no_entropy': 'energy_no_entropy_final',
    'energy_extrapolated_electronic': 'energy_extrapolated',
    'energy_free_electronic': 'energy_free',
    'energy_no_entropy_electronic': 'energy_no_entropy',
}

ENERGY_MAPPING_VASP5 = {
    'energy_extrapolated': 'energy_no_entropy_final',
    'energy_free': 'energy_free_final',
    # Not that energy_extrapolated_final parsed is the entropy term
    'energy_no_entropy': 'energy_extrapolated_final',
    'energy_extrapolated_electronic': 'energy_extrapolated',
    'energy_free_electronic': 'energy_free',
    'energy_no_entropy_electronic': 'energy_no_entropy',
}
```