### PR TITLE
Remove check of handler type

### DIFF
--- a/aiida_vasp/parsers/content_parsers/base.py
+++ b/aiida_vasp/parsers/content_parsers/base.py
@@ -5,7 +5,6 @@ Base classes for the VASP content parsers.
 Contains the base classes for the VASP content parsers.
 """
 # pylint: disable=import-outside-toplevel
-import io
 
 from aiida.orm import Data
 from aiida.common import AIIDA_LOGGER as aiidalogger
@@ -91,11 +90,7 @@ class BaseFileParser():
 
         # Set ``handler`` (parsing from some source) or ``data`` (eventually for example executing write)
         if handler is not None:
-            # Check that the supplied handler is IOBase.
-            if isinstance(handler, io.IOBase):
-                self._init_from_handler(handler)
-            else:
-                raise TypeError('The supplied handler is not of IOBase type.')
+            self._init_from_handler(handler)
         if data is not None:
             # Check that the supplied handler is Data, one of the AiiDA supported data types.
             if isinstance(data, Data):

--- a/aiida_vasp/parsers/content_parsers/tests/test_base_file_parser.py
+++ b/aiida_vasp/parsers/content_parsers/tests/test_base_file_parser.py
@@ -23,6 +23,3 @@ def test_base_content_parser(tmpdir):
     with pytest.raises(TypeError):
         # Check that something else than Data for the AiiDA data type raises an exception.
         _ = BaseFileParser(data=[])
-
-    # Check that something else than IOBase will not raise an exception as it is allowed
-    _ = BaseFileParser(handler=[])

--- a/aiida_vasp/parsers/content_parsers/tests/test_base_file_parser.py
+++ b/aiida_vasp/parsers/content_parsers/tests/test_base_file_parser.py
@@ -21,8 +21,8 @@ def test_base_content_parser(tmpdir):
         # Does not have a init_data method, should be implemented in child
         _ = BaseFileParser(data=get_data_node('dict', dict={}))
     with pytest.raises(TypeError):
-        # Check that something else than IOBase raises an exception as it is not allowed
-        _ = BaseFileParser(handler=[])
-    with pytest.raises(TypeError):
         # Check that something else than Data for the AiiDA data type raises an exception.
         _ = BaseFileParser(data=[])
+
+    # Check that something else than IOBase will not raise an exception as it is allowed
+    _ = BaseFileParser(handler=[])


### PR DESCRIPTION
With AiiDA 2.0, the handler returned by `node.base.repositiory.open` may be of any class, and it is backend dependent. Hence, we need to remove the overly cautious check of passed handler type. 

This did not trigger test failure probably because when parsing calculation results before they are stored in the storage backend, the handler return is still of a actual file on the disk.