### PR TITLE
Made custom_outputs work (issue #552)

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -112,6 +112,7 @@ class VaspCalculation(VaspCalcBase):
         spec.output('hessian', valid_type=get_data_class('array'), required=False, help='The output Hessian matrix.')
         spec.output('dynmat', valid_type=get_data_class('array'), required=False, help='The output dynamical matrix.')
         spec.output('site_magnetization', valid_type=get_data_class('dict'), required=False, help='The output of the site magnetization')
+        spec.output_namespace('custom_outputs', dynamic=True)
         spec.exit_code(0, 'NO_ERROR', message='the sun is shining')
         spec.exit_code(350,
                        'ERROR_NO_RETRIEVED_FOLDER',

--- a/aiida_vasp/parsers/node_composer.py
+++ b/aiida_vasp/parsers/node_composer.py
@@ -73,6 +73,9 @@ class NodeComposer:
         :return: An AiidaData object of a type corresponding to node_type.
         """
 
+        if node_type in ('float', 'int', 'str'):
+            return cls._compose_basic_type(node_type, inputs)
+
         # Call the correct specialised method for assembling.
         method_name = '_compose_' + node_type.replace('.', '_')
         return getattr(cls, method_name)(node_type, inputs)
@@ -102,6 +105,16 @@ class NodeComposer:
         for item in inputs:
             for key, value in inputs[item].items():
                 node.set_array(key, value)
+        return node
+
+    @staticmethod
+    def _compose_basic_type(node_type, inputs):
+        """Compose a basic type node (int, float, str)."""
+        node = None
+        for key in inputs:
+            # Technically this dictionary has only one key. to
+            # avoid problems with python 2/3 it is done with the loop.
+            node = get_data_class(node_type)(inputs[key])
         return node
 
     @staticmethod

--- a/aiida_vasp/parsers/settings.py
+++ b/aiida_vasp/parsers/settings.py
@@ -7,6 +7,7 @@ compositions of quantities.
 """
 # pylint: disable=import-outside-toplevel
 from copy import deepcopy
+
 from aiida_vasp.parsers.file_parsers.doscar import DosParser
 from aiida_vasp.parsers.file_parsers.eigenval import EigParser
 from aiida_vasp.parsers.file_parsers.kpoints import KpointsParser
@@ -213,7 +214,8 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
 
     """
 
-    def __init__(self, settings, default_settings=None):
+    def __init__(self, settings, default_settings=None, vasp_parser_logger=None):
+        self._vasp_parser_logger = vasp_parser_logger
         if settings is None:
             self._settings = {}
         else:
@@ -250,18 +252,26 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
         """Return the list of critical notification names to be checked"""
         return self._critical_error_list
 
-    def add_output_node(self, node_name, node_dict=None):
+    def add_output_node(self, node_name, node_dict, is_custom_node=False):
         """Add a definition of node to the nodes dictionary."""
-        if node_dict is None:
-            # Try to get a node_dict from NODES.
-            node_dict = deepcopy(NODES.get(node_name, {}))
+        _node_dict = deepcopy(node_dict)
 
-        # Check, whether the node_dict contains required keys 'type' and 'quantities'
-        for key in ['type', 'quantities']:
-            if node_dict.get(key) is None:
-                return
+        if is_custom_node:
+            if 'link_name' not in _node_dict:
+                _node_dict['link_name'] = node_name
+                self._vasp_parser_logger.info(f'\'{node_name}\' was set as \'link_name\' in node_dict.')
+            if 'quantities' not in node_dict:
+                _node_dict['quantities'] = [node_name]
+                self._vasp_parser_logger.info(f'\'{node_name}\' was set as \'quantities\' in node_dict.')
 
-        self._output_nodes_dict[node_name] = node_dict
+        # Check, whether the node_dict contains required keys.
+        exist_missing_key = False
+        for key in ['type', 'quantities', 'link_name']:
+            if key not in _node_dict:
+                self._vasp_parser_logger.warning(f'\'{key}\' was not found in node_dict.')
+                exist_missing_key = True
+        if not exist_missing_key:
+            self._output_nodes_dict[node_name] = _node_dict
 
     def get(self, item, default=None):
         return self._settings.get(item, default)
@@ -301,6 +311,8 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
 
             node_name = key[4:]
             node_dict = deepcopy(NODES.get(node_name, {}))
+            # Considered as custom node if node_dict == {}.
+            is_custom_node = not bool(node_dict)
 
             if isinstance(value, list):
                 node_dict['quantities'] = value
@@ -308,10 +320,7 @@ class ParserSettings(object):  # pylint: disable=useless-object-inheritance
             if isinstance(value, dict):
                 node_dict.update(value)
 
-            if 'link_name' not in node_dict:
-                node_dict['link_name'] = node_name
-
-            self.add_output_node(node_name, node_dict)
+            self.add_output_node(node_name, node_dict, is_custom_node=is_custom_node)
 
     def _init_critical_error_list(self):
         """

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -371,29 +371,31 @@ def test_misc(request, calc_with_retrieved):
 
 def test_custom_outputs(request, calc_with_retrieved):
     """Test custom_outputs by fermi_level."""
-    for parser_settings in ({
-            'add_custom_outputs': {
-                'type': 'float',
-                'quantities': ['fermi_level',],
-                'link_name': 'custom_outputs.fermi_level',
-            }
+    parser_settings = [{
+        'add_custom_outputs': {
+            'type': 'float',
+            'quantities': ['fermi_level',],
+            'link_name': 'custom_outputs.fermi_level',
+        }
     }, {
-            'add_custom_outputs': {
-                'type': 'float',
-                'quantities': ['fermi_level',],
-                'link_name': 'fermi_level',
-            }
+        'add_custom_outputs': {
+            'type': 'float',
+            'quantities': ['fermi_level',],
+            'link_name': 'fermi_level',
+        }
     }, {
-            'add_fermi_level': {
-                'type': 'float',
-                'quantities': ['fermi_level',],
-            }
+        'add_fermi_level': {
+            'type': 'float',
+            'quantities': ['fermi_level',],
+        }
     }, {
-            'add_fermi_level': {
-                'type': 'float',
-            }
-    }):
-        parser, file_path, _ = _get_vasp_parser(calc_with_retrieved, request, settings_dict={'parser_settings': parser_settings})
+        'add_fermi_level': {
+            'type': 'float'
+        }
+    }]
+
+    for parser_setting in parser_settings:
+        parser, file_path, _ = _get_vasp_parser(calc_with_retrieved, request, settings_dict={'parser_settings': parser_setting})
         parser.parse(retrieved_temporary_folder=file_path)
         assert 'custom_outputs.fermi_level' in parser.outputs
         assert parser.outputs['custom_outputs.fermi_level'] == pytest.approx(4.29634683)

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access,unused-variable,too-few-public-methods, import-outside-toplevel
 
 import os
+from pathlib import Path
 import pytest
 import numpy as np
 
@@ -74,28 +75,38 @@ class ExampleFileParser2(BaseFileParser):
         return result
 
 
-def _get_vasp_parser(calc_with_retrieved):
+def _get_vasp_parser(calc_with_retrieved, request, settings_dict=None, relative_file_path=None):
     """Return vasp parser before parsing"""
-    settings_dict = {
-        # 'ADDITIONAL_RETRIEVE_LIST': CalculationFactory('vasp.vasp')._ALWAYS_RETRIEVE_LIST,
-        'parser_settings': {
-            'add_custom': {
-                'link_name': 'custom_node',
-                'type': 'dict',
-                'quantities': ['quantity2', 'quantity_with_alternatives']
+
+    if settings_dict is None:
+        _settings_dict = {
+            # 'ADDITIONAL_RETRIEVE_LIST': CalculationFactory('vasp.vasp')._ALWAYS_RETRIEVE_LIST,
+            'parser_settings': {
+                'add_custom': {
+                    'link_name': 'custom_node',
+                    'type': 'dict',
+                    'quantities': ['quantity2', 'quantity_with_alternatives']
+                }
             }
         }
-    }
-    file_path = str(os.path.abspath(os.path.dirname(__file__)) + '/../../test_data/basic_run')
-    node = calc_with_retrieved(file_path, settings_dict)
+    else:
+        _settings_dict = settings_dict
+    if relative_file_path is None:
+        _relative_file_path = '../../test_data/basic_run'
+    else:
+        _relative_file_path = relative_file_path
+
+    # Path(request.fspath) will be replaced by request.node.path from pytest v7.
+    file_path = str(Path(request.fspath).parent / _relative_file_path)
+    node = calc_with_retrieved(file_path, _settings_dict)
     parser = ParserFactory('vasp.vasp')(node)
     return parser, file_path, node
 
 
 @pytest.fixture
-def vasp_parser_with_test(calc_with_retrieved):
+def vasp_parser_with_test(calc_with_retrieved, request):
     """Fixture providing a VaspParser instance coupled to a VaspCalculation."""
-    parser, file_path, node = _get_vasp_parser(calc_with_retrieved)
+    parser, file_path, node = _get_vasp_parser(calc_with_retrieved, request)
     parser.add_parser_definition('_scheduler-stderr.txt', {'parser_class': ExampleFileParser, 'is_critical': False})
     success = parser.parse(retrieved_temporary_folder=file_path)
     try:
@@ -105,8 +116,8 @@ def vasp_parser_with_test(calc_with_retrieved):
 
 
 @pytest.fixture
-def vasp_parser_without_parsing(calc_with_retrieved):
-    parser, file_path, node = _get_vasp_parser(calc_with_retrieved)
+def vasp_parser_without_parsing(calc_with_retrieved, request):
+    parser, file_path, node = _get_vasp_parser(calc_with_retrieved, request)
     return parser, file_path
 
 
@@ -193,12 +204,10 @@ def xml_truncate(index, original, tmp):
 def test_parser_nodes(request, calc_with_retrieved):
     """Test a few basic node items of the parser."""
     settings_dict = {'parser_settings': {'add_bands': True, 'add_kpoints': True, 'add_misc': ['fermi_level']}}
-
-    file_path = str(request.fspath.join('..') + '../../../test_data/basic')
-
-    node = calc_with_retrieved(file_path, settings_dict)
-
-    parser = ParserFactory('vasp.vasp')(node)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved,
+                                            request,
+                                            settings_dict=settings_dict,
+                                            relative_file_path='../../test_data/basic')
     # The test data does not contain OUTCAR - make sure that is allowed
     parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
     parser.parse(retrieved_temporary_folder=file_path)
@@ -229,10 +238,9 @@ def test_parser_exception(request, calc_with_retrieved):
         }
     }
 
-    file_path = str(request.fspath.join('..') + '../../../test_data/basic_run_ill_format')
-
+    # Path(request.fspath) will be replaced by request.node.path from pytest v7.
+    file_path = str(Path(request.fspath).parent / '../../test_data/basic_run_ill_format')
     node = calc_with_retrieved(file_path, settings_dict)
-
     parser_cls = ParserFactory('vasp.vasp')
     result, output = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
@@ -279,11 +287,10 @@ def test_structure(request, calc_with_retrieved):
         }
     }
 
