### PR TITLE
Catch cases where site_magnetization output can be empty

### DIFF
--- a/aiida_vasp/utils/workchains.py
+++ b/aiida_vasp/utils/workchains.py
@@ -138,7 +138,7 @@ def site_magnetization_to_magmom(site_dict):
             break
     # No avaliable site magnetization for setting MAGMOM, something is wrong
     if to_use is None:
-        raise RuntimeError('No valid site-projected magnetization avaliable')
+        raise ValueError('No valid site-projected magnetization avaliable')
     # Ensure sorted list
     tmp = list(site_dict[to_use]['site_moment'].items())
     tmp.sort(key=lambda x: int(x[0]))

--- a/aiida_vasp/workchains/vasp.py
+++ b/aiida_vasp/workchains/vasp.py
@@ -269,7 +269,10 @@ class VaspWorkChain(BaseRestartWorkChain):
             node = self.ctx.children[-1]
 
         if 'site_magnetization' in node.outputs:
-            self.ctx.inputs.parameters['magmom'] = site_magnetization_to_magmom(node.outputs.site_magnetization.get_dict())
+            try:
+                self.ctx.inputs.parameters['magmom'] = site_magnetization_to_magmom(node.outputs.site_magnetization.get_dict())
+            except ValueError:
+                pass
 
     def init_inputs(self):  # pylint: disable=too-many-branches, too-many-statements
         """Make sure all the required inputs are there and valid, create input dictionary for calculation."""


### PR DESCRIPTION
It can be empty for various reason, this should be not cause an
exception..

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
Just a small fix on setting the site magnetization.

Sometimes the output of site_magnetization can be emtpy, e.g. non-spin polarised calculations. This can happen when someone launches an array of calculation that are mixed in `ISPIN` values yet having other input parameters identical....