### PR TITLE
Moved pre-commit tests into tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,18 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key:
-            pip-${{ matrix.python-version }}-tests-${{
-            hashFiles('**/setup.json') }}
-          restore-keys: pip-${{ matrix.python-version }}-tests
+          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
+          restore-keys: pip-${{ matrix.python }}-tests-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Pin pip to version 21.3
         run: pip install pip~=21.3
-      - name: Install wheel
-        run: pip install wheel
-      - name: Install AiiDA-VASP
-        run: |
-          pip install -e .[graphs,tests,pre-commit]
-          pip freeze
-      - name: Run pre-commit
-        run: pre-commit run --all-files || ( git diff; git status; exit 1; )
+      - name: Install Tox
+        run: pip install tox
+      - name: Run pre-commit in Tox
+        run: tox -e pre-commit
   tests:
     needs: [pre-commit]
     runs-on: ubuntu-latest
@@ -48,7 +42,6 @@ jobs:
         python: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
-
       - name: Cache python dependencies
         id: cache-pip
         uses: actions/cache@v1
@@ -56,7 +49,6 @@ jobs:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
           restore-keys: pip-${{ matrix.python }}-tests-
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/ops/update_version.py
+++ b/ops/update_version.py
@@ -5,7 +5,7 @@ import json
 import fileinput
 import contextlib
 from pathlib import Path
-import subprocess32 as subprocess
+import subprocess
 
 from packaging import version
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,26 @@
 [tox]
-envlist = {py37,py38,py39}-aiida_vasp
+envlist = pre-commit,{py37,py38,py39}-aiida_vasp
 
 [testenv]
-passenv = TRAVIS TRAVIS_*
-setenv = AIIDA_PATH={toxworkdir}/.aiida PATH={env:PATH}{:}{homedir}/.miniconda/envs/aiida121/bin/
-
-deps =
-    pip>=10
-    aiida_dev: git+https://github.com/aiidateam/aiida_core.git
-    git+https://github.com/aiidateam/aiida-wannier90#egg=aiida-wannier90
-    .[graphs,tests]
+setenv = AIIDA_PATH={toxworkdir}/.aiida
 whitelist_externals =
                     mkdir
                     rm
-
 commands =
-    mkdir -p {toxworkdir}/.aiida
-    reentry scan
-    pytest {posargs}
-    rm -r {toxworkdir}/.aiida
-
+	 mkdir -p {toxworkdir}/.aiida
+	 reentry scan
+	 pytest {posargs}
+	 rm -r {toxworkdir}/.aiida
 extras =
-    tests
-    wannier
+       tests
+       wannier
+
+[testenv:pre-commit]
+whitelist_externals = bash
+commands = bash -ec 'pre-commit run --all-files || ( git diff; git status; exit 1; )'
+extras =
+       pre-commit
+       tests
 
 [flake8]
 max-line-length = 140


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

Fixes #574

## Description
Here we move `pre-commit` into `tox` so that we can also run it in a reproducible manner locally with `tox -e pre-commit`. This would not rely on your locally installed `pre-commit` version, or any version conflicts that might appear from the `pre-commit` config and deps for your setup.