### PR TITLE
allow bypassing ionic check with settings

### DIFF
--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -764,12 +764,20 @@ class VaspWorkChain(BaseRestartWorkChain):
         """
         Check if the calculation has converged ionic structure.
         """
+
+        # Check if we have requested to ignore ionic convergence check at calculation level
+        # If so, then this handler should be by-passed
+        if 'settings' in node.inputs:
+            settings = node.inputs.settings.get_dict()
+            if not settings.get('CHECK_IONIC_CONVERGENCE', True):
+                return None
+
         misc = node.outputs.misc.get_dict()
         run_status = misc['run_status']
 
         # Check that the ionic structure is converged
         if run_status.get('ionic_converged') is False:
-            self.report(f'The child calculation {node} did not have converged electronic structure.')
+            self.report(f'The child calculation {node} did not have converged ionic structure.')
             return ProcessHandlerReport(exit_code=self.exit_codes.ERROR_IONIC_RELAXATION_NOT_CONVERGED, do_break=True)  #pylint: disable=no-member
         return None
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #538 

None of the above but is still related to the following:

## Description

The ionic convergence checkout should respect the `CHECK_IONIC_CONVERGENCE` flag in the settings that signals if the parser should be checking the ionic convergence and set exit_code accordingly. If the parser ignores it, the workchain should also ignore it.

Otherwise, the user can manually disable the handler with `handler_overrides` input to the workchain. But I can not think of a practical scenario where the parser ignores it but the workchain does not.