### PR TITLE
Minimum fix of parsing energy for non-VASP5

### DIFF
--- a/aiida_vasp/parsers/file_parsers/vasprun.py
+++ b/aiida_vasp/parsers/file_parsers/vasprun.py
@@ -588,7 +588,6 @@ class VasprunParser(BaseFileParser):
                 # which is then recovered as `energy_no_entropy` later
                 energies['energy_extrapolated_final'] = energies['energy_free_final'] - energies['energy_extrapolated_final']
         else:
-            etype = [ENERGY_MAPPING[key] for key in etype.items()]
             energies = self._xml.get_energies(status='all', etype=etype, nosc=nosc)
 
         if energies is None:

--- a/aiida_vasp/test_data/basic/vasprun621.xml
+++ b/aiida_vasp/test_data/basic/vasprun621.xml
@@ -1,0 +1,993 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">6.2.1  </i>
+  <i name="subversion" type="string">16May21 (build Nov 17 2021 16:16:37) complex                          parallel </i>
+  <i name="platform" type="string">LinuxIFC </i>
+  <i name="date" type="string">2021 11 24 </i>
+  <i name="time" type="string">17:36:04 </i>
+ </generator>
+ <incar>
+  <i type="string" name="PREC">NORMAL</i>
+  <i type="int" name="IALGO">    38</i>
+  <i name="EDIFF">      0.00010000</i>
+  <i name="ENCUT">    200.00000000</i>
+  <i type="int" name="ISMEAR">     0</i>
+  <i name="SIGMA">      0.10000000</i>
+ </incar>
+ <primitive_cell>
+  <structure name="primitive_cell" >
+   <crystal>
+    <varray name="basis" >
+     <v>       2.71550000       0.00000000       2.71550000 </v>
+     <v>       2.71550000       2.71550000       0.00000000 </v>
+     <v>       0.00000000       2.71550000       2.71550000 </v>
+    </varray>
+    <i name="volume">     40.04786950 </i>
+    <varray name="rec_basis" >
+     <v>       0.18412815      -0.18412815       0.18412815 </v>
+     <v>       0.18412815       0.18412815      -0.18412815 </v>
+     <v>      -0.18412815       0.18412815       0.18412815 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.87500000       0.87500000       0.87500000 </v>
+    <v>       0.12500000       0.12500000       0.12500000 </v>
+   </varray>
+  </structure>
+  <varray name="primitive_index" >
+   <v type="int" >        1 </v>
+   <v type="int" >        2 </v>
+  </varray>
+ </primitive_cell>
+ <kpoints>
+  <generation param="Gamma">
+   <v type="int" name="divisions">       2        2        2 </v>
+   <v name="usershift">      0.00000000       0.00000000       0.00000000 </v>
+   <v name="genvec1">      0.50000000       0.00000000       0.00000000 </v>
+   <v name="genvec2">      0.00000000       0.50000000       0.00000000 </v>
+   <v name="genvec3">      0.00000000       0.00000000       0.50000000 </v>
+   <v name="shift">      0.00000000       0.00000000       0.00000000 </v>
+  </generation>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.50000000       0.00000000 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.12500000 </v>
+   <v>       0.50000000 </v>
+   <v>       0.37500000 </v>
+  </varray>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">unknown system</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">normal</i>
+   <i name="ENMAX">    200.00000000</i>
+   <i name="ENAUG">    322.06900000</i>
+   <i name="EDIFF">      0.00010000</i>
+   <i type="int" name="IALGO">    38</i>
+   <i type="int" name="IWAVPR">    10</i>
+   <i type="int" name="NBANDS">    24</i>
+   <i type="int" name="NBANDSLOW">    -1</i>
+   <i type="int" name="NBANDSHIGH">    -1</i>
+   <i name="NELECT">      8.00000000</i>
+   <i type="int" name="TURBO">     0</i>
+   <i type="int" name="IRESTART">     0</i>
+   <i type="int" name="NREBOOT">     0</i>
+   <i type="int" name="NMIN">     0</i>
+   <i name="EREF">      0.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">     0</i>
+    <i name="SIGMA">      0.10000000</i>
+    <i name="KSPACING">      0.50000000</i>
+    <i type="logical" name="KGAMMA"> T  </i>
+    <i type="logical" name="KBLOWUP"> T  </i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> F  </i>
+    <v name="ROPT">      0.00000000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+    <i type="logical" name="NLSPLINE"> F  </i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">     2</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     1</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      1.00000000      1.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">    60</i>
+    <i type="int" name="NELMDL">    -5</i>
+    <i type="int" name="NELMIN">     2</i>
+    <i name="ENINI">    200.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i type="logical" name="LSUBROT"> F  </i>
+     <i name="WEIMIN">      0.00000000</i>
+     <i name="EBREAK">      0.00000104</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="logical" name="MIXFIRST"> F  </i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    14</i>
+   <i type="int" name="NGY">    14</i>
+   <i type="int" name="NGZ">    14</i>
+   <i type="int" name="NGXF">    28</i>
+   <i type="int" name="NGYF">    28</i>
+   <i type="int" name="NGZF">    28</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">     0</i>
+   <i type="int" name="IBRION">    -1</i>
+   <i type="int" name="MDALGO">     0</i>
+   <i type="int" name="ISIF">     2</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00100000</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      0.50000000</i>
+   <i name="SMASS">     -3.00000000</i>
+   <i name="SCALEE">      1.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">     1</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     16.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     2</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="int" name="LORBIT">     0</i>
+   <v name="RWIGS">     -1.00000000</v>
+   <i type="int" name="NEDOS">   301</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     2</i>
+   <i type="logical" name="LWAVE"> T  </i>
+   <i type="logical" name="LDOWNSAMPLE"> F  </i>
+   <i type="logical" name="LCHARG"> T  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LVHAR"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">    24</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    -1</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> T  </i>
+   <i type="logical" name="LSCAAWARE"> T  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+   <i type="logical" name="LORBITALREAL"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="int" name="PHON_NSTRUCT">    -1</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">     28.08500000</v>
+   <v name="DARWINR">      0.00000000</v>
+   <v name="DARWINV">      1.00000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="string" name="PRECFOCK"></i>
+   <i type="logical" name="LSYMGRAD"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i type="logical" name="LFOCKACE"> F  </i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="MCALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i type="logical" name="LFOCKAEDFT"> F  </i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+   <i type="int" name="NBANDSGWLOW">     0</i>
+  </separator>
+  <separator name="vdW DFT" >
+   <i type="logical" name="LUSE_VDW"> F  </i>
+   <i name="Zab_VDW">     -0.84910000</i>
+   <i name="PARAM1">      0.12340000</i>
+   <i name="PARAM2">      1.00000000</i>
+   <i name="PARAM3">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     12.01436085</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i type="int" name="KINTER">     0</i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+   <i name="DEG_THRESHOLD">      0.00200000</i>
+   <i name="RTIME">     -0.10000000</i>
+   <i name="WPLASMAI">      0.00000000</i>
+   <v name="DFIELD">      0.00000000      0.00000000      0.00000000</v>
+   <v name="WPLASMA">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="NUCIND"> F  </i>
+   <v name="MAGPOS">      0.00000000      0.00000000      0.00000000</v>
+   <i type="logical" name="LNICSALL"> T  </i>
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LFINITE_TEMPERATURE"> F  </i>
+   <i type="logical" name="LADDER"> F  </i>
+   <i type="logical" name="LRPAFORCE"> F  </i>
+   <i type="logical" name="LFXC"> F  </i>
+   <i type="logical" name="LHARTREE"> T  </i>
+   <i type="int" name="IBSE">     0</i>
+   <v type="int" name="KPOINT">    -1     0     0     0</v>
+   <i type="logical" name="LTCTC"> F  </i>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="LTRIPLET"> F  </i>
+   <i type="logical" name="LFXCEPS"> F  </i>
+   <i type="logical" name="LFXHEG"> F  </i>
+   <i type="int" name="NATURALO">     2</i>
+   <i type="logical" name="LHOLEGF"> F  </i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LDMP1"> F  </i>
+   <i type="logical" name="LMP2LT"> F  </i>
+   <i type="logical" name="LSMP2LT"> F  </i>
+   <i type="logical" name="LGWLF"> F  </i>
+   <i name="ENCUTGW">     -2.00000000</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="logical" name="LESF_SPLINES"> F  </i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSO">    -1</i>
+   <i type="int" name="NBANDSV">    -1</i>
+   <i type="int" name="NELM">     1</i>
+   <i type="int" name="NELMHF">     1</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="IESPILON">     4</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGAMIN">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">     0</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="LSELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="LSPECTRALGW"> F  </i>
+   <i type="logical" name="LSINGLES"> F  </i>
+   <i type="logical" name="LFERMIGW"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  2800</i>
+   <i type="int" name="TELESCOPE">     0</i>
+   <i type="int" name="NTAUPAR">    -1</i>
+   <i type="int" name="NOMEGAPAR">    -1</i>
+   <i name="DAMP_NEWTON">      0.80000001</i>
+   <i name="LAMBDA">      1.00000000</i>
+  </separator>
+  <separator name="External order field" >
+   <i name="OFIELD_KAPPA">      0.00000000</i>
+   <v name="OFIELD_K">      0.00000000      0.00000000      0.00000000</v>
+   <i name="OFIELD_Q6_NEAR">      0.00000000</i>
+   <i name="OFIELD_Q6_FAR">      0.00000000</i>
+   <i name="OFIELD_A">      0.00000000</i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       2 </atoms>
+  <types>       1 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Si</c><c>   1</c></rc>
+    <rc><c>Si</c><c>   1</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   2</c><c>Si</c><c>     28.08500000</c><c>      4.00000000</c><c>  PAW_PBE Si 05Jan2001                  </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       2.71550000       0.00000000       2.71550000 </v>
+    <v>       2.71550000       2.71550000       0.00000000 </v>
+    <v>       0.00000000       2.71550000       2.71550000 </v>
+   </varray>
+   <i name="volume">     40.04786950 </i>
+   <varray name="rec_basis" >
+    <v>       0.18412815      -0.18412815       0.18412815 </v>
+    <v>       0.18412815       0.18412815      -0.18412815 </v>
+    <v>      -0.18412815       0.18412815       0.18412815 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.87500000       0.87500000       0.87500000 </v>
+   <v>       0.12500000       0.12500000       0.12500000 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.03    0.03</time>
+   <energy>
+    <i name="alphaZ">      3.36228930 </i>
+    <i name="ewald">   -228.52143995 </i>
+    <i name="hartreedc">    -11.00937461 </i>
+    <i name="XCdc">    -18.60393110 </i>
+    <i name="pawpsdc">    176.24759923 </i>
+    <i name="pawaedc">   -141.06103558 </i>
+    <i name="eentropy">     -0.00000093 </i>
+    <i name="bandstr">      6.06906427 </i>
+    <i name="atom">    206.11247263 </i>
+    <i name="e_fr_energy">     -7.40435674 </i>
+    <i name="e_wo_entrp">     -7.40435581 </i>
+    <i name="e_0_energy">     -7.40435628 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.60679180 </i>
+    <i name="e_wo_entrp">     -8.60679180 </i>
+    <i name="e_0_energy">     -8.60679180 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.60777837 </i>
+    <i name="e_wo_entrp">     -8.60777837 </i>
+    <i name="e_0_energy">     -8.60777837 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.03    0.03</time>
+   <time name="total">    0.03    0.03</time>
+   <energy>
+    <i name="e_fr_energy">     -8.60777870 </i>
+    <i name="e_wo_entrp">     -8.60777870 </i>
+    <i name="e_0_energy">     -8.60777870 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.60777870 </i>
+    <i name="e_wo_entrp">     -8.60777870 </i>
+    <i name="e_0_energy">     -8.60777870 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.01    0.01</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.34632586 </i>
+    <i name="e_wo_entrp">     -8.34632586 </i>
+    <i name="e_0_energy">     -8.34632586 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.03    0.03</time>
+   <energy>
+    <i name="e_fr_energy">     -8.23486984 </i>
+    <i name="e_wo_entrp">     -8.23482834 </i>
+    <i name="e_0_energy">     -8.23484909 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.01    0.01</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.24003824 </i>
+    <i name="e_wo_entrp">     -8.24002737 </i>
+    <i name="e_0_energy">     -8.24003281 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.02    0.02</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="e_fr_energy">     -8.24085204 </i>
+    <i name="e_wo_entrp">     -8.24084439 </i>
+    <i name="e_0_energy">     -8.24084822 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    0.01    0.01</time>
+   <time name="total">    0.02    0.02</time>
+   <energy>
+    <i name="alphaZ">      3.36228930 </i>
+    <i name="ewald">   -228.52143995 </i>
+    <i name="hartreedc">    -17.19169200 </i>
+    <i name="XCdc">    -17.66740802 </i>
+    <i name="pawpsdc">   1392.13338137 </i>
+    <i name="pawaedc">  -1357.24450596 </i>
+    <i name="eentropy">     -0.00000687 </i>
+    <i name="bandstr">     10.77596326 </i>
+    <i name="atom">    206.11247263 </i>
+    <i name="e_fr_energy">     -8.24094623 </i>
+    <i name="e_wo_entrp">     -8.24093936 </i>
+    <i name="e_0_energy">     -8.24094279 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       2.71550000       0.00000000       2.71550000 </v>
+     <v>       2.71550000       2.71550000       0.00000000 </v>
+     <v>       0.00000000       2.71550000       2.71550000 </v>
+    </varray>
+    <i name="volume">     40.04786950 </i>
+    <varray name="rec_basis" >
+     <v>       0.18412815      -0.18412815       0.18412815 </v>
+     <v>       0.18412815       0.18412815      -0.18412815 </v>
+     <v>      -0.18412815       0.18412815       0.18412815 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.87500000       0.87500000       0.87500000 </v>
+    <v>       0.12500000       0.12500000       0.12500000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>      -0.00000000      -0.00000000      -0.00000000 </v>
+  </varray>
+  <varray name="stress" >
+   <v>      96.61478144       0.00000000       0.00000000 </v>
+   <v>      -0.00000000      96.61478144       0.00000000 </v>
+   <v>       0.00000000       0.00000000      96.61478144 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -8.24094623 </i>
+   <i name="e_wo_entrp">     -8.24093936 </i>
+   <i name="e_0_energy">     -8.24094279 </i>
+  </energy>
+  <time name="totalsc">    0.29    0.32</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>   -5.8858    1.0000 </r>
+       <r>    6.1522    1.0000 </r>
+       <r>    6.1522    1.0000 </r>
+       <r>    6.1522    1.0000 </r>
+       <r>    8.6016    0.0000 </r>
+       <r>    8.6016    0.0000 </r>
+       <r>    8.6016    0.0000 </r>
+       <r>    9.5217    0.0000 </r>
+       <r>   13.8304    0.0000 </r>
+       <r>   13.8304    0.0000 </r>
+       <r>   14.0847    0.0000 </r>
+       <r>   17.2713    0.0000 </r>
+       <r>   17.2714    0.0000 </r>
+       <r>   17.2714    0.0000 </r>
+       <r>   21.5435    0.0000 </r>
+       <r>   29.6240    0.0000 </r>
+       <r>   29.6240    0.0000 </r>
+       <r>   29.6240    0.0000 </r>
+       <r>   30.9277    0.0000 </r>
+       <r>   30.9277    0.0000 </r>
+       <r>   32.0850    0.0000 </r>
+       <r>   32.0852    0.0000 </r>
+       <r>   32.0852    0.0000 </r>
+       <r>   35.2394    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>   -3.5329    1.0000 </r>
+       <r>   -0.9057    1.0000 </r>
+       <r>    4.9111    1.0000 </r>
+       <r>    4.9111    1.0000 </r>
+       <r>    7.6474    0.0000 </r>
+       <r>    9.3739    0.0000 </r>
+       <r>    9.3740    0.0000 </r>
+       <r>   13.7885    0.0000 </r>
+       <r>   16.7642    0.0000 </r>
+       <r>   16.7643    0.0000 </r>
+       <r>   17.4530    0.0000 </r>
+       <r>   17.4530    0.0000 </r>
+       <r>   17.5622    0.0000 </r>
+       <r>   19.1509    0.0000 </r>
+       <r>   25.7913    0.0000 </r>
+       <r>   26.1126    0.0000 </r>
+       <r>   27.9118    0.0000 </r>
+       <r>   27.9120    0.0000 </r>
+       <r>   28.0990    0.0000 </r>
+       <r>   28.0994    0.0000 </r>
+       <r>   32.0877    0.0000 </r>
+       <r>   32.6545    0.0000 </r>
+       <r>   32.6550    0.0000 </r>
+       <r>   33.8549    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>   -1.7180    1.0000 </r>
+       <r>   -1.7180    1.0000 </r>
+       <r>    3.2177    1.0000 </r>
+       <r>    3.2178    1.0000 </r>
+       <r>    6.7545    0.0000 </r>
+       <r>    6.7546    0.0000 </r>
+       <r>   16.2373    0.0000 </r>
+       <r>   16.2373    0.0000 </r>
+       <r>   17.2816    0.0000 </r>
+       <r>   17.2817    0.0000 </r>
+       <r>   18.6974    0.0000 </r>
+       <r>   18.6974    0.0000 </r>
+       <r>   19.2285    0.0000 </r>
+       <r>   19.2286    0.0000 </r>
+       <r>   25.1755    0.0000 </r>
+       <r>   25.1757    0.0000 </r>
+       <r>   25.8478    0.0000 </r>
+       <r>   25.8478    0.0000 </r>
+       <r>   26.2741    0.0000 </r>
+       <r>   26.2741    0.0000 </r>
+       <r>   27.5731    0.0000 </r>
+       <r>   27.5732    0.0000 </r>
+       <r>   32.1699    0.0000 </r>
+       <r>   32.1706    0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      6.44789926 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r>    -7.9421     0.0000     0.0000 </r>
+       <r>    -7.7913     0.0000     0.0000 </r>
+       <r>    -7.6405     0.0000     0.0000 </r>
+       <r>    -7.4897     0.0000     0.0000 </r>
+       <r>    -7.3389     0.0000     0.0000 </r>
+       <r>    -7.1881     0.0000     0.0000 </r>
+       <r>    -7.0374     0.0000     0.0000 </r>
+       <r>    -6.8866     0.0000     0.0000 </r>
+       <r>    -6.7358     0.0000     0.0000 </r>
+       <r>    -6.5850     0.0000     0.0000 </r>
+       <r>    -6.4342     0.0000     0.0000 </r>
+       <r>    -6.2834     0.0000     0.0000 </r>
+       <r>    -6.1326     0.0004     0.0001 </r>
+       <r>    -5.9818     0.1445     0.0218 </r>
+       <r>    -5.8310     1.1499     0.1952 </r>
+       <r>    -5.6802     0.3601     0.2495 </r>
+       <r>    -5.5294     0.0030     0.2500 </r>
+       <r>    -5.3786     0.0000     0.2500 </r>
+       <r>    -5.2278     0.0000     0.2500 </r>
+       <r>    -5.0770     0.0000     0.2500 </r>
+       <r>    -4.9263     0.0000     0.2500 </r>
+       <r>    -4.7755     0.0000     0.2500 </r>
+       <r>    -4.6247     0.0000     0.2500 </r>
+       <r>    -4.4739     0.0000     0.2500 </r>
+       <r>    -4.3231     0.0000     0.2500 </r>
+       <r>    -4.1723     0.0000     0.2500 </r>
+       <r>    -4.0215     0.0000     0.2500 </r>
+       <r>    -3.8707     0.0000     0.2500 </r>
+       <r>    -3.7199     0.0271     0.2541 </r>
+       <r>    -3.5691     1.9899     0.5541 </r>
+       <r>    -3.4183     4.2657     1.1974 </r>
+       <r>    -3.2675     0.3483     1.2499 </r>
+       <r>    -3.1167     0.0006     1.2500 </r>
+       <r>    -2.9659     0.0000     1.2500 </r>
+       <r>    -2.8152     0.0000     1.2500 </r>
+       <r>    -2.6644     0.0000     1.2500 </r>
+       <r>    -2.5136     0.0000     1.2500 </r>
+       <r>    -2.3628     0.0000     1.2500 </r>
+       <r>    -2.2120     0.0000     1.2500 </r>
+       <r>    -2.0612     0.0000     1.2500 </r>
+       <r>    -1.9104     0.0323     1.2549 </r>
+       <r>    -1.7596     2.7327     1.6669 </r>
+       <r>    -1.6088     6.5722     2.6580 </r>
+       <r>    -1.4580     0.6090     2.7498 </r>
+       <r>    -1.3072     0.0012     2.7500 </r>
+       <r>    -1.1564     0.0013     2.7502 </r>
+       <r>    -1.0056     0.5217     2.8289 </r>
+       <r>    -0.8549     4.5447     3.5142 </r>
+       <r>    -0.7041     1.5496     3.7478 </r>
+       <r>    -0.5533     0.0144     3.7500 </r>
+       <r>    -0.4025     0.0000     3.7500 </r>
+       <r>    -0.2517     0.0000     3.7500 </r>
+       <r>    -0.1009     0.0000     3.7500 </r>
+       <r>     0.0499     0.0000     3.7500 </r>
+       <r>     0.2007     0.0000     3.7500 </r>
+       <r>     0.3515     0.0000     3.7500 </r>
+       <r>     0.5023     0.0000     3.7500 </r>
+       <r>     0.6531     0.0000     3.7500 </r>
+       <r>     0.8039     0.0000     3.7500 </r>
+       <r>     0.9547     0.0000     3.7500 </r>
+       <r>     1.1055     0.0000     3.7500 </r>
+       <r>     1.2562     0.0000     3.7500 </r>
+       <r>     1.4070     0.0000     3.7500 </r>
+       <r>     1.5578     0.0000     3.7500 </r>
+       <r>     1.7086     0.0000     3.7500 </r>
+       <r>     1.8594     0.0000     3.7500 </r>
+       <r>     2.0102     0.0000     3.7500 </r>
+       <r>     2.1610     0.0000     3.7500 </r>
+       <r>     2.3118     0.0000     3.7500 </r>
+       <r>     2.4626     0.0000     3.7500 </r>
+       <r>     2.6134     0.0000     3.7500 </r>
+       <r>     2.7642     0.0000     3.7500 </r>
+       <r>     2.9150     0.0001     3.7500 </r>
+       <r>     3.0658     0.1571     3.7737 </r>
+       <r>     3.2165     4.7495     4.4899 </r>
+       <r>     3.3673     4.8697     5.2242 </r>
+       <r>     3.5181     0.1709     5.2500 </r>
+       <r>     3.6689     0.0001     5.2500 </r>
+       <r>     3.8197     0.0000     5.2500 </r>
+       <r>     3.9705     0.0000     5.2500 </r>
+       <r>     4.1213     0.0000     5.2500 </r>
+       <r>     4.2721     0.0000     5.2500 </r>
+       <r>     4.4229     0.0000     5.2500 </r>
+       <r>     4.5737     0.0000     5.2500 </r>
+       <r>     4.7245     0.0551     5.2583 </r>
+       <r>     4.8753     4.0051     5.8622 </r>
+       <r>     5.0261     8.5132     7.1460 </r>
+       <r>     5.1769     0.6887     7.2498 </r>
+       <r>     5.3276     0.0011     7.2500 </r>
+       <r>     5.4784     0.0000     7.2500 </r>
+       <r>     5.6292     0.0000     7.2500 </r>
+       <r>     5.7800     0.0000     7.2500 </r>
+       <r>     5.9308     0.0043     7.2507 </r>
+       <r>     6.0816     0.7865     7.3693 </r>
+       <r>     6.2324     3.5442     7.9037 </r>
+       <r>     6.3832     0.6359     7.9996 </r>
+       <r>     6.5340     0.0117     8.0014 </r>
+       <r>     6.6848     1.6018     8.2429 </r>
+       <r>     6.8356     7.0842     9.3112 </r>
+       <r>     6.9864     1.2472     9.4992 </r>
+       <r>     7.1372     0.0052     9.5000 </r>
+       <r>     7.2879     0.0000     9.5000 </r>
+       <r>     7.4387     0.0105     9.5016 </r>
+       <r>     7.5895     1.3582     9.7064 </r>
+       <r>     7.7403     4.6362    10.4055 </r>
+       <r>     7.8911     0.6248    10.4997 </r>
+       <r>     8.0419     0.0019    10.5000 </r>
+       <r>     8.1927     0.0000    10.5000 </r>
+       <r>     8.3435     0.0007    10.5001 </r>
+       <r>     8.4943     0.3208    10.5485 </r>
+       <r>     8.6451     3.3137    11.0482 </r>
+       <r>     8.7959     1.3237    11.2478 </r>
+       <r>     8.9467     0.0149    11.2500 </r>
+       <r>     9.0975     0.0006    11.2501 </r>
+       <r>     9.2483     0.5002    11.3255 </r>
+       <r>     9.3990     8.0397    12.5378 </r>
+       <r>     9.5498     5.7226    13.4008 </r>
+       <r>     9.7006     0.6486    13.4986 </r>
+       <r>     9.8514     0.0095    13.5000 </r>
+       <r>    10.0022     0.0000    13.5000 </r>
+       <r>    10.1530     0.0000    13.5000 </r>
+       <r>    10.3038     0.0000    13.5000 </r>
+       <r>    10.4546     0.0000    13.5000 </r>
+       <r>    10.6054     0.0000    13.5000 </r>
+       <r>    10.7562     0.0000    13.5000 </r>
+       <r>    10.9070     0.0000    13.5000 </r>
+       <r>    11.0578     0.0000    13.5000 </r>
+       <r>    11.2086     0.0000    13.5000 </r>
+       <r>    11.3594     0.0000    13.5000 </r>
+       <r>    11.5101     0.0000    13.5000 </r>
+       <r>    11.6609     0.0000    13.5000 </r>
+       <r>    11.8117     0.0000    13.5000 </r>
+       <r>    11.9625     0.0000    13.5000 </r>
+       <r>    12.1133     0.0000    13.5000 </r>
+       <r>    12.2641     0.0000    13.5000 </r>
+       <r>    12.4149     0.0000    13.5000 </r>
+       <r>    12.5657     0.0000    13.5000 </r>
+       <r>    12.7165     0.0000    13.5000 </r>
+       <r>    12.8673     0.0000    13.5000 </r>
+       <r>    13.0181     0.0000    13.5000 </r>
+       <r>    13.1689     0.0000    13.5000 </r>
+       <r>    13.3197     0.0000    13.5000 </r>
+       <r>    13.4704     0.0000    13.5000 </r>
+       <r>    13.6212     0.0648    13.5098 </r>
+       <r>    13.7720     3.3189    14.0102 </r>
+       <r>    13.9228     6.0745    14.9262 </r>
+       <r>    14.0736     1.2141    15.1093 </r>
+       <r>    14.2244     0.8931    15.2440 </r>
+       <r>    14.3752     0.0399    15.2500 </r>
+       <r>    14.5260     0.0000    15.2500 </r>
+       <r>    14.6768     0.0000    15.2500 </r>
+       <r>    14.8276     0.0000    15.2500 </r>
+       <r>    14.9784     0.0000    15.2500 </r>
+       <r>    15.1292     0.0000    15.2500 </r>
+       <r>    15.2800     0.0000    15.2500 </r>
+       <r>    15.4308     0.0000    15.2500 </r>
+       <r>    15.5815     0.0000    15.2500 </r>
+       <r>    15.7323     0.0000    15.2500 </r>
+       <r>    15.8831     0.0000    15.2500 </r>
+       <r>    16.0339     0.0200    15.2530 </r>
+       <r>    16.1847     2.2518    15.5926 </r>
+       <r>    16.3355     6.8548    16.6262 </r>
+       <r>    16.4863     0.8192    16.7498 </r>
+       <r>    16.6371     0.4798    16.8221 </r>
+       <r>    16.7879     7.8888    18.0117 </r>
+       <r>    16.9387     4.8058    18.7364 </r>
+       <r>    17.0895     0.1482    18.7587 </r>
+       <r>    17.2403     4.3788    19.4190 </r>
+       <r>    17.3911    12.2314    21.2634 </r>
+       <r>    17.5418    12.6930    23.1774 </r>
+       <r>    17.6926     5.2345    23.9667 </r>
+       <r>    17.8434     0.2204    24.0000 </r>
+       <r>    17.9942     0.0002    24.0000 </r>
+       <r>    18.1450     0.0000    24.0000 </r>
+       <r>    18.2958     0.0000    24.0000 </r>
+       <r>    18.4466     0.0019    24.0003 </r>
+       <r>    18.5974     0.7800    24.1179 </r>
+       <r>    18.7482     6.8142    25.1454 </r>
+       <r>    18.8990     2.3309    25.4969 </r>
+       <r>    19.0498     0.5836    25.5849 </r>
+       <r>    19.2006     7.9118    26.7780 </r>
+       <r>    19.3514     7.6789    27.9359 </r>
+       <r>    19.5022     0.4246    27.9999 </r>
+       <r>    19.6529     0.0005    28.0000 </r>
+       <r>    19.8037     0.0000    28.0000 </r>
+       <r>    19.9545     0.0000    28.0000 </r>
+       <r>    20.1053     0.0000    28.0000 </r>
+       <r>    20.2561     0.0000    28.0000 </r>
+       <r>    20.4069     0.0000    28.0000 </r>
+       <r>    20.5577     0.0000    28.0000 </r>
+       <r>    20.7085     0.0000    28.0000 </r>
+       <r>    20.8593     0.0000    28.0000 </r>
+       <r>    21.0101     0.0000    28.0000 </r>
+       <r>    21.1609     0.0000    28.0000 </r>
+       <r>    21.3117     0.0009    28.0001 </r>
+       <r>    21.4625     0.2078    28.0315 </r>
+       <r>    21.6133     1.1807    28.2095 </r>
+       <r>    21.7640     0.2670    28.2498 </r>
+       <r>    21.9148     0.0015    28.2500 </r>
+       <r>    22.0656     0.0000    28.2500 </r>
+       <r>    22.2164     0.0000    28.2500 </r>
+       <r>    22.3672     0.0000    28.2500 </r>
+       <r>    22.5180     0.0000    28.2500 </r>
+       <r>    22.6688     0.0000    28.2500 </r>
+       <r>    22.8196     0.0000    28.2500 </r>
+       <r>    22.9704     0.0000    28.2500 </r>
+       <r>    23.1212     0.0000    28.2500 </r>
+       <r>    23.2720     0.0000    28.2500 </r>
+       <r>    23.4228     0.0000    28.2500 </r>
+       <r>    23.5736     0.0000    28.2500 </r>
+       <r>    23.7243     0.0000    28.2500 </r>
+       <r>    23.8751     0.0000    28.2500 </r>
+       <r>    24.0259     0.0000    28.2500 </r>
+       <r>    24.1767     0.0000    28.2500 </r>
+       <r>    24.3275     0.0000    28.2500 </r>
+       <r>    24.4783     0.0000    28.2500 </r>
+       <r>    24.6291     0.0000    28.2500 </r>
+       <r>    24.7799     0.0000    28.2500 </r>
+       <r>    24.9307     0.0026    28.2504 </r>
+       <r>    25.0815     0.9081    28.3873 </r>
+       <r>    25.2323     6.9330    29.4328 </r>
+       <r>    25.3831     2.0871    29.7475 </r>
+       <r>    25.5339     0.0176    29.7501 </r>
+       <r>    25.6847     0.5404    29.8316 </r>
+       <r>    25.8354     8.6124    31.1303 </r>
+       <r>    25.9862     7.4016    32.2464 </r>
+       <r>    26.1370     4.4961    32.9244 </r>
+       <r>    26.2878     7.8522    34.1085 </r>
+       <r>    26.4386     4.1548    34.7350 </r>
+       <r>    26.5894     0.0995    34.7500 </r>
+       <r>    26.7402     0.0000    34.7500 </r>
+       <r>    26.8910     0.0000    34.7500 </r>
+       <r>    27.0418     0.0000    34.7500 </r>
+       <r>    27.1926     0.0000    34.7500 </r>
+       <r>    27.3434     0.0058    34.7509 </r>
+       <r>    27.4942     1.3082    34.9481 </r>
+       <r>    27.6450     7.0944    36.0179 </r>
+       <r>    27.7957     2.1971    36.3492 </r>
+       <r>    27.9465     8.6696    37.6565 </r>
+       <r>    28.0973    10.3684    39.2200 </r>
+       <r>    28.2481     6.5969    40.2148 </r>
+       <r>    28.3989     0.2334    40.2500 </r>
+       <r>    28.5497     0.0001    40.2500 </r>
+       <r>    28.7005     0.0000    40.2500 </r>
+       <r>    28.8513     0.0000    40.2500 </r>
+       <r>    29.0021     0.0000    40.2500 </r>
+       <r>    29.1529     0.0000    40.2500 </r>
+       <r>    29.3037     0.0000    40.2500 </r>
+       <r>    29.4545     0.0410    40.2562 </r>
+       <r>    29.6053     1.9260    40.5466 </r>
+       <r>    29.7561     2.8529    40.9768 </r>
+       <r>    29.9068     0.1536    41.0000 </r>
+       <r>    30.0576     0.0002    41.0000 </r>
+       <r>    30.2084     0.0000    41.0000 </r>
+       <r>    30.3592     0.0000    41.0000 </r>
+       <r>    30.5100     0.0000    41.0000 </r>
+       <r>    30.6608     0.0003    41.0000 </r>
+       <r>    30.8116     0.1665    41.0251 </r>
+       <r>    30.9624     2.1149    41.3441 </r>
+       <r>    31.1132     1.0197    41.4978 </r>
+       <r>    31.2640     0.0144    41.5000 </r>
+       <r>    31.4148     0.0000    41.5000 </r>
+       <r>    31.5656     0.0000    41.5000 </r>
+       <r>    31.7164     0.0000    41.5000 </r>
+       <r>    31.8671     0.0112    41.5017 </r>
+       <r>    32.0179     2.0695    41.8138 </r>
+       <r>    32.1687    12.9899    43.7725 </r>
+       <r>    32.3195     6.3036    44.7231 </r>
+       <r>    32.4703     0.2388    44.7591 </r>
+       <r>    32.6211     4.1457    45.3842 </r>
+       <r>    32.7719     8.4102    46.6524 </r>
+       <r>    32.9227     0.6461    46.7498 </r>
+       <r>    33.0735     0.0010    46.7500 </r>
+       <r>    33.2243     0.0000    46.7500 </r>
+       <r>    33.3751     0.0000    46.7500 </r>
+       <r>    33.5259     0.0000    46.7500 </r>
+       <r>    33.6767     0.0388    46.7559 </r>
+       <r>    33.8275     2.2744    47.0988 </r>
+       <r>    33.9782     4.0493    47.7094 </r>
+       <r>    34.1290     0.2688    47.7499 </r>
+       <r>    34.2798     0.0004    47.7500 </r>
+       <r>    34.4306     0.0000    47.7500 </r>
+       <r>    34.5814     0.0000    47.7500 </r>
+       <r>    34.7322     0.0000    47.7500 </r>
+       <r>    34.8830     0.0000    47.7500 </r>
+       <r>    35.0338     0.0030    47.7505 </r>
+       <r>    35.1846     0.3601    47.8048 </r>
+       <r>    35.3354     1.1499    47.9782 </r>
+       <r>    35.4862     0.1445    47.9999 </r>
+       <r>    35.6370     0.0004    48.0000 </r>
+       <r>    35.7878     0.0000    48.0000 </r>
+       <r>    35.9386     0.0000    48.0000 </r>
+       <r>    36.0893     0.0000    48.0000 </r>
+       <r>    36.2401     0.0000    48.0000 </r>
+       <r>    36.3909     0.0000    48.0000 </r>
+       <r>    36.5417     0.0000    48.0000 </r>
+       <r>    36.6925     0.0000    48.0000 </r>
+       <r>    36.8433     0.0000    48.0000 </r>
+       <r>    36.9941     0.0000    48.0000 </r>
+       <r>    37.1449     0.0000    48.0000 </r>
+       <r>    37.2957     0.0000    48.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+  </dos>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       2.71550000       0.00000000       2.71550000 </v>
+    <v>       2.71550000       2.71550000       0.00000000 </v>
+    <v>       0.00000000       2.71550000       2.71550000 </v>
+   </varray>
+   <i name="volume">     40.04786950 </i>
+   <varray name="rec_basis" >
+    <v>       0.18412815      -0.18412815       0.18412815 </v>
+    <v>       0.18412815       0.18412815      -0.18412815 </v>
+    <v>      -0.18412815       0.18412815       0.18412815 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.87500000       0.87500000       0.87500000 </v>
+   <v>       0.12500000       0.12500000       0.12500000 </v>
+  </varray>
+ </structure>
+</modeling>

