### PR TITLE
Same pymatgen version dependency as aiida-core v1.6.5

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -89,7 +89,7 @@
 	"aiida-core[atomic_tools] >= 1.2.1,!=1.4.0,!=1.4.1,<2",
 	"psycopg2-binary~=2.8.3",
 	"subprocess32",
-	"pymatgen<=2020.12.3",
+	"pymatgen>=2019.7.2,<=2022.02.03,!=2019.9.7",
 	"lxml",
 	"packaging",
 	"parsevasp >= 2.0.1"


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description

When setting up aiida-core v1.6.5 (latest release at this moment) and then aiida-vasp installation, pymatgen is re-installed because of version mismatch of `setup.json` of these two. This PR is just use the same pymatgen version dependency as the aiida-core v1.6.5.