### PR TITLE
Removed Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ notifications:
 dist: xenial
 language: python
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 services:
   - postgresql
   - rabbitmq

--- a/setup.json
+++ b/setup.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/aiida-vasp/aiida-vasp",
     "version": "2.1.1",
     "reentry_register": true,
+    "python_requires": ">=3.7",
     "setup_requires": [
 	"reentry"
     ],

--- a/setup.json
+++ b/setup.json
@@ -6,9 +6,9 @@
 	"Environment :: Plugins",
 	"Intended Audience :: Science/Research",
 	"License :: OSI Approved :: MIT License",
-	"Programming Language :: Python :: 3.6",
 	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
+	"Programming Language :: Python :: 3.9",
 	"Topic :: Scientific/Engineering :: Physics",
 	"Topic :: Scientific/Engineering :: Chemistry",
 	"Framework :: AiiDA"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38}-aiida_vasp
+envlist = {py37,py38,py39}-aiida_vasp
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)

## Interactions with issues / other PRs

fixes:
#542

## Description
Removed all things related to Python 3.6 and also added `python_requires`. Implicitly we depend on this as we depend on `aiida_core`, but maybe nice to have it explicitly in the file.