### PR TITLE
Migrate from aiida.manage.tests.pytest_fixtures to aiida.tools.pytest_fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,31 @@ jobs:
         python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
-    #   - name: Cache python dependencies
-    #     id: cache-pip
-    #     uses: actions/cache@v4.0.2
-    #     with:
-    #       path: ~/.cache/pip
-    #       key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
-    #       restore-keys: pip-${{ matrix.python }}-tests-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python }}
+          miniforge-version: latest
+      - name: Install dependencies
+        run: |
+          conda activate test
+          conda install --yes -c conda-forge python=${{ matrix.python-version }}
+          conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
       - name: Install aiida-vasp
-        run: pip install -e ."[tests]" -vvv
+        run: |
+          conda activate test
+          pip install -e . -vvv
       - name: Run tests with codecov
-        run: pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
-      - name: Archive error mock calculations
-        uses: actions/upload-artifact@v4
-        if: ${{ failure() }}
-        with:
-          name: error-mock-calc-archive
-          path: |
-            test_mock_error.aiida
-          retention-days: 5
-          if-no-files-found: warn
+        run: |
+          conda activate test
+          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
+    #   - name: Archive error mock calculations
+    #     uses: actions/upload-artifact@v4
+    #     if: ${{ failure() }}
+    #     with:
+    #       name: error-mock-calc-archive
+    #       path: |
+    #         test_mock_error.aiida
+    #       retention-days: 5
+    #       if-no-files-found: warn
       - name: Upload coverage to Codecov
         if: matrix.python == '3.12'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,57 +3,12 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    strategy:
-      matrix:
-        python: ['3.9']
-    steps:
-      - uses: actions/checkout@v4
-      - name: Cache python dependencies
-        id: cache-pip
-        uses: actions/cache@v4.0.2
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: pip-${{ matrix.python }}-tests-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
-        run: pip install 'virtualenv>20'
-      - name: Install Tox
-        run: pip install tox
-      - name: Run pre-commit in Tox
-        run: tox -e pre-commit
-
   tests:
-    needs: [pre-commit]
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_DB: test_vasp
-          POSTGRES_PASSWORD: ""
-          POSTGRES_HOST_AUTH_METHOD: trust
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
+        python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Cache python dependencies
@@ -71,16 +26,13 @@ jobs:
 
       - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
         run: pip install 'virtualenv>20'
-
-      - name: Install Tox
-        run: pip install tox
 
       - name: Install codecov
         if: matrix.python == '3.9'
         run: pip install codecov pytest-cov
 
       - name: Run tox and codecov
-        run: tox -e ${{ matrix.python }}-aiida_vasp -- --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
+        run: pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
 
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
@@ -93,7 +45,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.9'
+        if: matrix.python == '3.12'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Make sure virtualevn>20 is installed, which will yield newer pip and possibility to pin pip version.
-        run: pip install 'virtualenv>20'
+      - name: Install parsevasp
+        run: pip install -e ."[tests]" -vvv
 
-      - name: Install codecov
-        if: matrix.python == '3.9'
-        run: pip install codecov pytest-cov
-
-      - name: Run tox and codecov
+      - name: Run tests with codecov
         run: pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
 
       - name: Archive error mock calculations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,21 @@ jobs:
         python: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
-      - name: Cache python dependencies
-        id: cache-pip
-        uses: actions/cache@v4.0.2
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: pip-${{ matrix.python }}-tests-
-
+    #   - name: Cache python dependencies
+    #     id: cache-pip
+    #     uses: actions/cache@v4.0.2
+    #     with:
+    #       path: ~/.cache/pip
+    #       key: pip-${{ matrix.python }}-tests-${{ hashFiles('**/pyproject.toml') }}
+    #       restore-keys: pip-${{ matrix.python }}-tests-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Install parsevasp
+      - name: Install aiida-vasp
         run: pip install -e ."[tests]" -vvv
-
       - name: Run tests with codecov
         run: pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
-
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -39,7 +35,6 @@ jobs:
             test_mock_error.aiida
           retention-days: 5
           if-no-files-found: warn
-
       - name: Upload coverage to Codecov
         if: matrix.python == '3.12'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
           conda activate test
           conda install --yes -c conda-forge python=${{ matrix.python-version }}
           conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
+      - name: Setup parsevasp
+        run: |
+          conda activate test
+          git clone --depth 1 https://github.com/aiida-vasp/parsevasp.git
+          cd parsevasp
+          pip install -e . -vvv
+          cd ..
       - name: Install aiida-vasp
         run: |
           conda activate test
@@ -30,15 +37,15 @@ jobs:
         run: |
           conda activate test
           pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
