### PR TITLE
Disabled required for custom output namespace

### DIFF
--- a/aiida_vasp/calcs/vasp.py
+++ b/aiida_vasp/calcs/vasp.py
@@ -238,7 +238,7 @@ class VaspCalculation(VaspCalcBase):
             required=False,
             help='The output of the site magnetization',
         )
-        spec.output_namespace('custom_outputs', dynamic=True)
+        spec.output_namespace('custom_outputs', required=False, dynamic=True)
         spec.exit_code(0, 'NO_ERROR', message='the sun is shining')
         spec.exit_code(
             350,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,13 @@ Source = "https://github.com/aiida-vasp/aiida-vasp"
 [project.optional-dependencies]
 tests = [
 
-    "aiida-core[tests]>=2.0.1,<3",
+    "aiida-core[tests]>=2.0.1,<2.1.1",
     "tox>=3.23.0",
     "virtualenv>20"
 ]
 
 pre-commit = [
-    "aiida-core[pre-commit]>=2.0.1,<3",
+    "aiida-core[pre-commit]>=2.0.1,<2.1.1",
     "tox>=3.23.0",
     "virtualenv>20"
 ]


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Fixes the `custom_outputs` to be a non-required output as the reports where complaining about it.