### PR TITLE
Dropping threshold for codecov after release

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 3.0%
+        threshold: 1.0%
     patch:
       default:
         target: 50%


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x} ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
In prep for the release, we increased the threshold due to large code changes. In the PR we reset it back.