-    #   - name: Archive error mock calculations
-    #     uses: actions/upload-artifact@v4
-    #     if: ${{ failure() }}
-    #     with:
-    #       name: error-mock-calc-archive
-    #       path: |
-    #         test_mock_error.aiida
-    #       retention-days: 5
-    #       if-no-files-found: warn
+      - name: Archive error mock calculations
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: error-mock-calc-archive
+          path: |
+            test_mock_error.aiida
+          retention-days: 5
+          if-no-files-found: warn
       - name: Upload coverage to Codecov
         if: matrix.python == '3.12'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    defaults:
+        run:
+          shell: bash -l {0}
     timeout-minutes: 90
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests with codecov
         run: |
           conda activate test
-          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc'
+          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' src
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,1 @@
-pytest_plugins = ('aiida.manage.tests.pytest_fixtures',)
+pytest_plugins = 'aiida.tools.pytest_fixtures'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,51 +6,52 @@ build-backend = "flit_core.buildapi"
 [project]
 # See https://www.python.org/dev/peps/pep-0621/
 name = "aiida-vasp"
-dynamic = ["version"]  # read from aiida_vasp/__init__.py
+dynamic = ["version"] # read from aiida_vasp/__init__.py
 description = "AiiDA plugin for running VASP calculations and workflows."
-authors = [{name = "Espen Flage-Larsen", email = "espen.flage-larsen@sigma2.no"}]
+authors = [
+    { name = "Espen Flage-Larsen", email = "espen.flage-larsen@sigma2.no" },
+]
 readme = "README.rst"
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 classifiers = [
     "Programming Language :: Python",
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Framework :: AiiDA",
     "Development Status :: 5 - Production/Stable",
-	"Environment :: Plugins",
-	"Intended Audience :: Science/Research",
-	"License :: OSI Approved :: MIT License",
-	"Programming Language :: Python :: 3.9",
-	"Programming Language :: Python :: 3.10",
-	"Programming Language :: Python :: 3.11",
-	"Topic :: Scientific/Engineering :: Physics",
-	"Topic :: Scientific/Engineering :: Chemistry",
-	"Framework :: AiiDA"
+    "Environment :: Plugins",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Framework :: AiiDA",
 ]
 keywords = ["aiida", "plugin"]
 requires-python = ">=3.9"
 dependencies = [
-	"aiida-core[atomic_tools]~=2.3",
-	"lxml",
-	"packaging",
-	"parsevasp~=3.2"
+    "aiida-core~=2.3",
+    "ase",
+    "lxml",
+    "seekpath",
+    "packaging",
+    "parsevasp~=3.2",
 ]
 
 [project.urls]
 Source = "https://github.com/aiida-vasp/aiida-vasp"
 
 [project.optional-dependencies]
-tests = [
-    "aiida-core[tests]~=2.3",
-    "tox>=3.23.0",
-    "virtualenv>20"
-]
+tests = ["aiida-core>=2.6", "pytest", "PyCifRW"]
 pre-commit = [
     "tox>=3.23.0",
     "virtualenv>20",
     "pre-commit>=2.2,<4.0",
     "pylint>=2.15,<3.3",
-    "sphinx-lint~=0.6"
+    "sphinx-lint~=0.6",
 ]
 docs = [
     "aiida-core[docs]~=2.4",
@@ -58,11 +59,9 @@ docs = [
     "sphinx-lint",
     "sphinx-rtd-theme",
     "sphinxcontrib-apidoc",
-    "sphinxext.remoteliteralinclude"
+    "sphinxext.remoteliteralinclude",
 ]
-graphs = [
-    "matplotlib"
-]
+graphs = ["matplotlib"]
 
 [project.entry-points."aiida.cmdline.data"]
 "vasp-potcar" = "aiida_vasp.commands.potcar:potcar"
@@ -133,7 +132,7 @@ disable = [
     "too-many-public-methods",
     "missing-module-docstring",
     "too-many-ancestors",
-    "too-many-lines"
+    "too-many-lines",
 ]
 
 [tool.pytest.ini_options]
@@ -159,19 +158,26 @@ filterwarnings = [
     "ignore::DeprecationWarning:networkx:",
     "ignore::DeprecationWarning:ase:",
     "ignore::DeprecationWarning:aiida:",
-    "ignore::DeprecationWarning:plumpy:"
+    "ignore::DeprecationWarning:plumpy:",
 ]
 
 [tool.coverage.run]
 # Configuration of [coverage.py](https://coverage.readthedocs.io)
 # reporting which lines of your plugin are covered by tests
-source=["aiida_vasp"]
+source = ["aiida_vasp"]
 
 [tool.isort]
 # Configuration of [isort](https://isort.readthedocs.io)
 line_length = 120
 force_sort_within_sections = true
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'AIIDA', 'FIRSTPARTY', 'LOCALFOLDER']
+sections = [
+    'FUTURE',
+    'STDLIB',
+    'THIRDPARTY',
+    'AIIDA',
+    'FIRSTPARTY',
+    'LOCALFOLDER',
+]
 known_aiida = ['aiida']
 # this configuration is compatible with yapf
 multi_line_output = 3