-    file_path = str(request.fspath.join('..') + '../../../test_data/basic')
-
-    node = calc_with_retrieved(file_path, settings_dict)
-
-    parser = ParserFactory('vasp.vasp')(node)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved,
+                                            request,
+                                            settings_dict=settings_dict,
+                                            relative_file_path='../../test_data/basic')
     # The test data does not contain OUTCAR - make sure that is allowed
     parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
     parser.parse(retrieved_temporary_folder=file_path)
@@ -295,11 +302,10 @@ def test_structure(request, calc_with_retrieved):
     assert isinstance(structure_vasprun, get_data_class('structure'))
 
     # Then from POSCAR/CONTCAR
-    file_path = str(request.fspath.join('..') + '../../../test_data/basic_poscar')
-
-    node = calc_with_retrieved(file_path, settings_dict)
-
-    parser = ParserFactory('vasp.vasp')(node)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved,
+                                            request,
+                                            settings_dict=settings_dict,
+                                            relative_file_path='../../test_data/basic_poscar')
     # The test data does not contain OUTCAR - make sure that is allowed
     parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
     parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
@@ -346,10 +352,9 @@ def test_misc(request, calc_with_retrieved):
         }
     }
 
-    file_path = str(request.fspath.join('..') + '../../../test_data/disp_details')
-
+    # Path(request.fspath) will be replaced by request.node.path from pytest v7.
+    file_path = str(Path(request.fspath).parent / '../../test_data/disp_details')
     node = calc_with_retrieved(file_path, settings_dict)
