### PR TITLE
Dropped Python version for RTD

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
It seems only Python up and including `3.8` is supported at RTD without enabling for instance a testing image, so we lower the specified version in the config file.