### PR TITLE
Option to omit static run in relax workchain

### DIFF
--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -234,7 +234,7 @@ class RelaxWorkChain(WorkChain):
                 ),
                 cls.store_relaxed,
             ),
-            if_(cls.perform_final_static_calculation)(
+            if_(cls.perform_final_static)(
                 cls.init_relaxed,
                 cls.init_next_workchain,
                 cls.run_next_workchain,

--- a/aiida_vasp/workchains/relax.py
+++ b/aiida_vasp/workchains/relax.py
@@ -47,6 +47,15 @@ class RelaxWorkChain(WorkChain):
             required=False,
         )
         spec.input(
+            'perform_static',
+            valid_type=get_data_class('core.bool'),
+            required=False,
+            default=lambda: get_data_node('core.bool', True),
+            help="""
+            If True, perform static calculation after relaxation.
+            """,
+        )
+        spec.input(
             'relax.perform',
             valid_type=get_data_class('core.bool'),
             required=False,
@@ -225,10 +234,12 @@ class RelaxWorkChain(WorkChain):
                 ),
                 cls.store_relaxed,
             ),
-            cls.init_relaxed,
-            cls.init_next_workchain,
-            cls.run_next_workchain,
-            cls.verify_next_workchain,
+            if_(cls.perform_final_static_calculation)(
+                cls.init_relaxed,
+                cls.init_next_workchain,
+                cls.run_next_workchain,
+                cls.verify_next_workchain,
+            ),
             cls.results,
             cls.finalize
         )  # yapf: disable
@@ -513,3 +524,7 @@ class RelaxWorkChain(WorkChain):
     def perform_relaxation(self):
         """Check if a relaxation is to be performed."""
         return self.ctx.relax
+
+    def perform_final_static(self):
+        """Check if the final static calculation is to be performed."""
+        return self.inputs.perform_static


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR is ready to be reviewed. Probably input variable name (tentatively `perform_static`) should be reconsidered. Test is not written yet. Tox doesn't work on my environment, maybe due to behind proxy...

## Description

In the relax workchain, it may be useful if we can omit running the final static calculation. This PR adds the option.