-
     parser_cls = ParserFactory('vasp.vasp')
     result, _ = parser_cls.parse_from_node(node, store_provenance=False, retrieved_temporary_folder=file_path)
 
@@ -392,8 +397,6 @@ def test_misc(request, calc_with_retrieved):
 @pytest.mark.parametrize('misc_input', [[], ['notifications']])
 def test_stream(misc_input, config, request, calc_with_retrieved):
     """Test that the stream parser works and gets stored on a node."""
-    file_path = str(request.fspath.join('..') + '../../../test_data/stdout/out')
-
     # turn of everything, except misc
     settings_dict = {
         'parser_settings': {
@@ -416,9 +419,10 @@ def test_stream(misc_input, config, request, calc_with_retrieved):
         }
     }
 
-    node = calc_with_retrieved(file_path, settings_dict)
-
-    parser = ParserFactory('vasp.vasp')(node)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved,
+                                            request,
+                                            settings_dict=settings_dict,
+                                            relative_file_path='../../test_data/stdout/out')
     parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
     parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
     parser.parse(retrieved_temporary_folder=file_path)
@@ -457,8 +461,6 @@ def test_stream(misc_input, config, request, calc_with_retrieved):
 
 def test_stream_history(request, calc_with_retrieved):
     """Test that the stream parser keeps history."""