--- a/aiida_vasp/utils/fixtures/__init__.py
+++ b/aiida_vasp/utils/fixtures/__init__.py
@@ -1,15 +1,15 @@
 """Expose all fixtures."""
-from .data import localhost_dir, localhost, vasp_params, potentials, vasp_structure, vasp_kpoints, vasp_code, ref_incar, \
-    ref_incar_vasp2w90, vasp_chgcar, vasp_wavecar, ref_retrieved, vasp_structure_poscar, temp_pot_folder, potcar_family, \
-    vasprun_parser, outcar_parser, mock_vasp, mock_vasp_strict, wannier_params, wannier_projections, ref_win, phonondb_run, vasp_inputs, \
-    vasp2w90_inputs, stream_parser
+from .data import (localhost_dir, localhost, vasp_params, potentials, vasp_structure, vasp_kpoints, vasp_code, ref_incar,
+                   ref_incar_vasp2w90, vasp_chgcar, vasp_wavecar, ref_retrieved, vasp_structure_poscar, temp_pot_folder, potcar_family,
+                   vasprun_parser, vasprun_parser_v621, outcar_parser, mock_vasp, mock_vasp_strict, wannier_params, wannier_projections,
+                   ref_win, phonondb_run, vasp_inputs, vasp2w90_inputs, stream_parser)
 from .environment import fresh_aiida_env
 from .calcs import base_calc, vasp_calc_and_ref, vasp2w90_calc_and_ref, vasp2w90_calc, vasp_calc, run_vasp_process
 
 __all__ = [
     'fresh_aiida_env', 'localhost_dir', 'localhost', 'vasp_params', 'potentials', 'vasp_structure', 'vasp_kpoints', 'vasp_code',
     'ref_incar', 'ref_incar_vasp2w90', 'vasp_chgcar', 'vasp_wavecar', 'ref_retrieved', 'vasp_calc_and_ref', 'vasp2w90_calc_and_ref',
-    'vasp2w90_calc', 'vasp_structure_poscar', 'temp_pot_folder', 'potcar_family', 'vasprun_parser', 'outcar_parser', 'mock_vasp',
-    'mock_vasp_strict', 'wannier_params', 'wannier_projections', 'ref_win', 'phonondb_run', 'base_calc', 'vasp_calc', 'vasp_inputs',
-    'vasp2w90_inputs', 'run_vasp_process', 'stream_parser'
+    'vasp2w90_calc', 'vasp_structure_poscar', 'temp_pot_folder', 'potcar_family', 'vasprun_parser', 'vasprun_parser_v621', 'outcar_parser',
+    'mock_vasp', 'mock_vasp_strict', 'wannier_params', 'wannier_projections', 'ref_win', 'phonondb_run', 'base_calc', 'vasp_calc',
+    'vasp_inputs', 'vasp2w90_inputs', 'run_vasp_process', 'stream_parser'
 ]

--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -422,6 +422,18 @@ def vasprun_parser(request):
     return parser
 
 
+@pytest.fixture(params=[('basic', {})])
+def vasprun_parser_v621(request):
+    """Return an instance of VasprunParser for a reference vasprun.xml of VASP6."""
+    from aiida_vasp.parsers.settings import ParserSettings
+    from aiida_vasp.calcs.vasp import VaspCalculation
+    file_name = 'vasprun621.xml'
+    path_to_file, settings = request.param
+    path = data_path(path_to_file, file_name)
+    parser = VasprunParser(file_path=path, settings=ParserSettings(settings), exit_codes=VaspCalculation.exit_codes)
+    return parser
+
+
 @pytest.fixture()
 def outcar_parser(request):
     """Return an instance of OutcarParser for a reference OUTCAR."""


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description

This causes error because `etype` is not a dict but a list.
https://github.com/aiida-vasp/aiida-vasp/blob/50f025e4df61c3cbc627ebef53ad624058ccf464/aiida_vasp/parsers/file_parsers/vasprun.py#L591
