### PR TITLE
DevOps: Fix the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: nightly against develop aiida-core
+name: nightly against `main` branch of `aiida-core`
 
 on:
   schedule:
@@ -43,11 +43,10 @@ jobs:
         run: |
           pip install -e .[graphs,dev]
           pip freeze
-      - name: Install AiiDA develop branch
+      - name: Install AiiDA main branch
         id: install_aiida
         run: |
-          pip install git+https://github.com/aiidateam/aiida-core@develop
-          reentry scan
+          pip install git+https://github.com/aiidateam/aiida-core@main
       - name: Remove dot in Python version for passing version to tox
         uses: frabert/replace-string-action@master
         id: tox
@@ -66,5 +65,5 @@ jobs:
           SLACK_USERNAME: aiida-vasp
           SLACK_CHANNEL: nightly
           SLACK_COLOR: b60205
-          SLACK_TITLE: "Nightly build against `aiida-core/develop` failed"
-          SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/develop`."
+          SLACK_TITLE: "Nightly build against `aiida-core/main` failed"
+          SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/main`."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: nightly against `main` branch of `aiida-core`
 on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
It was installing the `develop` branch of `aiida-core` but the main
branch has been changed to `main` since `aiida-core==2.0`. Also, since
that version, `reentry` has been removed so `reentry scan` is no longer
necessary.