-    file_path = str(request.fspath.join('..') + '../../../test_data/stdout/out')
-
     # turn of everything, except misc
     settings_dict = {
         'parser_settings': {
@@ -491,9 +493,11 @@ def test_stream_history(request, calc_with_retrieved):
         }
     }
 
-    node = calc_with_retrieved(file_path, settings_dict)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved,
+                                            request,
+                                            settings_dict=settings_dict,
+                                            relative_file_path='../../test_data/stdout/out')
 
-    parser = ParserFactory('vasp.vasp')(node)
     # The test data does not contain OUTCAR - make sure that is allowed
     parser._definitions.parser_definitions['OUTCAR']['is_critical'] = False
     parser._definitions.parser_definitions['vasprun.xml']['is_critical'] = False
@@ -546,16 +550,16 @@ def test_notification_composer(vasp_parser_without_parsing):
     assert exit_code.status == 703
 
 
-def test_critical_file_missing(calc_with_retrieved):
+def test_critical_file_missing(calc_with_retrieved, request):
     """Test raising return code to indicate that one or more critical filse are missing"""
-    parser, file_path, node = _get_vasp_parser(calc_with_retrieved)
+    parser, file_path, node = _get_vasp_parser(calc_with_retrieved, request)
     parser.add_parser_definition('some-critical-file.txt', {'parser_class': ExampleFileParser, 'is_critical': True})
     parser.add_parsable_quantity('quantity_with_alternatives', {'inputs': [], 'prerequisites': [], 'file_name': '_scheduler-stderr.txt'})
     success = parser.parse(retrieved_temporary_folder=file_path)
     assert success == parser.exit_codes.ERROR_CRITICAL_MISSING_FILE
 
     # Test missing OUTCAR
-    parser, file_path, node = _get_vasp_parser(calc_with_retrieved)
+    parser, file_path, node = _get_vasp_parser(calc_with_retrieved, request)
     # Delete the retrieved OUTCAR file and instantiate the parser
     node.outputs.retrieved.delete_object('OUTCAR', force=True)
     parser = ParserFactory('vasp.vasp')(node)

--- a/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -76,7 +76,7 @@ class ExampleFileParser2(BaseFileParser):
 
 
 def _get_vasp_parser(calc_with_retrieved, request, settings_dict=None, relative_file_path=None):
