### PR TITLE
Avoid redundant second pytest run in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python: ['3.8']
+        python: ["3.8"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache python dependencies
@@ -16,9 +16,10 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-          restore-keys:
-                      pip-${{ matrix.python-version }}-tests
+          key:
+            pip-${{ matrix.python-version }}-tests-${{
+            hashFiles('**/setup.json') }}
+          restore-keys: pip-${{ matrix.python-version }}-tests
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -46,7 +47,7 @@ jobs:
           - 5672:5672
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9']
+        python: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
 
@@ -54,10 +55,9 @@ jobs:
         id: cache-pip
         uses: actions/cache@v1
         with:
-            path: ~/.cache/pip
-            key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
-            restore-keys:
-                pip-${{ matrix.python }}-tests-
+          path: ~/.cache/pip
+          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
+          restore-keys: pip-${{ matrix.python }}-tests-
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -78,14 +78,16 @@ jobs:
         run: pip install wheel
       - name: Install Tox
         run: pip install tox
-      - name: Install Coveralls
-        if: ${{ matrix.python }} == '3.8'
-        run: pip install coveralls
+      - name: Install codecov
+        if: matrix.python == '3.8'
+        run: pip install codecov pytest-cov
       - name: Install AiiDA
         #run: pip install -e git+https://github.com/aiidateam/aiida_core#egg=aiida-core
         run: pip install 'psycopg2-binary~=2.8.3' 'aiida-core>=1.6.1,<2'
       - name: Install AiiDA-Wannier90
-        run: pip install -e git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
+        run:
+          pip install -e
+          git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
       - name: Install AiiDA-VASP
         run: |
           pip install -e .[graphs,tests]
@@ -96,14 +98,18 @@ jobs:
         with:
           pattern: '\.'
           string: ${{ matrix.python }}
-          replace-with: ''
+          replace-with: ""
+      - name: Run tox and codecov
+        if: matrix.python == '3.8'
+        run:
+          tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp --
+          --cov=./aiida_vasp --cov-append --cov-report=xml
       - name: Run tox
+        if: matrix.python != '3.8'
         run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
-      - name: Run coverage from coverage-python by running pytest yet again
-        if: ${{ matrix.python }} == '3.8'
-        run: pytest --cov-report=xml --cov-append --cov=aiida_vasp
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        if: matrix.python == '3.8'
+        uses: codecov/codecov-action@v2
         with:
           name: aiida-vasp
           fail_ci_if_error: true


### PR DESCRIPTION
* Run code coverage with pytest in tox only for matrix.python == '3.8'
* Fix if statements to check matrix.python
* Replace coveralls with codecov and pytest-cov

 - [x] ready to be reviewed and merged (as soon as tests have passed)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes: #563