@@ -214,7 +220,6 @@ extras =
 """
 
 
-
 [tool.ruff]
 exclude = [
     "cookiecutters",
@@ -254,27 +259,27 @@ quote-style = 'single'
 
 [tool.ruff.lint]
 ignore = [
-  'F403',  # Star imports unable to detect undefined names
-  'F405',  # Import may be undefined or defined from star imports
-  'PLR0911',  # Too many return statements
-  'PLR0912',  # Too many branches
-  'PLR0913',  # Too many arguments in function definition
-  'PLR0915',  # Too many statements
-  'PLR2004',  # Magic value used in comparison
-  'RUF005',  # Consider iterable unpacking instead of concatenation
-  'RUF012'  # Mutable class attributes should be annotated with `typing.ClassVar`
+    'F403',    # Star imports unable to detect undefined names
+    'F405',    # Import may be undefined or defined from star imports
+    'PLR0911', # Too many return statements
+    'PLR0912', # Too many branches
+    'PLR0913', # Too many arguments in function definition
+    'PLR0915', # Too many statements
+    'PLR2004', # Magic value used in comparison
+    'RUF005',  # Consider iterable unpacking instead of concatenation
+    'RUF012',  # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 select = [
-  'E',  # pydocstyle
-  'W',  # pydocstyle
-  'F',  # pyflakes
-  'I',  # isort
-  'N',  # pep8-naming
-  'PLC',  # pylint-convention
-  'PLE',  # pylint-error
-  'PLR',  # pylint-refactor
-  'PLW',  # pylint-warning
-  'RUF'  # ruff
+    'E',   # pydocstyle
+    'W',   # pydocstyle
+    'F',   # pyflakes
+    'I',   # isort
+    'N',   # pep8-naming
+    'PLC', # pylint-convention
+    'PLE', # pylint-error
+    'PLR', # pylint-refactor
+    'PLW', # pylint-warning
+    'RUF', # ruff
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,12 @@ classifiers = [
 keywords = ["aiida", "plugin"]
 requires-python = ">=3.9"
 dependencies = [
-    "aiida-core~=2.3",
+    "aiida-core>=2.3",
     "ase",
     "lxml",
     "seekpath",
     "packaging",
-    "parsevasp~=3.2",
+    "parsevasp>=3.2",
 ]
 
 [project.urls]

--- a/src/aiida_vasp/calcs/tests/test_immigrant.py
+++ b/src/aiida_vasp/calcs/tests/test_immigrant.py
@@ -65,7 +65,7 @@ def test_vasp_immigrant(immigrant_with_builder):
     result, node = run.get_node(builder)
     assert node.exit_status == 0
 
-    expected_output_nodes = {'misc', 'remote_folder', 'retrieved'}
+    expected_output_nodes = {'misc', 'retrieved'}
     assert expected_output_nodes.issubset(set(result))
 
 
@@ -124,5 +124,5 @@ def test_vasp_immigrant_example_3(immigrant_with_builder_example_3):  # pylint: 
     result, node = run.get_node(immigrant, **inputs)
     assert node.exit_status == 0
 
-    expected_output_nodes = {'misc', 'remote_folder', 'retrieved'}
+    expected_output_nodes = {'misc', 'retrieved'}
     assert expected_output_nodes.issubset(set(result))

--- a/src/aiida_vasp/calcs/tests/test_neb.py
+++ b/src/aiida_vasp/calcs/tests/test_neb.py
@@ -12,7 +12,6 @@ from aiida_vasp.utils.fixtures.calcs import ONLY_ONE_CALC
 @ONLY_ONE_CALC
 def test_prepare(
     fresh_aiida_env,
-    aiida_instance,
     vasp_neb_calc,
     vasp_neb_inputs,
     localhost_dir,

--- a/src/aiida_vasp/calcs/tests/test_vasp.py
+++ b/src/aiida_vasp/calcs/tests/test_vasp.py
@@ -189,7 +189,7 @@ def managed_temp_object():
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 @pytest.mark.usefixtures('fresh_aiida_env')
-def test_vasp_calc_only_output(run_vasp_process, aiida_caplog):
+def test_vasp_calc_only_output(run_vasp_process):
     """Test a run of a basic VASP calculation which misses critical files."""
     _, node = run_vasp_process(test_case='stdout')
     assert node.exit_status == 352
@@ -200,7 +200,7 @@ def test_vasp_calc_only_output(run_vasp_process, aiida_caplog):
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 @pytest.mark.usefixtures('fresh_aiida_env')
-def test_vasp_calc(run_vasp_process, aiida_caplog):
+def test_vasp_calc(run_vasp_process):
     """Test a run of a basic VASP calculation and its details."""
     from aiida_vasp.calcs.vasp import VaspCalculation
 

--- a/src/aiida_vasp/commands/tests/test_potcar_cmd.py
+++ b/src/aiida_vasp/commands/tests/test_potcar_cmd.py
@@ -7,19 +7,19 @@ import os
 from pathlib import Path
 
 import pytest
+from aiida.common import AttributeDict
 from aiida_vasp.commands.potcar import potcar
 from aiida_vasp.data.potcar import PotcarGroup
 from aiida_vasp.utils.aiida_utils import get_data_class
 from aiida_vasp.utils.fixtures import *
 from aiida_vasp.utils.fixtures.data import POTCAR_FAMILY_NAME, legacy_potcar_family  # noqa: F401
 from click.testing import CliRunner
-from monty.collections import AttrDict
 
 
 @pytest.fixture
 def cmd_params(temp_pot_folder):
     """Common building blocks for ``uploadfamily`` calls."""
-    params = AttrDict()
+    params = AttributeDict()
     params.POTCAR_PATH = str(temp_pot_folder)
     params.FAMILY_NAME = POTCAR_FAMILY_NAME
     params.PATH_OPTION = f'--path={params.POTCAR_PATH}'

--- a/src/aiida_vasp/parsers/tests/test_vasp_parser.py
+++ b/src/aiida_vasp/parsers/tests/test_vasp_parser.py
@@ -142,7 +142,7 @@ def test_add_parser_quantity_fail(vasp_parser_without_parsing):
         parser.parse(retrieved_temporary_folder=path)
 
 
-def test_add_parser_quantity(vasp_parser_without_parsing, aiida_caplog):
+def test_add_parser_quantity(vasp_parser_without_parsing):
     """Add_parsable_quantity with name succeeds."""
     parser, path = vasp_parser_without_parsing
     parser.add_parsable_quantity(

--- a/src/aiida_vasp/utils/fixtures/environment.py
+++ b/src/aiida_vasp/utils/fixtures/environment.py
@@ -23,7 +23,7 @@ from aiida.tools.archive import create_archive
 
 
 @pytest.fixture()
-def fresh_aiida_env(aiida_profile_clean, aiida_caplog):
+def fresh_aiida_env(aiida_profile_clean):
     """Reset the database before and after the test function."""
     try:
         yield aiida_profile_clean

--- a/src/aiida_vasp/workchains/tests/test_vasp_wc.py
+++ b/src/aiida_vasp/workchains/tests/test_vasp_wc.py
@@ -32,7 +32,7 @@ def test_vasp_wc(fresh_aiida_env, run_vasp_process):
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_vasp_wc_chgcar(fresh_aiida_env, run_vasp_process, aiida_caplog):
+def test_vasp_wc_chgcar(fresh_aiida_env, run_vasp_process):
     """Test submitting only, not correctness, with mocked vasp code, test fetching and parsing of the CHGCAR content."""
     settings = {
         'ADDITIONAL_RETRIEVE_LIST': ['CHGCAR'],

--- a/src/aiida_vasp/workchains/v2/common/transform.py
+++ b/src/aiida_vasp/workchains/v2/common/transform.py
@@ -321,7 +321,7 @@ def match_atomic_order_(atoms: Atoms, atoms_ref: Atoms) -> Tuple[Atoms, List[int
     return atoms[new_index], new_index
 
 
-def create_additional_species(species: list, magmom: list):
+def create_additional_species(species: list, magmoms: list):
     """
     Create additional species depending on magnetic moments.
     For example, create Fe1 and Fe2 if there are Fe with different
@@ -334,7 +334,7 @@ def create_additional_species(species: list, magmom: list):
     unique_species = set(species)
     new_species = []
     current_species_mapping = {sym: {} for sym in unique_species}
-    for symbol, magmom in zip(species, magmom):
+    for symbol, magmom in zip(species, magmoms):
         current_symbol = symbol
         # Mappings for this original symbol
         mapping = current_species_mapping[symbol]


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

aiida-core v2.6 implements `aiida.tools.pytest_fixtures` instead of `aiida.manage.tests.pytest_fixtures`. This PR is for this migration.

@zhubonan, could you confirm the followings are not the problem for you?

`aiida_instance` and `aiida_caplog` seem not existing. I just removed them from the tests.

* `aiida_instance` in `test_neb.py::test_prepare` was removed. It seems `aiida_config` can replace it.
* `aiida_caplog` in several tests were removed. -> will be replaced by pytest's caplot if necessary.

Some behaviour related to immigrant changed, but since anyway the implementation of immigrant is like a hack, I just changed the test references to agree with the latest behaviour.