-    """Return vasp parser before parsing"""
+    """Return vasp parser before parsing."""
 
     if settings_dict is None:
         _settings_dict = {
@@ -117,7 +117,7 @@ def vasp_parser_with_test(calc_with_retrieved, request):
 
 @pytest.fixture
 def vasp_parser_without_parsing(calc_with_retrieved, request):
-    parser, file_path, node = _get_vasp_parser(calc_with_retrieved, request)
+    parser, file_path, _ = _get_vasp_parser(calc_with_retrieved, request)
     return parser, file_path
 
 
@@ -367,6 +367,36 @@ def test_misc(request, calc_with_retrieved):
     assert data['maximum_stress'] == pytest.approx(42.96872956444064)
     assert data['maximum_force'] == pytest.approx(0.21326679)
     assert data['total_energies']['energy_extrapolated'] == pytest.approx(-10.823296)
+
+
+def test_custom_outputs(request, calc_with_retrieved):
+    """Test custom_outputs by fermi_level."""
+    for parser_settings in ({
+            'add_custom_outputs': {
+                'type': 'float',
+                'quantities': ['fermi_level',],
+                'link_name': 'custom_outputs.fermi_level',
+            }
+    }, {
+            'add_custom_outputs': {
+                'type': 'float',
+                'quantities': ['fermi_level',],
+                'link_name': 'fermi_level',
+            }
+    }, {
+            'add_fermi_level': {
+                'type': 'float',
+                'quantities': ['fermi_level',],
+            }
+    }, {
+            'add_fermi_level': {
+                'type': 'float',
+            }
+    }):
+        parser, file_path, _ = _get_vasp_parser(calc_with_retrieved, request, settings_dict={'parser_settings': parser_settings})
+        parser.parse(retrieved_temporary_folder=file_path)
+        assert 'custom_outputs.fermi_level' in parser.outputs
+        assert parser.outputs['custom_outputs.fermi_level'] == pytest.approx(4.29634683)
 
 
 @pytest.mark.parametrize(

--- a/aiida_vasp/parsers/vasp.py
+++ b/aiida_vasp/parsers/vasp.py
@@ -130,7 +130,7 @@ class VaspParser(BaseParser):
             parser_settings = calc_settings.get_dict().get('parser_settings')
 
         self._definitions = ParserDefinitions()
-        self._settings = ParserSettings(parser_settings, default_settings=DEFAULT_OPTIONS)
+        self._settings = ParserSettings(parser_settings, default_settings=DEFAULT_OPTIONS, vasp_parser_logger=self.logger)
         self._parsable_quantities = ParsableQuantities(vasp_parser_logger=self.logger)
         self._file_parser_exit_codes = {}
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes: issue #552

## Description

This is a fix to support custom outputs. For example

```python
        "add_custom_outputs": {
            "type": "float",
            "quantities": [
                "fermi_level",
            ],
            "link_name": "fermi_level",
        },
```
or

```python
        "add_custom_outputs": {
            "type": "float",
            "quantities": [
                "fermi_level",
            ],
            "link_name": "custom_outputs.fermi_level",
        },
```
This attaches `Float(fermi_level)` to `custom_outputs.fermi_level`.

## What has been done at the first PR commit
- Custom outputs are attached to "custom_outputs" output_namespace.
- Add float, int, str supports of NodeComposer.

## What should be discussed
Currently `xxxxx` of `add_xxxxx` is used for the dict key to handle the node information dictionaries. `xxxxx` is used only searching the key in `NODES` (`settings.py`), and not used anywhere else (except for the case below). To add custom outputs, the condition that has to be satisfied is that `xxxxx` is not in `Nodes`, i.e., it is unnecessary to use `add_custom_outputs` as the key in the example above.

So should we define `xxxxx` as fixed such as `custom_outputs`?

But  the following specification looks nice, and indeed works,
```python
        "add_fermi_level": {
            "type": "float",
            "quantities": [
                "fermi_level",
            ],
        },
```
where `xxxxx` is used as the `link_name`. In fact, I like this though we should leave message in the report.