### PR TITLE
Updated aiida core dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python: ["3.8"]
+        python: ['3.9']
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Cache python dependencies
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v3.2.6
         with:
           path: ~/.cache/pip
-          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
+          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: pip-${{ matrix.python }}-tests-
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
@@ -39,7 +39,7 @@ jobs:
           - 5672:5672
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3.3.0
       - name: Cache python dependencies
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v3.2.6
         with:
           path: ~/.cache/pip
-          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/setup.json') }}
+          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: pip-${{ matrix.python }}-tests-
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
@@ -61,11 +61,11 @@ jobs:
           sudo updatedb
           sudo apt install postgresql
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and posibility to pin pip version.
-        run: pip install "virtualenv>20"
+        run: pip install 'virtualenv>20'
       - name: Install Tox
         run: pip install tox
       - name: Install codecov
-        if: matrix.python == '3.8'
+        if: matrix.python == '3.9'
         run: pip install codecov pytest-cov
       - name: Remove dot in Python version for passing version to tox
         uses: frabert/replace-string-action@master
@@ -73,13 +73,13 @@ jobs:
         with:
           pattern: '\.'
           string: ${{ matrix.python }}
-          replace-with: ""
+          replace-with: ''
       - name: Run tox and codecov
-        if: matrix.python == '3.8'
+        if: matrix.python == '3.9'
         run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp --
           --cov=./aiida_vasp --cov-append --cov-report=xml
       - name: Run tox
-        if: matrix.python != '3.8'
+        if: matrix.python != '3.9'
         run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v2
@@ -91,7 +91,7 @@ jobs:
           retention-days: 5
           if-no-files-found: warn
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.8'
+        if: matrix.python == '3.9'
         uses: codecov/codecov-action@v3
         with:
           name: aiida-vasp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include setup.json
 include aiida_vasp/assistant/parameters.yml
 recursive-include aiida_vasp/test_data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 	"Environment :: Plugins",
 	"Intended Audience :: Science/Research",
 	"License :: OSI Approved :: MIT License",
-	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
@@ -29,9 +28,9 @@ classifiers = [
 	"Framework :: AiiDA"
 ]
 keywords = ["aiida", "plugin"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-	"aiida-core[atomic_tools]~=2.3",
+	"aiida-core[atomic_tools]~=2.4",
 	"lxml",
 	"packaging",
 	"parsevasp~=3.2"
@@ -42,7 +41,7 @@ Source = "https://github.com/aiida-vasp/aiida-vasp"
 
 [project.optional-dependencies]
 tests = [
-    "aiida-core[tests]~=2.3",
+    "aiida-core[tests]~=2.4",
     "tox>=3.23.0",
     "virtualenv>20"
 ]
@@ -54,7 +53,7 @@ pre-commit = [
     "sphinx-lint~=0.6"
 ]
 docs = [
-    "aiida-core[docs]~=2.3",
+    "aiida-core[docs]~=2.4",
     "sphinx-autobuild",
     "sphinx-lint",
     "sphinx-rtd-theme",
@@ -156,7 +155,7 @@ indent_dictionary_value = false
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pre-commit,{py38,py39,py310,py311}-aiida_vasp
+envlist = pre-commit,{py39,py310,py311}-aiida_vasp
 requires = virtualenv >= 20
 isolated_build = True
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
Here we bump the dependency for `aiida-core` to `~=2.4` due to recent release. This removes Python 3.8 support,
which we also do here. We still keep the Python 3.8 usage on RTD as that is decoupled from local Python versions.