### PR TITLE
701 refatcor the GitHub workflows to make them more maintenable

### DIFF
--- a/.ci/enable_ssh_localhost.sh
+++ b/.ci/enable_ssh_localhost.sh
@@ -1,8 +1,0 @@
-et -ev
-
-ssh-keygen -q -t rsa -b 4096 -m PEM -N "" -f "${HOME}/.ssh/id_rsa"
-ssh-keygen -y -f "${HOME}/.ssh/id_rsa" >> "${HOME}/.ssh/authorized_keys"
-ssh-keyscan -H localhost >> "${HOME}/.ssh/known_hosts"
-
-# The permissions on the GitHub runner are 777 which will cause SSH to refuse the keys and cause authentication to fail
-chmod 755 "${HOME}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,24 @@
-name: ci
+name: cd
 
-on: [push, pull_request]
+on:
+  push:
+    tags:
+    - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
+  validate-release-tag:
+    if: github.repository == 'aiida-vasp/aiida-vasp' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - name: Validate the tag version against the package version
+      run: python .github/workflows/validate_release_tag.py $GITHUB_REF
+
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -100,3 +116,22 @@ jobs:
           name: aiida-vasp
           flags: pytests
           fail_ci_if_error: true
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [pre-commit, tests, validate-release-tag]
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - name: Install flit
+      run: pip install flit~=3.4
+    - name: Build and publish
+      run: flit publish
+      env:
+        FLIT_USERNAME: __token__
+        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         run: pip install tox
       - name: Run pre-commit in Tox
         run: tox -e pre-commit
+
   tests:
     needs: [pre-commit]
     runs-on: ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
       postgres:
         image: postgres:12
         env:
-          POSTGRES_DB: test_lammps
+          POSTGRES_DB: test_vasp
           POSTGRES_PASSWORD: ""
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
@@ -68,36 +69,25 @@ jobs:
           path: ~/.cache/pip
           key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: pip-${{ matrix.python }}-tests-
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install system dependencies
-        run: |
-          sudo apt update
-          sudo .ci/enable_ssh_localhost.sh
-          sudo apt install locate
-          sudo updatedb
+
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and posibility to pin pip version.
         run: pip install 'virtualenv>20'
+
       - name: Install Tox
         run: pip install tox
+
       - name: Install codecov
         if: matrix.python == '3.9'
         run: pip install codecov pytest-cov
-      - name: Remove dot in Python version for passing version to tox
-        uses: frabert/replace-string-action@master
-        id: tox
-        with:
-          pattern: '\.'
-          string: ${{ matrix.python }}
-          replace-with: ''
+
       - name: Run tox and codecov
-        if: matrix.python == '3.9'
-        run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp -- --cov=aiida_vasp --cov-append --cov-report=xml
-      - name: Run tox
-        if: matrix.python != '3.9'
-        run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
+        run: tox -e ${{ matrix.python }}-aiida_vasp -- --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing
+
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -107,6 +97,7 @@ jobs:
             test_mock_error.aiida
           retention-days: 5
           if-no-files-found: warn
+
       - name: Upload coverage to Codecov
         if: matrix.python == '3.9'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
       postgres:
         image: postgres:12
         env:
-          POSTGRES_DB: test_lammps
+          POSTGRES_DB: test_vasp
           POSTGRES_PASSWORD: ""
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
@@ -36,13 +36,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install system dependencies
-        run: |
-          curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-          sudo apt update
-          sudo .ci/enable_ssh_localhost.sh
-          sudo apt install locate
-          sudo updatedb
+
       - name: Upgrade pip
         run: |
           pip install --upgrade pip
@@ -60,23 +54,5 @@ jobs:
         id: install_aiida
         run: |
           pip install git+https://github.com/aiidateam/aiida-core@main
-      - name: Remove dot in Python version for passing version to tox
-        uses: frabert/replace-string-action@master
-        id: tox
-        with:
-          pattern: '\.'
-          string: ${{ matrix.python }}
-          replace-with: ""
       - name: Run tox
-        run: tox -e py${{ steps.tox.outputs.replaced }}-aiida_vasp
-      - name: Notification to Slack channel
-        if: steps.install_plugin.outcome == 'Failure' || steps.install_aiida.outcome == 'Failure' || steps.tox.outcome == 'Failure'
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_ICON: https://www.materialscloud.org/discover/images/0ba0a17d.aiida-logo-128.png
-          SLACK_USERNAME: aiida-vasp
-          SLACK_CHANNEL: nightly
-          SLACK_COLOR: b60205
-          SLACK_TITLE: "Nightly build against `aiida-core/main` failed"
-          SLACK_MESSAGE: "The tests fail with the current version of `aiida-core/main`."
+        run: tox -e ${{ matrix.python }}-aiida_vasp

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -31,6 +31,6 @@ if __name__ == '__main__':
     TAG_PREFIX = 'refs/tags/v'
     assert args.GITHUB_REF.startswith(TAG_PREFIX), f'GITHUB_REF should start with "{TAG_PREFIX}": {args.GITHUB_REF}'
     tag_version = args.GITHUB_REF[len(TAG_PREFIX):]
-    package_version = get_version_from_module(Path('aiida_vasp/__init__.py').read_text(encoding='utf-8'))
+    package_version = get_version_from_module(Path('src/aiida_vasp/__init__.py').read_text(encoding='utf-8'))
     error_message = f'The tag version `{tag_version}` is different from the package version `{package_version}`'
     assert tag_version == package_version, error_message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ indent_dictionary_value = false
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = pre-commit,{py39,py310,py311}-aiida_vasp
+envlist = pre-commit,{3.9,3.10,3.11}-aiida_vasp
 requires = virtualenv >= 20
 isolated_build = True
 


### PR DESCRIPTION
Refactoring the CI/CD workflows to ensure that they are easier to maintain. Moved the CD part of the workflows to its own file, remove deprecated parts of the workflows, and make changes to ensure that the tag validation works with the source layer of the repo.