### PR TITLE
Set job poll interval to zero in localhost fixture

### DIFF
--- a/aiida_vasp/utils/fixtures/data.py
+++ b/aiida_vasp/utils/fixtures/data.py
@@ -52,6 +52,7 @@ def localhost(fresh_aiida_env, localhost_dir):
                             transport_type='local',
                             scheduler_type='direct',
                             workdir=str(localhost_dir)).store()
+        computer.set_minimum_job_poll_interval(0.)
     return computer
 
 


### PR DESCRIPTION
It is safe to set job poll interval of computer to zero in testing. This
fix sets it to zero to reduce time to run CI.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes: https://github.com/aiida-vasp/aiida-vasp/issues/564

## Description
There is an alternative way to set job poll interval, to use `aiida_localhost`, not aiida-vasp's localhost fixture.
However, that direction seems to need further refactoring on the whole testing infrastructure of aiiva-vasps.
Thus, for now, this PR does not choose to replace aiida-vasp's localhost fixture with `aiida_localhost`.