### PR TITLE
Fix compatibility with parsevasp development branch

### DIFF
--- a/aiida_vasp/parsers/content_parsers/kpoints.py
+++ b/aiida_vasp/parsers/content_parsers/kpoints.py
@@ -98,10 +98,13 @@ class KpointsParser(BaseFileParser):
             pass
 
         kpoints_dict = {}
-        for keyword in ['comment', 'divisions', 'shifts', 'points', 'tetra', 'tetra_volume', 'mode', 'centering', 'num_kpoints']:
+        for keyword in [
+                'comment', 'divisions', 'shifts', 'points', 'tetra', 'tetra_volume', 'mode', 'centering', 'num_kpoints',
+                'generating_vectors'
+        ]:
             kpoints_dict[keyword] = None
 
-            kpoints_dict.update(getattr(self, '_get_kpointsdict_' + mode)(self._content_data))
+        kpoints_dict.update(getattr(self, '_get_kpointsdict_' + mode)(self._content_data))
 
         # We brake hard if ``parsevasp`` fail here. If we can not write we will not try another parser.
         content_parser = Kpoints(kpoints_dict=kpoints_dict, logger=self._logger)


### PR DESCRIPTION
The KPOINTS parser in `parsevsap` now probes the `generating_vectors` key, should make it default ot None.
Otherwise, the KPOINTS file cannot be written for VASP calculation.


**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)


## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description
