### PR TITLE
Pinned parsevasp to commit before work on parsing infrastructure started

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -92,6 +92,6 @@
 	"pymatgen>=2019.7.2,<=2022.02.03,!=2019.9.7",
 	"lxml",
 	"packaging",
-	"parsevasp >= 2.0.1"
+	"parsevasp@git+https://github.com/aiida-vasp/parsevasp#058bb26872588c4a83dbc93afcfbf638963be1fc"
     ]
 }

--- a/setup.json
+++ b/setup.json
@@ -92,6 +92,6 @@
 	"pymatgen>=2019.7.2,<=2022.02.03,!=2019.9.7",
 	"lxml",
 	"packaging",
-	"parsevasp@git+https://github.com/aiida-vasp/parsevasp#058bb26872588c4a83dbc93afcfbf638963be1fc"
+	"parsevasp@git+https://github.com/aiida-vasp/parsevasp@058bb26872588c4a83dbc93afcfbf638963be1fc"
     ]
 }


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)

## Interactions with issues / other PRs

fixes:
#540

## Description
We pin the `parsevasp` version to a commit before the updates related to the work on the parsing infrastructure started. This way, the development branch of `aiida-vasp` is not broken.