### PR TITLE
Improve the BuilderUpdater tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "lxml",
     "seekpath",
     "packaging",
+    "pydantic",
     "parsevasp>=3.2",
 ]
 

--- a/src/aiida_vasp/assistant/parameters.py
+++ b/src/aiida_vasp/assistant/parameters.py
@@ -349,8 +349,9 @@ class ParameterSetFunctions:
             return
         energy_cutoff = False
         try:
-            self._incar.ediffg = self._parameters.relax.energy_cutoff
-            energy_cutoff = True
+            if self._parameters.relax.energy_cutoff is not None:
+                self._incar.ediffg = self._parameters.relax.energy_cutoff
+                energy_cutoff = True
         except AttributeError:
             pass
         try:

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -2,8 +2,10 @@
 Module containing the OptionHolder class
 """
 
+from typing import Optional
+
 from aiida.orm import Dict
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 # pylint:disable=raise-missing-from
 
@@ -68,3 +70,160 @@ class OptionContainer(BaseModel):
                 )
             )
         return '\n'.join(lines)
+
+
+class CalcSettingsConfig(OptionContainer):
+    """Schema for the .setting port"""
+
+    parser_setting: Optional[dict] = Field(description='Settings for the parser')
+    ADDITIONAL_RETRIEVE_LIST: Optional[list] = Field(description='Additional list of files to be retrieved')
+    ADDITIONAL_RETRIEVE_TEMPORARY_LIST: Optional[list] = Field(
+        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
+    )
+    PROVENANCE_EXCLUDE_LIST: Optional[list] = Field(
+        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
+    )
+    ALWAYS_STORE: Optional[list] = Field(
+        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
+    )
+
+
+class RelaxOptions(OptionContainer):
+    """Options for VaspRelaxWorkChain"""
+
+    algo: str = Field(description='The algorithm to use for relaxation', examples=['cg', 'rd'], default='cg')
+    energy_cutoff: Optional[float] = Field(
+        description='The cut off energy difference when the relaxation is stopped (e.g. EDIFF)',
+        default=None,
+    )
+    force_cutoff: float = Field(
+        description='The maximum force when the relaxation is stopped (e.g. EDIFFG)',
+        default=0.03,
+    )
+    steps: float = Field(description='Number of relaxation steps to perform (eg. NSW)', default=60)
+    positions: bool = Field(description='If True, perform relaxation of the atomic positions', default=True)
+    shape: bool = Field(description='If True, perform relaxation of the cell shape', default=True)
+    volume: bool = Field(description='If True, perform relaxation of the cell volume', default=True)
+    convergence_on: bool = Field(description='If True, perform convergence checks within the workchain', default=True)
+    convergence_absolute: bool = Field(
+        description='If True, use absolute values where possible when performing convergence checks',
+        default=False,
+    )
+    convergence_max_iterations: int = Field(description='Maximum iterations for convergence checking', default=5)
+    convergence_positions: float = Field(
+        description=(
+            'The cutoff value for the convergence check on positions in Angstram.'
+            ' A negative value by pass the check.'
+        ),
+        default=0.1,
+    )
+    convergence_volume: float = Field(
+        description='The cutoff value for the convergence check on volume between the two structures.'
+        ' A negative value by pass the check.',
+        default=0.01,
+    )
+    convergence_shape_lengths: float = Field(
+        description='The cutoff value for the convergence check on the lengths of the unit cell'
+        ' vectors, between input and the outputs structure. A negative value by pass'
+        ' the check.',
+        default=0.1,
+    )
+    convergence_shape_angles: float = Field(
+        description='The cutoff value for the convergence check on the angles of the unit cell vectors, '
+        'between input and the outputs structure. A'
+        ' negative value by pass the check.',
+        default=0.1,
+    )
+    convergence_mode: str = Field(
+        description="Mode of the convergence check for positions. 'inout' for checking input/output structure, "
+        "or 'last' to check only the change of"
+        ' the last step.',
+        examples=['inout', 'last'],
+        default='last',
+    )
+    reuse: bool = Field(
+        description='Whether reuse the previous calculation by copying over the remote folder',
+        default=False,
+    )
+    clean_reuse: bool = Field(
+        description='Whether to perform a final cleaning of the reused calculations', default=True
+    )
+    keep_sp_workdir: bool = Field(
+        description='Whether to keep the workdir of the final singlepoint calculation', default=False
+    )
+    perform: bool = Field(description="Do not perform any relaxation if set to 'False'", default=True)
+    hybrid_calc_bootstrap: bool = Field(
+        description='Whether to bootstrap hybrid calculation by performing standard DFT first', default=False
+    )
+    hybrid_calc_bootstrap_wallclock: int = Field(
+        description='Wall time limit in second for the bootstrap calculation', default=3600
+    )
+    keep_magnetization: bool = Field(
+        description='Whether to keep magnetization from the previous calculation if possible', default=False
+    )
+
+    # TODO: implement pyandtic checks
+
+    # @classmethod
+    # def validate_dict(cls, input_dict, port=None):
+    #     """Check mutually exclusive fields"""
+    #     super().validate_dict(input_dict, port)
+    #     if isinstance(input_dict, orm.Dict):
+    #         input_dict = input_dict.get_dict()
+    #     force_cut = input_dict.get('force_cutoff')
+    #     energy_cut = input_dict.get('energy_cutoff')
+    #     if force_cut is None and energy_cut is None:
+    #         raise InputValidationError("Either 'force_cutoff' or 'energy_cutoff' should be supplied")
+    #     if (force_cut is not None) and (energy_cut is not None):
+    #         raise InputValidationError("Cannot set both 'force_cutoff' and 'energy_cutoff'")
+
+
+class ConvOptions(OptionContainer):
+    """Template for the Dict node controlling the workchain behaviour"""
+
+    cutoff_start: float = Field(description='The starting cut-off energy', default=300.0)
+    cutoff_stop: float = Field(description='The Final cut-off energy', default=700.0)
+    cutoff_step: float = Field(description='Step size of the cut-off energy', default=50.0)
+    kspacing_start: float = Field(description='The starting kspacing', default=0.07)
+    kspacing_stop: float = Field(description='The final kspacing', default=0.02)
+    kspacing_step: float = Field(description='Step size of the cut-off energy', default=0.01)
+    cutoff_kconv: float = Field(description='The cut-off energy used for kpoints convergence tests', default=450.0)
+    kspacing_cutconv: float = Field(
+        description='The kpoints spacing used for cut-off energy convergence tests', default=0.07
+    )
+
+
+class BandOptions(OptionContainer):
+    """Options for VaspRelaxWorkChain"""
+
+    symprec: float = Field(description='Precision of the symmetry determination', default=0.01)
+    band_mode: str = Field(
+        description=(
+            'Mode for generating the band path. Choose from: bradcrack, pymatgen,' 'seekpath-aiida and latimer-munro.'
+        ),
+        examples=['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
+        default='seekpath-aiida',
+    )
+    # TODO: enable explicit seekpath passing
+    band_kpoints_distance: float = Field(
+        description='Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
+        default=0.025,
+    )
+    line_density: float = Field(
+        description='Density of the point along the path, used by the sumo interface.',
+        default=20,
+    )
+    dos_kpoints_distance: float = Field(
+        description=(
+            'Kpoints for running DOS calculations in A^-1 * 2pi.' ' Will perform non-SCF DOS calculation is supplied.'
+        ),
+        default=0.03,
+    )
+    only_dos: bool = Field(
+        description='Flag for running only DOS calculations',
+        default=False,
+    )
+    run_dos: bool = Field(
+        description='Flag for running DOS calculations',
+        default=False,
+    )

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -2,7 +2,6 @@
 Module containing the OptionHolder class
 """
 
-from aiida.common.exceptions import InputValidationError
 from aiida.orm import Dict
 from pydantic import BaseModel, ValidationError
 
@@ -21,16 +20,18 @@ class OptionContainer(BaseModel):
         return Dict(dict=python_dict)
 
     @classmethod
-    def aiida_validate(cls, input_dict) -> None:  # pylint:disable=unused-argument
+    def aiida_validate(cls, input_dict, namespace=None) -> None:  # pylint:disable=unused-argument
         """
         Validate a dictionary/Dict node, this can be used as the validator for
         the Port accepting the inputs
         """
+        if isinstance(input_dict, Dict):
+            input_dict = input_dict.get_dict()
         try:
             cls(**input_dict)
         except ValidationError as error:
-            raise InputValidationError(f'Input validation failed: {error}') from error
-        return True
+            return str(error)
+        return None
 
     @classmethod
     def aiida_serialize(cls, python_dict: dict):

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -1,0 +1,69 @@
+"""
+Module containing the OptionHolder class
+"""
+
+from aiida.common.exceptions import InputValidationError
+from aiida.orm import Dict
+from pydantic import BaseModel, ValidationError
+
+# pylint:disable=raise-missing-from
+
+
+class OptionContainer(BaseModel):
+    """
+    Base class for a container of options
+    """
+
+    def aiida_dict(self):
+        """Return an ``aiida.orm.Dict`` presentation"""
+
+        python_dict = self.model_dump()
+        return Dict(dict=python_dict)
+
+    @classmethod
+    def aiida_validate(cls, input_dict) -> None:  # pylint:disable=unused-argument
+        """
+        Validate a dictionary/Dict node, this can be used as the validator for
+        the Port accepting the inputs
+        """
+        try:
+            cls(**input_dict)
+        except ValidationError as error:
+            raise InputValidationError(f'Input validation failed: {error}') from error
+        return True
+
+    @classmethod
+    def aiida_serialize(cls, python_dict: dict):
+        """
+        serialize a dictionary into Dict
+
+        This method can be passed as a `serializer` key word parameter of for the `spec.input` call.
+        """
+        obj = cls(**python_dict)
+        return obj.aiida_dict()
+
+    @classmethod
+    def aiida_description(cls):
+        """
+        Return a string for the options of a OptionContains in a human-readable format.
+        """
+
+        obj = cls()
+        template = '{:>{width_name}s}:  {:10s} \n{default:>{width_name2}}: {}'
+        entries = []
+        for name, field in obj.model_fields.items():
+            # Each entry is name, type, doc, default value
+            entries.append([name, str(field.annotation.__name__), field.description, field.default])
+        max_width_name = max(len(entry[0]) for entry in entries) + 2
+
+        lines = []
+        for entry in entries:
+            lines.append(
+                template.format(
+                    *entry,
+                    width_name=max_width_name,
+                    width_name2=max_width_name + 10,
+                    default='Default',
+                )
+            )
+        return '\n'.join(lines)

--- a/src/aiida_vasp/workchains/v2/__init__.py
+++ b/src/aiida_vasp/workchains/v2/__init__.py
@@ -1,0 +1,1 @@
+from .common.builder_updater import *

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -17,11 +17,12 @@ from aiida.common.links import LinkType
 from aiida.engine import WorkChain, append_, calcfunction, if_
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import WorkflowFactory
+from pydantic import Field
 
 from aiida_vasp.utils.aiida_utils import get_data_class
+from aiida_vasp.utils.opthold import OptionContainer
 
 from .common import OVERRIDE_NAMESPACE, nested_update, nested_update_dict_node
-from .common.opthold import BoolOption, ChoiceOption, FloatOption, IntOption, OptionContainer
 from .common.transform import magnetic_structure_decorate, magnetic_structure_dedecorate
 from .mixins import WithVaspInputSet
 
@@ -34,37 +35,36 @@ except ImportError:
 class BandOptions(OptionContainer):
     """Options for VaspRelaxWorkChain"""
 
-    symprec = FloatOption('Precision of the symmetry determination', default_value=0.01, required=False)
-    band_mode = ChoiceOption(
-        'Mode for generating the band path. Choose from: bradcrack, pymatgen, seekpath-aiida and latimer-munro.',
-        ['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
-        default_value='seekpath-aiida',
+    symprec: float = Field(description='Precision of the symmetry determination', default=0.01)
+    band_mode: str = Field(
+        description=(
+            'Mode for generating the band path. Choose from: bradcrack, pymatgen,' 'seekpath-aiida and latimer-munro.'
+        ),
+        examples=['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
+        default='seekpath-aiida',
     )
     # TODO: enable explicit seekpath passing
-    band_kpoints_distance = FloatOption(
-        'Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
-        default_value=None,
-        required=False,
+    band_kpoints_distance: float = Field(
+        description='Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
+        default=0.025,
     )
-    line_density = IntOption(
-        'Density of the point along the path, used by the sumo interface.',
-        default_value=20,
-        required=False,
+    line_density: float = Field(
+        description='Density of the point along the path, used by the sumo interface.',
+        default=20,
     )
-    dos_kpoints_distance = FloatOption(
-        'Kpoints for running DOS calculations in A^-1 * 2pi. Will perform non-SCF DOS calculation is supplied.',
-        default_value=0.03,
-        required=False,
+    dos_kpoints_distance: float = Field(
+        description=(
+            'Kpoints for running DOS calculations in A^-1 * 2pi.' ' Will perform non-SCF DOS calculation is supplied.'
+        ),
+        default=0.03,
     )
-    only_dos = BoolOption(
-        'Flag for running only DOS calculations',
-        default_value=False,
-        required=False,
+    only_dos: bool = Field(
+        description='Flag for running only DOS calculations',
+        default=False,
     )
-    run_dos = BoolOption(
-        'Flag for running DOS calculations',
-        default_value=False,
-        required=False,
+    run_dos: bool = Field(
+        description='Flag for running DOS calculations',
+        default=False,
     )
 
 
@@ -118,10 +118,10 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
         )
         spec.input(
             'band_settings',
-            help=BandOptions.get_description(),
+            help=BandOptions.aiida_description(),
             valid_type=get_data_class('core.dict'),
-            validator=BandOptions.validate_dict,
-            serializer=to_aiida_type,
+            validator=BandOptions.aiida_validate,
+            serializer=BandOptions.aiida_serialize,
         )
         spec.expose_inputs(
             relax_work,
@@ -298,6 +298,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
         if mode == 'seekpath-aiida':
             inputs = {
                 'reference_distance': self.inputs.band_settings['band_kpoints_distance'],
+                'symprec': self.inputs.band_settings['symprec'],
                 'metadata': {'call_link_label': 'seekpath'},
             }
             func = seekpath_structure_analysis

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -17,10 +17,9 @@ from aiida.common.links import LinkType
 from aiida.engine import WorkChain, append_, calcfunction, if_
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import WorkflowFactory
-from pydantic import Field
 
 from aiida_vasp.utils.aiida_utils import get_data_class
-from aiida_vasp.utils.opthold import OptionContainer
+from aiida_vasp.utils.opthold import BandOptions
 
 from .common import OVERRIDE_NAMESPACE, nested_update, nested_update_dict_node
 from .common.transform import magnetic_structure_decorate, magnetic_structure_dedecorate
@@ -30,42 +29,6 @@ try:
     from aiida_vasp.parsers.content_parsers.vasprun import VasprunParser
 except ImportError:
     from aiida_vasp.parsers.file_parsers.vasprun import VasprunParser
-
-
-class BandOptions(OptionContainer):
-    """Options for VaspRelaxWorkChain"""
-
-    symprec: float = Field(description='Precision of the symmetry determination', default=0.01)
-    band_mode: str = Field(
-        description=(
-            'Mode for generating the band path. Choose from: bradcrack, pymatgen,' 'seekpath-aiida and latimer-munro.'
-        ),
-        examples=['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
-        default='seekpath-aiida',
-    )
-    # TODO: enable explicit seekpath passing
-    band_kpoints_distance: float = Field(
-        description='Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
-        default=0.025,
-    )
-    line_density: float = Field(
-        description='Density of the point along the path, used by the sumo interface.',
-        default=20,
-    )
-    dos_kpoints_distance: float = Field(
-        description=(
-            'Kpoints for running DOS calculations in A^-1 * 2pi.' ' Will perform non-SCF DOS calculation is supplied.'
-        ),
-        default=0.03,
-    )
-    only_dos: bool = Field(
-        description='Flag for running only DOS calculations',
-        default=False,
-    )
-    run_dos: bool = Field(
-        description='Flag for running DOS calculations',
-        default=False,
-    )
 
 
 class VaspBandsWorkChain(WorkChain, WithVaspInputSet):

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -21,6 +21,7 @@ from aiida.plugins import WorkflowFactory
 from aiida_vasp.utils.aiida_utils import get_data_class
 
 from .common import OVERRIDE_NAMESPACE, nested_update, nested_update_dict_node
+from .common.opthold import BoolOption, ChoiceOption, FloatOption, IntOption, OptionContainer
 from .common.transform import magnetic_structure_decorate, magnetic_structure_dedecorate
 from .mixins import WithVaspInputSet
 
@@ -28,6 +29,42 @@ try:
     from aiida_vasp.parsers.content_parsers.vasprun import VasprunParser
 except ImportError:
     from aiida_vasp.parsers.file_parsers.vasprun import VasprunParser
+
+
+class BandOptions(OptionContainer):
+    """Options for VaspRelaxWorkChain"""
+
+    symprec = FloatOption(help='Precision of the symmetry determination', default_value=0.01, required=False)
+    band_mode = ChoiceOption(
+        'Mode for generating the band path. Choose from: bradcrack, pymatgen, seekpath-aiida and latimer-munro.',
+        ['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
+        default_value='bradcrack',
+    )
+    band_kpoints_distance = FloatOption(
+        'Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
+        default_value=None,
+        required=False,
+    )
+    line_density = IntOption(
+        'Density of the point along the path, used by sumo interface.',
+        default_value=20,
+        required=False,
+    )
+    dos_kpoints_distance = FloatOption(
+        'Kpoints for running DOS calculations in A^-1 * 2pi. Will perform non-SCF DOS calculation is supplied.',
+        default_value=0.03,
+        required=False,
+    )
+    only_dos = BoolOption(
+        'Flag for running only DOS calculations',
+        default_value=False,
+        required=False,
+    )
+    run_dos = BoolOption(
+        'Flag for running DOS calculations',
+        default_value=False,
+        required=False,
+    )
 
 
 class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
@@ -79,37 +116,11 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
             required=False,
         )
         spec.input(
-            'bands_kpoints_distance',
-            help='Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
-            valid_type=orm.Float,
-            required=False,
-        )
-        spec.input(
-            'line_density',
-            help='Density of the point along the path, used by sumo interface.',
-            valid_type=orm.Float,
-            required=False,
-        )
-        spec.input(
-            'band_mode',
-            help='Mode for generating the band path. Choose from: bradcrack, pymatgen, seekpath, '
-            'seekpath-aiida and latimer-munro.',
-            required=False,
-            valid_type=orm.Str,
-        )
-        spec.input(
-            'symprec',
-            help='Precision of the symmetry determination',
-            valid_type=orm.Float,
-            required=True,
-        )
-        spec.input(
-            'dos_kpoints_density',
-            help='Kpoints for running DOS calculations in A^-1 * 2pi. Will perform '
-            'non-SCF DOS calculation is supplied.',
+            'band_settings',
+            help=BandOptions.get_description(),
+            valid_type=get_data_class('core.dict'),
+            validator=BandOptions.validate_dict,
             serializer=to_aiida_type,
-            required=False,
-            valid_type=orm.Float,
         )
         spec.expose_inputs(
             relax_work,
@@ -279,7 +290,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
         Seekpath should only run if no explicit bands is provided or we are just
         running for DOS, in which case the original structure is used.
         """
-        return 'bs_kpoints' not in self.inputs and (not self.inputs.get('only_dos', False))
+        return 'bs_kpoints' not in self.inputs and (not self.inputs.band_settings['only_dos'])
 
     def generate_path(self):
         """
@@ -288,7 +299,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
         current_structure_backup = self.ctx.current_structure
 
-        mode = self.inputs.get('band_mode')
+        mode = self.inputs.band_settings['band_mode']
         if mode is None:
             mode = self.DEFAULT_BAND_MODE
         else:
@@ -296,7 +307,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
         if mode == 'seekpath-aiida':
             inputs = {
-                'reference_distance': self.inputs.get('bands_kpoints_distance', None),
+                'reference_distance': self.inputs.band_settings['band_kpoints_distance'],
                 'metadata': {'call_link_label': 'seekpath'},
             }
             func = seekpath_structure_analysis
@@ -305,8 +316,8 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
             from .common.sumo_kpath import kpath_from_sumo
 
             inputs = {
-                'line_density': self.inputs.get('line_density', orm.Float(self.DEFAULT_LINE_DENSITY)),
-                'symprec': self.inputs.get('symprec', orm.Float(self.DEFAULT_SYMPREC)),
+                'line_density': self.inputs.band_settings['line_density'],
+                'symprec': self.inputs.band_settings['symprec'],
                 'mode': orm.Str(mode),
                 'metadata': {'call_link_label': 'sumo_kpath'},
             }
@@ -414,9 +425,9 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
         running = {}
 
-        only_dos = self.inputs.get('only_dos')
+        only_dos = self.inputs.band_settings['only_dos']
 
-        if (only_dos is None) or (only_dos.value is False):
+        if only_dos.value is False:
             if 'bands' in self.inputs:
                 bands_input = AttributeDict(self.exposed_inputs(base_work, namespace='bands'))
             else:
@@ -463,7 +474,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
         # Do DOS calculation if dos input namespace is populated or a
         # dos_kpoints input is passed.
-        if ('dos_kpoints_density' in self.inputs) or ('dos' in self.inputs):
+        if (self.inputs.band_settings['run_dos']) or ('dos' in self.inputs):
             if 'dos' in self.inputs:
                 dos_input = AttributeDict(self.exposed_inputs(base_work, namespace='dos'))
             else:
@@ -474,11 +485,10 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
                     }
                 )
             # Use the supplied kpoints density for DOS
-            if 'dos_kpoints_density' in self.inputs:
-                dos_kpoints = orm.KpointsData()
-                dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
-                dos_kpoints.set_kpoints_mesh_from_density(self.inputs.dos_kpoints_density.value * 2 * np.pi)
-                dos_input.kpoints = dos_kpoints
+            dos_kpoints = orm.KpointsData()
+            dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
+            dos_kpoints.set_kpoints_mesh_from_density(self.inputs.band_settings['dos_kpoints_density'] * 2 * np.pi)
+            dos_input.kpoints = dos_kpoints
 
             # Special treatment - combine the parameters
             parameters = inputs.parameters.get_dict()
@@ -756,7 +766,7 @@ class VaspHybridBandsWorkChain(VaspBandsWorkChain):
             return self.exit_codes.ERROR_NO_VALID_SCF_KPOINTS_INPUT  # pylint: disable=no-member
 
         # Number of kpoints per split, NOT including the SCF kpoints
-        per_split = orm.Int(self.inputs.kpoints_per_split.value - scf_kpoints.get_kpoints().shape[0])
+        per_split = orm.Int(self.inputs.band_settings['kpoints_per_split'] - scf_kpoints.get_kpoints().shape[0])
         kpoints_for_calc = split_kpoints(scf_kpoints, full_kpoints, per_split)
         self.ctx.kpoints_for_calc = kpoints_for_calc
 

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -38,15 +38,16 @@ class BandOptions(OptionContainer):
     band_mode = ChoiceOption(
         'Mode for generating the band path. Choose from: bradcrack, pymatgen, seekpath-aiida and latimer-munro.',
         ['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
-        default_value='bradcrack',
+        default_value='seekpath-aiida',
     )
+    # TODO: enable explicit seekpath passing
     band_kpoints_distance = FloatOption(
         'Spacing for band distances for automatic kpoints generation, used by seekpath-aiida mode.',
         default_value=None,
         required=False,
     )
     line_density = IntOption(
-        'Density of the point along the path, used by sumo interface.',
+        'Density of the point along the path, used by the sumo interface.',
         default_value=20,
         required=False,
     )
@@ -93,6 +94,9 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
     Input for bands and dos calculations are optional. However, if they are needed, the full list of inputs must
     be passed. For the `parameters` node, one may choose to only specify those fields that need to be updated.
+
+    For optics calculations, one should run with `only_dos`, set 'NBANDS' to a high value and
+    set 'LOPTICS' to be True.
     """
 
     _base_wk_string = 'vasp.v2.vasp'

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -34,7 +34,7 @@ except ImportError:
 class BandOptions(OptionContainer):
     """Options for VaspRelaxWorkChain"""
 
-    symprec = FloatOption(help='Precision of the symmetry determination', default_value=0.01, required=False)
+    symprec = FloatOption('Precision of the symmetry determination', default_value=0.01, required=False)
     band_mode = ChoiceOption(
         'Mode for generating the band path. Choose from: bradcrack, pymatgen, seekpath-aiida and latimer-munro.',
         ['bradcrack', 'pymatgen', 'seekpath', 'seekpath-aiida', 'latimer-munro'],
@@ -97,9 +97,6 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
     _base_wk_string = 'vasp.v2.vasp'
     _relax_wk_string = 'vasp.v2.relax'
-    DEFAULT_BAND_MODE = 'bradcrack'
-    DEFAULT_LINE_DENSITY = 20
-    DEFAULT_SYMPREC = 0.01
 
     @classmethod
     def define(cls, spec):
@@ -171,13 +168,6 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
             default=lambda: orm.Str('none'),
         )
         spec.input(
-            'only_dos',
-            required=False,
-            help='Flag for running only DOS calculations',
-            valid_type=orm.Bool,
-            serializer=to_aiida_type,
-        )
-        spec.input(
             'chgcar',
             required=False,
             valid_type=get_data_class('vasp.chargedensity'),
@@ -247,7 +237,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
         self.ctx.current_structure = self.inputs.structure
         self.ctx.bs_kpoints = self.inputs.get('bs_kpoints')
         param = self.inputs.scf.parameters.get_dict()
-        if 'magmom' in param[OVERRIDE_NAMESPACE] and not self.inputs.get('only_dos'):
+        if 'magmom' in param[OVERRIDE_NAMESPACE] and not self.inputs.band_settings['only_dos']:
             self.report('Magnetic system passed for BS')
             self.ctx.magmom = param[OVERRIDE_NAMESPACE]['magmom']
         else:
@@ -300,10 +290,6 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
         current_structure_backup = self.ctx.current_structure
 
         mode = self.inputs.band_settings['band_mode']
-        if mode is None:
-            mode = self.DEFAULT_BAND_MODE
-        else:
-            mode = mode.value
 
         if mode == 'seekpath-aiida':
             inputs = {
@@ -427,7 +413,7 @@ class VaspBandsWorkChain(WorkChain, WithVaspInputSet):
 
         only_dos = self.inputs.band_settings['only_dos']
 
-        if only_dos.value is False:
+        if only_dos is False:
             if 'bands' in self.inputs:
                 bands_input = AttributeDict(self.exposed_inputs(base_work, namespace='bands'))
             else:

--- a/src/aiida_vasp/workchains/v2/common/VaspPreset.yaml
+++ b/src/aiida_vasp/workchains/v2/common/VaspPreset.yaml
@@ -1,0 +1,26 @@
+name: 'VaspPreset'
+inputset: 'UCLRelaxSet'
+default_code: 'vasp@localhost'
+
+code_specific:
+    # These are code specific settings for the VaspCalculation
+    'vasp@localhost':
+        options:
+            max_wallclock_seconds: 3600
+            resources:
+                tot_num_mpiprocs: 1
+        settings: {}
+        inputset_overrides: {}
+default_options:
+    # Put default options for the VaspCalculation here
+    max_wallclock_seconds: 3600
+    resources:
+        tot_num_mpiprocs: 1
+# default_settings:
+    # Put default settings for the VaspCalculation here
+# default_inputset_overrides:
+    # Put overrides for input set here
+# default_relax_settings:
+    # Put relaxation calculation settings here
+# default_band_settings:
+    # Put band structure calculation settings here

--- a/src/aiida_vasp/workchains/v2/common/VaspPreset.yaml
+++ b/src/aiida_vasp/workchains/v2/common/VaspPreset.yaml
@@ -9,6 +9,7 @@ code_specific:
             max_wallclock_seconds: 3600
             resources:
                 tot_num_mpiprocs: 1
+                num_machines: 1
         settings: {}
         inputset_overrides: {}
 default_options:
@@ -16,11 +17,13 @@ default_options:
     max_wallclock_seconds: 3600
     resources:
         tot_num_mpiprocs: 1
+        num_machines: 1
 # default_settings:
     # Put default settings for the VaspCalculation here
 # default_inputset_overrides:
     # Put overrides for input set here
 # default_relax_settings:
     # Put relaxation calculation settings here
-# default_band_settings:
+default_band_settings:
     # Put band structure calculation settings here
+    symprec: 1e-5

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -382,6 +382,18 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         warn('update_resources is deprecated, use set_resources instead', DeprecationWarning)
         return self.set_resources(*args, **kwargs)
 
+    def _set_options(
+        self, option_class, option_name: str, target_namespace: Union[ProcessBuilder, ProcessBuilderNamespace], **kwargs
+    ):
+        if getattr(target_namespace, option_name) is None:
+            current_option = option_class()
+        else:
+            current_option = option_class(**getattr(target_namespace, option_name).get_dict())
+        for key, value in kwargs.items():
+            setattr(current_option, key, value)
+        setattr(target_namespace, option_name, current_option.to_aiida_dict())
+        return self
+
 
 class VaspNEBUpdater(VaspBuilderUpdater):
     WF_ENTRYPOINT = 'vasp.neb'
@@ -501,14 +513,7 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
 
     def set_relax_settings(self, **kwargs) -> 'VaspRelaxUpdater':
         """Set/update RelaxOptions controlling the operation of the workchain"""
-
-        if self.namespace_relax.relax_settings is None:
-            current_options = RelaxOptions()
-        else:
-            current_options = RelaxOptions(**self.namespace_relax.relax_settings.get_dict())
-        for key, value in kwargs.items():
-            setattr(current_options, key, value)
-        self.namespace_relax.relax_settings = current_options.to_aiida_dict()
+        self._set_options(RelaxOptions, 'relax_settings', self.namespace_relax, **kwargs)
         return self
 
     update_relax_settings = set_relax_settings
@@ -535,12 +540,7 @@ class VaspConvUpdater(VaspBuilderUpdater):
         """
         from ..converge import ConvOptions
 
-        conv_dict = self.preset.get_code_specific_options(self.code, 'convergence_settings')
-        conv_dict = deepcopy(conv_dict)
-        conv_dict.update(dict(**kwargs))
-
-        opts = ConvOptions(**conv_dict)
-        self.builder.conv_settings = opts.to_aiida_dict()
+        self._set_options(ConvOptions, 'conv_settings', self.builder, **kwargs)
         return self
 
 
@@ -569,16 +569,13 @@ class VaspBandUpdater(VaspBuilderUpdater):
                 override_vasp_namespace=self.root_namespace.relax.vasp,
             )
             relax_upd.apply_preset(structure, *args, **kwargs)
+        self.set_band_settings()
         return self
 
-    def set_label(self, label=None) -> 'VaspBandUpdater':
-        """Set the toplevel label, default to the label of the structure"""
-        super().set_label(label)
-        if label:
-            if is_specified(self.root_namespace.relax):
-                self.root_namespace.relax.metadata.label = label
-            if is_specified(self.root_namespace.scf):
-                self.root_namespace.scf.metadata.label = label
+    def set_band_settings(self, **kwargs) -> 'VaspBandUpdater':
+        from aiida_vasp.workchains.v2.bands import BandOptions
+
+        self._set_options(BandOptions, 'band_settings', self.root_namespace, **kwargs)
         return self
 
 

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -391,7 +391,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             current_option = option_class(**getattr(target_namespace, option_name).get_dict())
         for key, value in kwargs.items():
             setattr(current_option, key, value)
-        setattr(target_namespace, option_name, current_option.to_aiida_dict())
+        setattr(target_namespace, option_name, current_option.aiida_dict())
         return self
 
 
@@ -520,7 +520,7 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
 
     def clear_relax_settings(self) -> 'VaspRelaxUpdater':
         """Reset any existing relax options"""
-        self.namespace_relax.relax_settings = RelaxOptions().to_aiida_dict()
+        self.namespace_relax.relax_settings = RelaxOptions().aiida_dict()
         return self
 
     def clear(self) -> 'VaspRelaxUpdater':

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -534,6 +534,11 @@ class VaspConvUpdater(VaspBuilderUpdater):
 
     WF_ENTRYPOINT = 'vasp.v2.converge'
 
+    def apply_preset(self, initial_structure, code=None, label=None) -> VaspBuilderUpdater:
+        super().apply_preset(initial_structure, code, label)
+        self.set_conv_settings()
+        return self
+
     def set_conv_settings(self, **kwargs) -> 'VaspConvUpdater':
         """
         Use the supplied convergence settings

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -1,47 +1,30 @@
 """
-Pipline for in place modification of builders
-
-## Basic usage
-
-```python
-builder = VaspRelaxWorkChain.get_builder()
-upd = VaspRelaxBuilder(builder)
-upd.use_input_set(structure, ..., ...)
-upd.use_code(...., ...)
-upd.set_wallclock_seconds(...).set_num_machines(...)
-```
-
-## Using configuration dictionary
-
-Instead of setting up the builder interactively, the updater can be initialised using
-a dictionary.
-
-```python
-config_relax = {
-    'overrides': {'encut': 520, 'ediff': 1e-6, 'ispin': 1, 'ncore': 2, 'kpar': 8},
-    'code': 'vasp-6.3.0-std@mn',
-    'options': {'max_wallclock_seconds': 3600 * 24 },
-    'resources': {'tot_num_mpiprocs': 48 * 16, 'num_machines': 16},
-    'inputset': 'UCLHSE06RelaxSet',
-    'relax_settings': {'force_cutoff': 0.02},
-    'kspacing': 0.07
-}
-
-upd = VaspRelaxWorkChain.init_from_config(structure, config_relax)
-```
+One liner input generator for aiida-vasp
 """
 
-from pprint import pprint
+import logging
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Union
 from warnings import warn
 
 from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
 from aiida.engine.processes.builder import ProcessBuilder
+from yaml import safe_load
 
 from ..inputset.vaspsets import VASPInputSet
 from ..relax import RelaxOptions
-from .dictwrap import DictWrapper
+
+DEFAULT_PRESET = 'VaspPreset'
+DEFAULT_INPUTSET = 'UCLRelaxSet'
+
+
+def get_library_path():
+    """Get the path where the YAML files are stored within this package"""
+    return Path(__file__).parent
+
 
 # Template for setting options
 OPTIONS_TEMPLATES = {
@@ -78,12 +61,69 @@ OPTIONS_TEMPLATES = {
 }
 
 
-class BuilderUpdater:
+@dataclass
+class VaspPresetConfig:
+    """Class to store the configuration for a VaspBuilderUpdater"""
+
+    name: str
+    inputset: str
+    default_code: str
+    code_specific: dict = field(default_factory=dict)
+    default_options: dict = field(default_factory=dict)
+    default_settings: dict = field(default_factory=dict)
+    default_inputset_overrides: dict = field(default_factory=dict)
+    default_relax_settings: dict = field(default_factory=dict)
+    default_band_settings: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, fname):
+        """Load from file"""
+
+        _load_paths = (get_library_path(), Path('~/.aiida-vasp').expanduser())
+        for parent in _load_paths:
+            target_path = parent / (fname + '.yaml')
+            if target_path.is_file():
+                break
+        if target_path is None:
+            raise RuntimeError(f'Cannot find preset definition for {fname}')
+
+        with open(target_path, encoding='utf-8', mode='r') as fhandle:
+            data = safe_load(fhandle)
+        return cls(**data)
+
+    def get_code_specific_options(self, code, namespace):
+        """Return code specific options, if exists"""
+        if code in self.code_specific:
+            if namespace in self.code_specific[code]:
+                code_specific = self.code_specific[code][namespace]
+                default = getattr(self, f'default_{namespace}', {})
+                if default is None:
+                    default = {}
+                default = deepcopy(default)
+                default.update(code_specific)
+                return default
+        return deepcopy(getattr(self, f'default_{namespace}'))
+
+
+class BaseBuilderUpdater:
     """Base class for builder updater"""
 
-    def __init__(self, builder: ProcessBuilder):
-        """Instantiate a pipline"""
+    def __init__(
+        self, preset_name: Union[None, str] = None, builder: Union[ProcessBuilder, None] = None, verbose=False
+    ):
+        """Instantiate a pipeline"""
+        # Configure the builder
+        from aiida.plugins import WorkflowFactory
+
+        assert hasattr(self, 'WF_ENTRYPOINT'), 'WF_ENTRYPOINT must be specified by the class'
+        self.verbose = verbose
+        if builder is None:
+            builder = WorkflowFactory(self.WF_ENTRYPOINT).get_builder()
         self._builder = builder
+        if preset_name is None:
+            preset_name = DEFAULT_PRESET
+        self.preset_name = preset_name
+        self.preset = VaspPresetConfig.from_file(preset_name)
 
     @property
     def builder(self):
@@ -92,17 +132,14 @@ class BuilderUpdater:
 
     def show_builder(self):
         """Print stuff defined in the builder"""
-        pprint(builder_to_dict(self.builder, unpack=True))
+        print(self.builder)
 
 
-DEFAULT_SET = 'UCLRelaxSet'
+class VaspBuilderUpdater(BaseBuilderUpdater):
+    WF_ENTRYPOINT = 'vasp.v2.vasp'
+    DEFAULT_INPUTSET = DEFAULT_INPUTSET
 
-
-class VaspBuilderUpdater(BuilderUpdater):
-    WF_ENTRYPOINT = 'vaspu.vasp'
-    DEFAULT_SET = DEFAULT_SET
-
-    def __init__(self, builder, root_namespace=None):
+    def __init__(self, preset_name=None, builder=None, root_namespace=None, code=None, verbose=False):
         """
         Initialise the update object.
 
@@ -112,51 +149,84 @@ class VaspBuilderUpdater(BuilderUpdater):
         :param root_namespace: The namespace to be assumed to be the *root*, e.g. where the input structure
           should be specified.
         """
-        super().__init__(builder)
+        super().__init__(preset_name=preset_name, builder=builder, verbose=verbose)
+        # Define the root namespace - e.g. the VaspWorkChain namespace where structure should be specified
         if root_namespace is None:
-            self.root_namespace = builder
+            self.root_namespace = self._builder
         else:
             self.root_namespace = root_namespace
 
-        self.namespace_vasp = builder
-        self.parameters_wrapped = None
-        self.options_wrapped = None
-        self.settings_wrapped = None
+        self.namespace_vasp = self._builder
+        # Defult
+        self.inputset = None
+        self.code = self.preset.default_code if code is None else code
 
     @property
     def reference_structure(self):
         """Reference structure used for setting kpoints and other stuff"""
         return self.root_namespace.structure
 
+    def clear(self):
+        """Clear the nodes set to the namespace"""
+        self.namespace_vasp.parameters = None
+        self.namespace_vasp.options = None
+        self.namespace_vasp.settings = None
+        self.namespace_vasp.kpoints = None
+        self.namespace_vasp.potential_family = None
+        self.namespace_vasp.potential_mapping = None
+
+        self.root_namespace.structure = None
+        self.root_namespace.metadata.label = None
+
     @property
     def builder(self):
         """The builder to be used for launching the calculation"""
-        return self.root_namespace
+        return self._builder
 
-    def use_inputset(self, structure, set_name='UCLRelaxSet', overrides=None):
-        inset = VASPInputSet(set_name, structure, overrides=overrides)
-        self.namespace_vasp.parameters = orm.Dict(dict={'incar': inset.get_input_dict()})
-        self.namespace_vasp.potential_family = orm.Str('PBE.54')
-        self.namespace_vasp.potential_mapping = orm.Dict(dict=inset.get_pp_mapping())
-        self.namespace_vasp.kpoints_spacing = orm.Float(0.05)
-        self.root_namespace.structure = structure
-
+    def apply_preset(self, initial_structure, code=None, label=None):
+        """
+        Apply the preset
+        """
+        if code is None:
+            code = self.code
+            logging.info(f'Using code {code}')
+        self.use_inputset(
+            initial_structure, set_name=self.preset.inputset, overrides=None, apply_preset=True, code=code
+        )
+        self.set_code(code=code)
+        self.set_options(code=code, apply_preset=True)
+        self.set_settings(code=code, apply_preset=True)
+        self.set_label(label)
         return self
 
-    def _initialise_parameters_wrapper(self, force=False):
-        """Initialise DictWrapper for tracking INCAR tags"""
-        if self.parameters_wrapped is None or force:
-            self.parameters_wrapped = DictWrapper(self.namespace_vasp.parameters, self.namespace_vasp, 'parameters')
+    def use_inputset(
+        self,
+        structure,
+        set_name='UCLRelaxSet',
+        overrides=None,
+        apply_preset=False,
+        code=None,
+        structure_node_name='structure',
+    ):
+        if overrides is None:
+            overrides = {}
 
-    def _initialise_options_wrapper(self, force=False):
-        """Initialise DictWrapper for tracking INCAR tags"""
-        if self.options_wrapped is None or force:
-            self.options_wrapped = DictWrapper(self.namespace_vasp.options, self.namespace_vasp, 'options')
+        if apply_preset:
+            if code is None:
+                code = self.preset.default_code
+            overrides_ = self.preset.get_code_specific_options(code, 'inputset_overrides')
+            overrides_.update(overrides)
+        else:
+            overrides_ = overrides
 
-    def _initialise_settings_wrapper(self, force=False):
-        """Initialise DictWrapper for tracking INCAR tags"""
-        if self.settings_wrapped is None or force:
-            self.settings_wrapped = DictWrapper(self.namespace_vasp.settings, self.namespace_vasp, 'settings')
+        inset = VASPInputSet(set_name, overrides=overrides_, verbose=self.verbose)
+        self.namespace_vasp.parameters = orm.Dict(dict={'incar': inset.get_input_dict(structure)})
+        self.namespace_vasp.potential_family = orm.Str(inset.get_potcar_family())
+        self.namespace_vasp.potential_mapping = orm.Dict(dict=inset.get_pp_mapping(structure))
+        self.namespace_vasp.kpoints_spacing = orm.Float(inset.get_kpoints_spacing())
+        setattr(self.root_namespace, structure_node_name, structure)
+        self.inputset = inset
+        return self
 
     def set_kspacing(self, kspacing: float):
         self.namespace_vasp.kpoints_spacing = orm.Float(kspacing)
@@ -167,93 +237,64 @@ class VaspBuilderUpdater(BuilderUpdater):
     update_kspacing = set_kspacing
 
     @property
-    def incar(self):
-        """Return the INCAR dictionary"""
-        return dict(self.namespace_vasp.parameters['incar'])
+    def parameters(self):
+        """Return the parameters node"""
+        return self.namespace_vasp.parameters
 
     @property
     def settings(self):
-        """Return the wrapped settings dictionary"""
-        self._initialise_settings_wrapper()
-        return self.settings_wrapped
-
-    @property
-    def parameters(self):
-        """Return the wrapped parameters dictionary"""
-        self._initialise_parameters_wrapper()
-        return self.parameters_wrapped
+        """Return the wrapped settings node"""
+        return self.namespace_vasp.settings
 
     @property
     def options(self):
-        """Return the wrapped options dictionary"""
-        self._initialise_options_wrapper()
-        return self.options_wrapped
+        """Return the wrapped options node"""
+        return self.namespace_vasp.options
 
-    def set_code(self, code: Union[str, orm.Code]):
+    def set_code(self, code: Union[str, orm.Code, None] = None):
+        if code is None:
+            code = self.preset.default_code
         if isinstance(code, str):
-            self.namespace_vasp.code = orm.Code.get_from_string(code)
-        else:
-            self.namespace_vasp.code = code
+            code = orm.load_code(code)
+
+        self.namespace_vasp.code = code
         return self
 
-    update_code = set_code
+    def update_code(self, code: Union[str, orm.Code]):
+        warn('update_code is deprecated, use set_code instead', DeprecationWarning)
+        return self.set_code(code)
 
-    def clear_incar(self):
-        """Clear existing settings"""
-        if self.namespace_vasp.parameters:
-            del self.namespace_vasp.parameters
-        self.parameters_wrapped = None
-        return self
-
-    def update_incar(self, *args, **kwargs):
+    def set_incar(self, *args, **kwargs):
         """Update incar tags"""
         if self.namespace_vasp.parameters is None:
             self.namespace_vasp.parameters = orm.Dict(dict={'incar': {}})
-
-        self._initialise_parameters_wrapper()
-        # Make a copy of the incar for modification
-        incar = dict(self.parameters_wrapped['incar'])
-        incar.update(*args, **kwargs)
-        self.parameters_wrapped['incar'] = incar
+        content = dict(*args, **kwargs)
+        node = update_dict_node(self.namespace_vasp.parameters, content, 'incar')
+        self.namespace_vasp.parameters = node
         return self
 
-    def set_default_options(self, **override):
-        options = None
+    def update_incar(self, *args, **kwargs):
+        warn('update_incar is deprecated, use set_incar instead', DeprecationWarning)
+        return self.set_incar(*args, **kwargs)
 
-        # Try to use a sensible default from code's computer/scheduler type
-        if self.namespace_vasp.code:
-            computer = self.namespace_vasp.code.computer
-            for key in OPTIONS_TEMPLATES:
-                if key in computer.label.upper():
-                    new = dict(OPTIONS_TEMPLATES[key])
-                    new.update(override)
-                    options = orm.Dict(dict=new)
-                    break
-            if options is None:
-                for key in OPTIONS_TEMPLATES:
-                    if key in computer.scheduler_type.upper():
-                        new = dict(OPTIONS_TEMPLATES[key])
-                        new.update(override)
-                        options = orm.Dict(dict=new)
-                        break
+    def set_options(self, *args, code=None, apply_preset=False, **kwargs):
+        if apply_preset:
+            if code is None:
+                code = self.preset.default_code
+            odict = self.preset.get_code_specific_options(code, 'options')
+            odict.update(dict(*args, **kwargs))
+        else:
+            odict = dict(*args, **kwargs)
 
-        # Use the very default settings
-        if options is None:
-            warn('Using default options template - adjustment needed for the target computer')
-            options = orm.Dict(
-                dict={
-                    'resources': {
-                        'tot_num_mpiprocs': 1,
-                    },
-                    'max_wallclock_seconds': 3600,
-                    'import_sys_environment': False,
-                    **override,
-                }
-            )
-
-        self.namespace_vasp.options = options
-        self._initialise_options_wrapper()
+        if self.namespace_vasp.options is None:
+            self.namespace_vasp.options = orm.Dict(odict)
+        else:
+            self.namespace_vasp.options = update_dict_node(self.namespace_vasp.options, odict)
         return self
+
+    def update_options(self, *args, **kwargs):
+        warn('update_options is deprecated, use set_options instead', DeprecationWarning)
+        return self.set_options(*args, **kwargs)
 
     def set_kpoints_mesh(self, mesh: List[int], offset: List[float]):
         """Use mesh for kpoints"""
@@ -267,35 +308,31 @@ class VaspBuilderUpdater(BuilderUpdater):
             pass
         return self
 
-    update_kpoints_mesh = set_kpoints_mesh
+    def update_kpoints_mesh(self, mesh: List[int], offset: List[float]):
+        warn('update_kpoints_mesh is deprecated, use set_kpoints_mesh instead', DeprecationWarning)
+        return self.set_kpoints_mesh(mesh, offset)
 
-    def update_options(self, *args, **kwargs):
-        """Update the options"""
-        if self.options_wrapped is None:
-            self.set_default_options()
-        self.options_wrapped.update(*args, **kwargs)
-        return self
+    def set_settings(self, *args, code=None, apply_preset=False, **kwargs):
+        """Update the settings"""
 
-    def clear_options(self):
-        if self.namespace_vasp.options:
-            del self.namespace_vasp.options
-        self.options_wrapped = None
+        if apply_preset:
+            if code is None:
+                code = self.preset.default_code
+            sdict = self.preset.get_code_specific_options(code, 'settings')
+            # Apply use supplied contents
+            sdict.update(dict(*args, **kwargs))
+        else:
+            sdict = dict(*args, **kwargs)
+
+        if self.namespace_vasp.settings is None:
+            self.namespace_vasp.settings = orm.Dict(sdict)
+        else:
+            self.namespace_vasp.settings = update_dict_node(self.namespace_vasp.options, sdict)
         return self
 
     def update_settings(self, *args, **kwargs):
-        """Update the settings"""
-        if self.namespace_vasp.settings is None:
-            self.namespace_vasp.settings = orm.Dict(dict={})
-        self._initialise_settings_wrapper()
-        self.settings_wrapped.update(*args, **kwargs)
-        return self
-
-    def clear_settings(self):
-        """Clear existing settings"""
-        if self.namespace_vasp.settings:
-            del self.namespace_vasp.settings
-        self.settings_wrapped = None
-        return self
+        warn('update_settings is deprecated, use set_settings instead', DeprecationWarning)
+        return self.set_settings(*args, **kwargs)
 
     def set_label(self, label=None):
         """Set the toplevel label, default to the label of the structure"""
@@ -304,87 +341,59 @@ class VaspBuilderUpdater(BuilderUpdater):
         self.root_namespace.metadata.label = label
         return self
 
-    update_label = set_label
+    def update_label(self, label=None):
+        warn('update_label is deprecated, use set_label instead', DeprecationWarning)
+        return self.set_label(label)
+
+    def set_resources(self, *args, **kwargs):
+        """Update resources"""
+        if self.namespace_vasp.options is None:
+            raise RuntimeError('Please set the options before setting resources')
+        resources = dict(self.namespace_vasp.options['resources'])
+        resources.update(*args, **kwargs)
+        self.namespace_vasp.options = update_dict_node(self.namespace_vasp.options, resources, 'resources')
+        return self
 
     def update_resources(self, *args, **kwargs):
-        """Update resources"""
-        if self.options_wrapped is None:
-            self.set_default_options()
-        resources = dict(self.options_wrapped['resources'])
-        resources.update(*args, **kwargs)
-        self.options_wrapped['resources'] = resources
-        return self
-
-    set_resources = update_resources
-
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        """
-        Setup from a configuration dictionary
-
-        The configuration dictionary should contain the following items:
-          - inputset
-          - overrides
-          - code
-          - options
-          - resources
-          - settings
-          - kspacing
-          - kmesh
-          - potential_mapping
-        """
-
-        self.use_inputset(
-            structure,
-            config.get('inputset', self.DEFAULT_SET),
-            overrides=config.get('overrides', {}),
-        )
-        self.set_code(orm.Code.get_from_string(config['code']))
-
-        # Kpoint spacing/mesh
-        if 'kspacing' in config:
-            self.set_kspacing(config['kspacing'])
-        if 'kmesh' in config:
-            self.set_kpoints_mesh(*config['kmesh'])
-
-        # Potential mapping
-        if 'potential_mapping' in config:
-            self.builder.potential_mapping = orm.Dict(dict=config['potential_mapping'])
-
-        self.set_default_options(**config.get('options', {}))
-        self.update_resources(**config.get('resources', {}))
-        if 'settings' in config:
-            self.update_settings(**config['settings'])
-        self.set_label(f'{structure.label}')
-        return self
-
-    @classmethod
-    def init_from_config(cls, structure, config):
-        """Initialise from a configuration dictionary"""
-        from aiida.plugins import WorkflowFactory
-
-        upd = cls(WorkflowFactory(cls.WF_ENTRYPOINT).get_builder())
-        return upd.update_from_config(structure, config)
+        warn('update_resources is deprecated, use set_resources instead', DeprecationWarning)
+        return self.set_resources(*args, **kwargs)
 
 
 class VaspNEBUpdater(VaspBuilderUpdater):
     WF_ENTRYPOINT = 'vasp.neb'
-
-    def __init__(self, builder):
-        """Initialise the builder updater"""
-        super().__init__(builder)
 
     @property
     def reference_structure(self):
         """Return the reference structure"""
         return self.namespace_vasp.initial_structure
 
-    def use_inputset(self, initial_structure, set_name='UCLRelaxSet', overrides=None):
-        inset = VASPInputSet(set_name, initial_structure, overrides=overrides)
-        self.namespace_vasp.parameters = orm.Dict(dict={'incar': inset.get_input_dict()})
-        self.namespace_vasp.potential_family = orm.Str('PBE.54')
-        self.namespace_vasp.potential_mapping = orm.Dict(dict=inset.get_pp_mapping())
-        self.namespace_vasp.kpoints_spacing = orm.Float(0.05)
-        self.namespace_vasp.initial_structure = initial_structure
+    def apply_preset(self, structure_init, structure_final, code=None, label=None, interpolate=True, nimages=5):
+        super().apply_preset(structure_init, code, label)
+        self.set_final_structure(structure_final)
+        if interpolate:
+            self.set_interpolated_images(nimages)
+        else:
+            logging.info('Not interpolating images, please set with .set_neb_image(images)')
+        self.update_incar(images=nimages)
+
+        return self
+
+    def use_inputset(self, initial_structure, set_name='UCLRelaxSet', overrides=None, apply_preset=False, code=None):
+        super().use_inputset(
+            structure=initial_structure,
+            set_name=set_name,
+            overrides=overrides,
+            apply_preset=apply_preset,
+            code=code,
+            structure_node_name='initial_structure',
+        )
+        return self
+
+    def set_label(self, label=None):
+        """Set the toplevel label, default to the label of the structure"""
+        if label is None:
+            label = self.root_namespace.initial_structure.label
+        self.root_namespace.metadata.label = label
         return self
 
     def set_final_structure(self, final_structure):
@@ -418,8 +427,8 @@ class VaspNEBUpdater(VaspBuilderUpdater):
         interpolated = neb_interpolate(initial, final, orm.Int(nimages))
         images = {key: value for key, value in interpolated.items() if not ('init' in key or 'final' in key)}
         self.namespace_vasp.neb_images = images
-        # Update the final image
-        self.set_final_structure = interpolated['image_final']
+        # Update the final image - make sure that is atoms are not wrapped around
+        self.set_final_structure(interpolated['image_final'])
 
 
 class VaspRelaxUpdater(VaspBuilderUpdater):
@@ -427,22 +436,27 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
     An updater for VaspRelaxWorkChain
     """
 
-    WF_ENTRYPOINT = 'vaspu.relax'
+    WF_ENTRYPOINT = 'vasp.v2.relax'
 
-    def __init__(self, builder, override_vasp_namespace=None, namespace_relax=None):
-        super().__init__(builder, root_namespace=builder)
+    def __init__(self, preset_name=None, builder=None, override_vasp_namespace=None, namespace_relax=None, code=None):
+        super().__init__(preset_name=preset_name, builder=builder, code=code, root_namespace=builder)
         # The primary VASP namespace is under builder.vasp
         if override_vasp_namespace is None:
-            self.namespace_vasp = builder.vasp
+            self.namespace_vasp = self._builder.vasp
         else:
             self.namespace_vasp = override_vasp_namespace
 
         if namespace_relax is None:
-            self.namespace_relax = builder
+            self.namespace_relax = self._builder
         else:
             self.namespace_relax = namespace_relax
 
-    def update_relax_settings(self, **kwargs):
+    def apply_preset(self, structure, code=None, label=None):
+        out = super().apply_preset(structure, code, label)
+        self.set_relax_settings()
+        return out
+
+    def set_relax_settings(self, **kwargs):
         """Set/update RelaxOptions controlling the operation of the workchain"""
 
         if self.namespace_relax.relax_settings is None:
@@ -454,15 +468,194 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
         self.namespace_relax.relax_settings = current_options.to_aiida_dict()
         return self
 
+    update_relax_settings = set_relax_settings
+
     def clear_relax_settings(self):
         """Reset any existing relax options"""
         self.namespace_relax.relax_settings = RelaxOptions().to_aiida_dict()
         return self
 
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        super().update_from_config(structure, config)
-        self.update_relax_settings(**config.get('relax_settings', {}))
+
+class VaspConvUpdater(VaspBuilderUpdater):
+    """Update for VaspConvergenceWorkChain"""
+
+    WF_ENTRYPOINT = 'vasp.v2.converge'
+
+    def set_conv_settings(self, **kwargs):
+        """
+        Use the supplied convergence settings
+        """
+        from ..converge import ConvOptions
+
+        opts = ConvOptions(**kwargs)
+        self.builder.conv_settings = opts.to_aiida_dict()
+
+
+class VaspBandUpdater(VaspBuilderUpdater):
+    """Updater for VaspBandsWorkChain"""
+
+    WF_ENTRYPOINT = 'vasp.v2.bands'
+
+    def __init__(self, preset_name=None, builder=None, override_vasp_namespace=None, code=None):
+        super().__init__(preset_name=preset_name, builder=builder, code=code, root_namespace=builder)
+        # The primary VASP namespace is under builder.vasp
+        if override_vasp_namespace is None:
+            self.namespace_vasp = self.builder.scf
+        else:
+            self.namespace_vasp = override_vasp_namespace
+
+    def apply_preset(self, structure: orm.StructureData, run_relax=False, *args, **kwargs):
+        super().apply_preset(structure, *args, **kwargs)
+
+        # Specify the relaxation and NAC namespace
+        if run_relax:
+            relax_upd = VaspRelaxUpdater(
+                preset_name=self.preset_name,
+                builder=self.builder,
+                namespace_relax=self.root_namespace.relax,
+                override_vasp_namespace=self.root_namespace.relax.vasp,
+            )
+            relax_upd.apply_preset(structure, *args, **kwargs)
         return self
+
+    def set_label(self, label=None):
+        """Set the toplevel label, default to the label of the structure"""
+        super().set_label(label)
+        if label:
+            if is_specified(self.root_namespace.relax):
+                self.root_namespace.relax.metadata.label = label
+            if is_specified(self.root_namespace.scf):
+                self.root_namespace.scf.metadata.label = label
+        return self
+
+
+class VaspHybridBandUpdater(VaspBandUpdater):
+    """Updater for VaspHybridBandsWorkChain"""
+
+    WF_ENTRYPOINT = 'vasp.v2.hybrid_bands'
+
+    def apply_preset(self, structure: orm.StructureData, *args, **kwargs):
+        """Apply the preset"""
+        super().apply_preset(structure, *args, **kwargs)
+        band_settings = self.preset.get_code_specific_options(self.code, 'band_settings')
+        self.builder.symprec = orm.Float(band_settings.get('symprec', 0.01))
+        self.builder.kpoints_per_split = orm.Int(band_settings.get('kpoints_per_split', 80))
+        return self
+
+
+# class VaspAutoPhononUpdater(VaspBuilderUpdater):
+#     """Updater for VaspAutoPhononWorkChain"""
+
+#     WF_ENTRYPOINT = 'vasp.v2.phonopy'
+
+#     def __init__(self, builder: ProcessBuilder):
+#         """Initialise with an existing ProcessBuilder for VaspAutoPhononWorkChain"""
+#         super().__init__(builder.singlepoint, root_namespace=builder)
+
+#     def set_phonon_settings(self, options):
+#         """
+#         Update the phonon-related options
+
+#         example::
+
+#           {
+#             'primitive_matrix': 'auto',
+#             'supercell_matrix': [2, 2, 2],    # Supercell matrix
+#             'mesh': 30,                       # Mesh for DOS/PDOS/thermal properties
+#           }
+
+
+#         """
+#         self.root_namespace.phonon_settings = orm.Dict(options)
+#         return self
+
+#     def update_from_config(self, structure: orm.StructureData, config: dict):
+#         """
+#         Update the builder from a configuration dictionary.
+
+#         The dictionary must has a ``singlepoint`` key holding the configurations for singlepoint
+#         calculations, and a ``phonon_options`` for Phonopy options to be used.
+#         The ``relax`` and ``nac`` keys are optional.
+#         """
+
+#         super().update_from_config(structure, config['singlepoint'])
+
+#         # Specify the relaxation and NAC namespace
+#         if 'relax' in config:
+#             relax_upd = VaspRelaxUpdater(
+#                 self.root_namespace,
+#                 namespace_relax=self.root_namespace.relax,
+#                 override_vasp_namespace=self.root_namespace.relax.vasp,
+#             )
+#             relax_upd.update_from_config(structure, config['relax'])
+
+#         if 'nac' in config:
+#             nac_upd = VaspBuilderUpdater(self.root_namespace.nac, root_namespace=self.root_namespace)
+#             nac_upd.update_from_config(structure, config['nac'])
+
+#         # Update the phonon settings
+#         self.set_phonon_settings(config['phonon_settings'])
+#         return self
+
+#     def set_kpoints_mesh(self, mesh, offset) -> None:
+#         """Use mesh for kpoints"""
+#         kpoints = orm.KpointsData()
+#         # Use the reference supercell structure
+#         kpoints.set_cell_from_structure(self.reference_structure)
+#         kpoints.set_kpoints_mesh(mesh, offset)
+#         self.namespace_vasp.kpoints = kpoints
+#         if self.namespace_vasp.kpoints_spacing:
+#             del self.namespace_vasp.kpoints_spacing
+#         return self
+
+#     def _get_singlepoint_supercell(self) -> orm.StructureData:
+#         """Obtain the supercell for the singlepoint calculation"""
+#         import numpy as np
+#         from ase.build import make_supercell
+
+#         ref = self.root_namespace.structure.get_ase()
+
+#         # The sueprcell matrix should be a vector or a matrix
+#         mat = np.array(self.root_namespace.phonon_settings['supercell_matrix'])
+#         if mat.size == 3:
+#             mat = np.diag(mat)
+
+#         # Convention of phonopy - the supercell matrix is the transpose of that would be used
+#         # for ase
+#         return orm.StructureData(ase=make_supercell(ref, mat.T))
+
+#     def show_builder(self):
+#         """Print stuff defined in the builder"""
+#         pprint(builder_to_dict(self.root_namespace, unpack=True))
+
+
+def is_specified(port_namespace):
+    """Check if there is anything specified under a PortNamespace"""
+    return any(map(bool, port_namespace.values()))
+
+
+def update_dict_node(node: orm.Dict, content: dict, namespace=None, reuse_if_possible=True) -> orm.Dict:
+    """
+    Update a Dict node with the content
+    Optionally update an item of the Dict node.
+    """
+    # Get pure-python dictionary
+    dtmp = node.get_dict()
+    dtmp_backup = None
+    if reuse_if_possible and node.is_stored:
+        dtmp_backup = deepcopy(dtmp)
+    if namespace:
+        dtmp.get(namespace, {}).update(content)
+    else:
+        dtmp.update(content)
+    if node.is_stored:
+        # There is no need to update the node if the content is the same as before
+        if reuse_if_possible and dtmp == dtmp_backup:
+            return node
+        # The content is different, but the node is immutable, so we create a new node
+        return orm.Dict(dict=dtmp)
+    node.update_dict(dtmp)
+    return node
 
 
 def builder_to_dict(builder, unpack=True):
@@ -486,171 +679,3 @@ def builder_to_dict(builder, unpack=True):
                 value_ = value
         data[key] = value_
     return data
-
-
-class VaspConvUpdater(VaspBuilderUpdater):
-    """Update for VaspConvergenceWorkChain"""
-
-    WF_ENTRYPOINT = 'vaspu.converge'
-
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        """Update from a configuration dictionary"""
-        super().update_from_config(structure, config)
-        self.use_conv_settings(**config.get('conv_settings', {}))
-        return self
-
-    def use_conv_settings(self, **kwargs):
-        """
-        Use the supplied convergence settings
-        """
-        from ..converge import ConvOptions
-
-        opts = ConvOptions(**kwargs)
-        self.builder.conv_settings = opts.to_aiida_dict()
-
-
-class VaspBandUpdater(VaspBuilderUpdater):
-    """Updater for VaspBandsWorkChain"""
-
-    WF_ENTRYPOINT = 'vaspu.bands'
-
-    def __init__(self, builder, namespace_vasp=None):
-        # The primary VASP namespace is under builder.vasp
-        if namespace_vasp is None:
-            super().__init__(builder.scf, root_namespace=builder)
-        else:
-            self.namespace_vasp = namespace_vasp
-
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        """
-        Update the builder from a configuration dictionary.
-
-        The dictionary must has a ``scf`` key holding the configurations for singlepoint
-        calculations.
-        The ``relax`` key is optional.
-        """
-        super().update_from_config(structure, config['scf'])
-
-        # Specify the relaxation and NAC namespace
-        if 'relax' in config:
-            relax_upd = VaspRelaxUpdater(
-                self.root_namespace,
-                namespace_relax=self.root_namespace.relax,
-                override_vasp_namespace=self.root_namespace.relax.vasp,
-            )
-            relax_upd.update_from_config(structure, config['relax'])
-        return self
-
-    def set_label(self, label=None):
-        """Set the toplevel label, default to the label of the structure"""
-        super().set_label(label)
-        if label:
-            if is_specified(self.root_namespace.relax):
-                self.root_namespace.relax.metadata.label = label
-            if is_specified(self.root_namespace.scf):
-                self.root_namespace.scf.metadata.label = label
-        return self
-
-
-class VaspHybridBandUpdater(VaspBandUpdater):
-    """Updater for VaspHybridBandsWorkChain"""
-
-    WF_ENTRYPOINT = 'vaspu.hybrid_bands'
-
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        super().update_from_config(structure, config)
-
-        self.builder.symprec = orm.Float(config['symprec'])
-        self.builder.kpoints_per_split = orm.Int(config['kpoints_per_split'])
-        return self
-
-
-class VaspAutoPhononUpdater(VaspBuilderUpdater):
-    """Updater for VaspAutoPhononWorkChain"""
-
-    WF_ENTRYPOINT = 'vaspu.phonopy'
-
-    def __init__(self, builder: ProcessBuilder):
-        """Initialise with an existing ProcessBuilder for VaspAutoPhononWorkChain"""
-        super().__init__(builder.singlepoint, root_namespace=builder)
-
-    def set_phonon_settings(self, options):
-        """
-        Update the phonon-related options
-
-        example::
-
-          {
-            'primitive_matrix': 'auto',
-            'supercell_matrix': [2, 2, 2],    # Supercell matrix
-            'mesh': 30,                       # Mesh for DOS/PDOS/thermal properties
-          }
-
-
-        """
-        self.root_namespace.phonon_settings = orm.Dict(options)
-        return self
-
-    def update_from_config(self, structure: orm.StructureData, config: dict):
-        """
-        Update the builder from a configuration dictionary.
-
-        The dictionary must has a ``singlepoint`` key holding the configurations for singlepoint
-        calculations, and a ``phonon_options`` for Phonopy options to be used.
-        The ``relax`` and ``nac`` keys are optional.
-        """
-
-        super().update_from_config(structure, config['singlepoint'])
-
-        # Specify the relaxation and NAC namespace
-        if 'relax' in config:
-            relax_upd = VaspRelaxUpdater(
-                self.root_namespace,
-                namespace_relax=self.root_namespace.relax,
-                override_vasp_namespace=self.root_namespace.relax.vasp,
-            )
-            relax_upd.update_from_config(structure, config['relax'])
-
-        if 'nac' in config:
-            nac_upd = VaspBuilderUpdater(self.root_namespace.nac, root_namespace=self.root_namespace)
-            nac_upd.update_from_config(structure, config['nac'])
-
-        # Update the phonon settings
-        self.set_phonon_settings(config['phonon_settings'])
-        return self
-
-    def set_kpoints_mesh(self, mesh, offset) -> None:
-        """Use mesh for kpoints"""
-        kpoints = orm.KpointsData()
-        # Use the reference supercell structure
-        kpoints.set_cell_from_structure(self.reference_structure)
-        kpoints.set_kpoints_mesh(mesh, offset)
-        self.namespace_vasp.kpoints = kpoints
-        if self.namespace_vasp.kpoints_spacing:
-            del self.namespace_vasp.kpoints_spacing
-        return self
-
-    def _get_singlepoint_supercell(self) -> orm.StructureData:
-        """Obtain the supercell for the singlepoint calculation"""
-        import numpy as np
-        from ase.build import make_supercell
-
-        ref = self.root_namespace.structure.get_ase()
-
-        # The sueprcell matrix should be a vector or a matrix
-        mat = np.array(self.root_namespace.phonon_settings['supercell_matrix'])
-        if mat.size == 3:
-            mat = np.diag(mat)
-
-        # Convention of phonopy - the supercell matrix is the transpose of that would be used
-        # for ase
-        return orm.StructureData(ase=make_supercell(ref, mat.T))
-
-    def show_builder(self):
-        """Print stuff defined in the builder"""
-        pprint(builder_to_dict(self.root_namespace, unpack=True))
-
-
-def is_specified(port_namespace):
-    """Check if there is anything specified under a PortNamespace"""
-    return any(map(bool, port_namespace.values()))

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -6,12 +6,12 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 from warnings import warn
 
 from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
-from aiida.engine.processes.builder import ProcessBuilder
+from aiida.engine.processes.builder import ProcessBuilder, ProcessBuilderNamespace
 from yaml import safe_load
 
 from ..inputset.vaspsets import VASPInputSet
@@ -63,7 +63,7 @@ OPTIONS_TEMPLATES = {
 
 @dataclass
 class VaspPresetConfig:
-    """Class to store the configuration for a VaspBuilderUpdater"""
+    """Class to store the preset for VaspBuilderUpdater"""
 
     name: str
     inputset: str
@@ -91,7 +91,7 @@ class VaspPresetConfig:
             data = safe_load(fhandle)
         return cls(**data)
 
-    def get_code_specific_options(self, code, namespace):
+    def get_code_specific_options(self, code: str, namespace: str) -> dict:
         """Return code specific options, if exists"""
         if code in self.code_specific:
             if namespace in self.code_specific[code]:
@@ -126,20 +126,35 @@ class BaseBuilderUpdater:
         self.preset = VaspPresetConfig.from_file(preset_name)
 
     @property
-    def builder(self):
+    def builder(self) -> ProcessBuilder:
         """The builder to be used for launching the calculation"""
         return self._builder
 
-    def show_builder(self):
-        """Print stuff defined in the builder"""
-        print(self.builder)
+    def submit(self) -> orm.WorkChainNode:
+        """Submit the workflow to the daemon and return the workchain node"""
+        from aiida.engine import submit
+
+        return submit(self.builder)
+
+    def run_get_node(self) -> orm.WorkChainNode:
+        """Run the workflow with the current python process"""
+        from aiida.engine import run_get_node
+
+        return run_get_node(self.builder)
 
 
 class VaspBuilderUpdater(BaseBuilderUpdater):
     WF_ENTRYPOINT = 'vasp.v2.vasp'
     DEFAULT_INPUTSET = DEFAULT_INPUTSET
 
-    def __init__(self, preset_name=None, builder=None, root_namespace=None, code=None, verbose=False):
+    def __init__(
+        self,
+        preset_name: Optional[str] = None,
+        builder: Optional[ProcessBuilder] = None,
+        root_namespace: Optional[str] = None,
+        code: Optional[str] = None,
+        verbose: bool = False,
+    ):
         """
         Initialise the update object.
 
@@ -162,11 +177,11 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.code = self.preset.default_code if code is None else code
 
     @property
-    def reference_structure(self):
+    def reference_structure(self) -> orm.StructureData:
         """Reference structure used for setting kpoints and other stuff"""
         return self.root_namespace.structure
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear the nodes set to the namespace"""
         self.namespace_vasp.parameters = None
         self.namespace_vasp.options = None
@@ -178,12 +193,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.root_namespace.structure = None
         self.root_namespace.metadata.label = None
 
-    @property
-    def builder(self):
-        """The builder to be used for launching the calculation"""
-        return self._builder
-
-    def apply_preset(self, initial_structure, code=None, label=None):
+    def apply_preset(self, initial_structure, code=None, label=None) -> 'VaspBuilderUpdater':
         """
         Apply the preset
         """
@@ -207,7 +217,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         apply_preset=False,
         code=None,
         structure_node_name='structure',
-    ):
+    ) -> 'VaspBuilderUpdater':
         if overrides is None:
             overrides = {}
 
@@ -228,7 +238,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.inputset = inset
         return self
 
-    def set_kspacing(self, kspacing: float):
+    def set_kspacing(self, kspacing: float) -> 'VaspBuilderUpdater':
         self.namespace_vasp.kpoints_spacing = orm.Float(kspacing)
         if self.namespace_vasp.kpoints:
             del self.namespace_vasp.kpoints
@@ -237,21 +247,21 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
     update_kspacing = set_kspacing
 
     @property
-    def parameters(self):
+    def parameters(self) -> Union[orm.Dict, None]:
         """Return the parameters node"""
         return self.namespace_vasp.parameters
 
     @property
-    def settings(self):
+    def settings(self) -> Union[orm.Dict, None]:
         """Return the wrapped settings node"""
         return self.namespace_vasp.settings
 
     @property
-    def options(self):
+    def options(self) -> Union[orm.Dict, None]:
         """Return the wrapped options node"""
         return self.namespace_vasp.options
 
-    def set_code(self, code: Union[str, orm.Code, None] = None):
+    def set_code(self, code: Union[str, orm.Code, None] = None) -> 'VaspBuilderUpdater':
         if code is None:
             code = self.preset.default_code
         if isinstance(code, str):
@@ -264,7 +274,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         warn('update_code is deprecated, use set_code instead', DeprecationWarning)
         return self.set_code(code)
 
-    def set_incar(self, *args, **kwargs):
+    def set_incar(self, *args, **kwargs) -> 'VaspBuilderUpdater':
         """Update incar tags"""
         if self.namespace_vasp.parameters is None:
             self.namespace_vasp.parameters = orm.Dict(dict={'incar': {}})
@@ -273,11 +283,13 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.namespace_vasp.parameters = node
         return self
 
-    def update_incar(self, *args, **kwargs):
+    def update_incar(self, *args, **kwargs) -> 'VaspBuilderUpdater':
         warn('update_incar is deprecated, use set_incar instead', DeprecationWarning)
         return self.set_incar(*args, **kwargs)
 
-    def set_options(self, *args, code=None, apply_preset=False, **kwargs):
+    def set_options(
+        self, *args, code: Optional[str] = None, apply_preset: bool = False, **kwargs
+    ) -> 'VaspBuilderUpdater':
         if apply_preset:
             if code is None:
                 code = self.preset.default_code
@@ -292,11 +304,11 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             self.namespace_vasp.options = update_dict_node(self.namespace_vasp.options, odict)
         return self
 
-    def update_options(self, *args, **kwargs):
+    def update_options(self, *args, **kwargs) -> 'VaspBuilderUpdater':
         warn('update_options is deprecated, use set_options instead', DeprecationWarning)
         return self.set_options(*args, **kwargs)
 
-    def set_kpoints_mesh(self, mesh: List[int], offset: List[float]):
+    def set_kpoints_mesh(self, mesh: List[int], offset: List[float]) -> 'VaspBuilderUpdater':
         """Use mesh for kpoints"""
         kpoints = orm.KpointsData()
         kpoints.set_cell_from_structure(self.reference_structure)
@@ -308,11 +320,13 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             pass
         return self
 
-    def update_kpoints_mesh(self, mesh: List[int], offset: List[float]):
+    def update_kpoints_mesh(self, mesh: List[int], offset: List[float]) -> 'VaspBuilderUpdater':
         warn('update_kpoints_mesh is deprecated, use set_kpoints_mesh instead', DeprecationWarning)
         return self.set_kpoints_mesh(mesh, offset)
 
-    def set_settings(self, *args, code=None, apply_preset=False, **kwargs):
+    def set_settings(
+        self, *args, code: Optional[str] = None, apply_preset: bool = False, **kwargs
+    ) -> 'VaspBuilderUpdater':
         """Update the settings"""
 
         if apply_preset:
@@ -334,18 +348,18 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         warn('update_settings is deprecated, use set_settings instead', DeprecationWarning)
         return self.set_settings(*args, **kwargs)
 
-    def set_label(self, label=None):
+    def set_label(self, label: Optional[str] = None) -> 'VaspBuilderUpdater':
         """Set the toplevel label, default to the label of the structure"""
         if label is None:
             label = self.root_namespace.structure.label
         self.root_namespace.metadata.label = label
         return self
 
-    def update_label(self, label=None):
+    def update_label(self, label=None) -> 'VaspBuilderUpdater':
         warn('update_label is deprecated, use set_label instead', DeprecationWarning)
         return self.set_label(label)
 
-    def set_resources(self, *args, **kwargs):
+    def set_resources(self, *args, **kwargs) -> 'VaspBuilderUpdater':
         """Update resources"""
         if self.namespace_vasp.options is None:
             raise RuntimeError('Please set the options before setting resources')
@@ -354,7 +368,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.namespace_vasp.options = update_dict_node(self.namespace_vasp.options, resources, 'resources')
         return self
 
-    def update_resources(self, *args, **kwargs):
+    def update_resources(self, *args, **kwargs) -> 'VaspBuilderUpdater':
         warn('update_resources is deprecated, use set_resources instead', DeprecationWarning)
         return self.set_resources(*args, **kwargs)
 
@@ -367,7 +381,9 @@ class VaspNEBUpdater(VaspBuilderUpdater):
         """Return the reference structure"""
         return self.namespace_vasp.initial_structure
 
-    def apply_preset(self, structure_init, structure_final, code=None, label=None, interpolate=True, nimages=5):
+    def apply_preset(
+        self, structure_init, structure_final, code=None, label=None, interpolate=True, nimages=5
+    ) -> 'VaspNEBUpdater':
         super().apply_preset(structure_init, code, label)
         self.set_final_structure(structure_final)
         if interpolate:
@@ -378,7 +394,14 @@ class VaspNEBUpdater(VaspBuilderUpdater):
 
         return self
 
-    def use_inputset(self, initial_structure, set_name='UCLRelaxSet', overrides=None, apply_preset=False, code=None):
+    def use_inputset(
+        self,
+        initial_structure: orm.StructureData,
+        set_name='UCLRelaxSet',
+        overrides=None,
+        apply_preset=False,
+        code=None,
+    ) -> 'VaspNEBUpdater':
         super().use_inputset(
             structure=initial_structure,
             set_name=set_name,
@@ -389,18 +412,18 @@ class VaspNEBUpdater(VaspBuilderUpdater):
         )
         return self
 
-    def set_label(self, label=None):
+    def set_label(self, label: Optional[str] = None) -> 'VaspNEBUpdater':
         """Set the toplevel label, default to the label of the structure"""
         if label is None:
             label = self.root_namespace.initial_structure.label
         self.root_namespace.metadata.label = label
         return self
 
-    def set_final_structure(self, final_structure):
+    def set_final_structure(self, final_structure: orm.StructureData) -> 'VaspNEBUpdater':
         self.namespace_vasp.final_structure = final_structure
         return self
 
-    def set_neb_images(self, images):
+    def set_neb_images(self, images: Union[list, dict, AttributeDict]) -> 'VaspNEBUpdater':
         """Set the NEB images"""
 
         if isinstance(images, list):
@@ -410,7 +433,7 @@ class VaspNEBUpdater(VaspBuilderUpdater):
         self.namespace_vasp.neb_images = output
         return self
 
-    def set_interpolated_images(self, nimages):
+    def set_interpolated_images(self, nimages: int) -> 'VaspNEBUpdater':
         """
         Interpolate images and set as inputs structures
 
@@ -429,6 +452,7 @@ class VaspNEBUpdater(VaspBuilderUpdater):
         self.namespace_vasp.neb_images = images
         # Update the final image - make sure that is atoms are not wrapped around
         self.set_final_structure(interpolated['image_final'])
+        return self
 
 
 class VaspRelaxUpdater(VaspBuilderUpdater):
@@ -438,7 +462,14 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
 
     WF_ENTRYPOINT = 'vasp.v2.relax'
 
-    def __init__(self, preset_name=None, builder=None, override_vasp_namespace=None, namespace_relax=None, code=None):
+    def __init__(
+        self,
+        preset_name: Optional[str] = None,
+        builder: Optional[ProcessBuilder] = None,
+        override_vasp_namespace: Optional[ProcessBuilderNamespace] = None,
+        namespace_relax: Optional[ProcessBuilderNamespace] = None,
+        code: Optional[str] = None,
+    ):
         super().__init__(preset_name=preset_name, builder=builder, code=code, root_namespace=builder)
         # The primary VASP namespace is under builder.vasp
         if override_vasp_namespace is None:
@@ -451,12 +482,14 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
         else:
             self.namespace_relax = namespace_relax
 
-    def apply_preset(self, structure, code=None, label=None):
+    def apply_preset(
+        self, structure: orm.StructureData, code: Optional[str] = None, label: Optional[str] = None
+    ) -> 'VaspRelaxUpdater':
         out = super().apply_preset(structure, code, label)
         self.set_relax_settings()
         return out
 
-    def set_relax_settings(self, **kwargs):
+    def set_relax_settings(self, **kwargs) -> 'VaspRelaxUpdater':
         """Set/update RelaxOptions controlling the operation of the workchain"""
 
         if self.namespace_relax.relax_settings is None:
@@ -470,9 +503,14 @@ class VaspRelaxUpdater(VaspBuilderUpdater):
 
     update_relax_settings = set_relax_settings
 
-    def clear_relax_settings(self):
+    def clear_relax_settings(self) -> 'VaspRelaxUpdater':
         """Reset any existing relax options"""
         self.namespace_relax.relax_settings = RelaxOptions().to_aiida_dict()
+        return self
+
+    def clear(self) -> 'VaspRelaxUpdater':
+        super().clear()
+        self.clear_relax_settings()
         return self
 
 
@@ -481,14 +519,19 @@ class VaspConvUpdater(VaspBuilderUpdater):
 
     WF_ENTRYPOINT = 'vasp.v2.converge'
 
-    def set_conv_settings(self, **kwargs):
+    def set_conv_settings(self, **kwargs) -> 'VaspConvUpdater':
         """
         Use the supplied convergence settings
         """
         from ..converge import ConvOptions
 
-        opts = ConvOptions(**kwargs)
+        conv_dict = self.preset.get_code_specific_options(self.code, 'convergence_settings')
+        conv_dict = deepcopy(conv_dict)
+        conv_dict.update(dict(**kwargs))
+
+        opts = ConvOptions(**conv_dict)
         self.builder.conv_settings = opts.to_aiida_dict()
+        return self
 
 
 class VaspBandUpdater(VaspBuilderUpdater):
@@ -504,7 +547,7 @@ class VaspBandUpdater(VaspBuilderUpdater):
         else:
             self.namespace_vasp = override_vasp_namespace
 
-    def apply_preset(self, structure: orm.StructureData, run_relax=False, *args, **kwargs):
+    def apply_preset(self, structure: orm.StructureData, run_relax: bool = False, *args, **kwargs) -> 'VaspBandUpdater':
         super().apply_preset(structure, *args, **kwargs)
 
         # Specify the relaxation and NAC namespace
@@ -518,7 +561,7 @@ class VaspBandUpdater(VaspBuilderUpdater):
             relax_upd.apply_preset(structure, *args, **kwargs)
         return self
 
-    def set_label(self, label=None):
+    def set_label(self, label=None) -> 'VaspBandUpdater':
         """Set the toplevel label, default to the label of the structure"""
         super().set_label(label)
         if label:
@@ -534,7 +577,7 @@ class VaspHybridBandUpdater(VaspBandUpdater):
 
     WF_ENTRYPOINT = 'vasp.v2.hybrid_bands'
 
-    def apply_preset(self, structure: orm.StructureData, *args, **kwargs):
+    def apply_preset(self, structure: orm.StructureData, *args, **kwargs) -> 'VaspHybridBandUpdater':
         """Apply the preset"""
         super().apply_preset(structure, *args, **kwargs)
         band_settings = self.preset.get_code_specific_options(self.code, 'band_settings')
@@ -629,12 +672,14 @@ class VaspHybridBandUpdater(VaspBandUpdater):
 #         pprint(builder_to_dict(self.root_namespace, unpack=True))
 
 
-def is_specified(port_namespace):
+def is_specified(port_namespace: ProcessBuilderNamespace) -> bool:
     """Check if there is anything specified under a PortNamespace"""
     return any(map(bool, port_namespace.values()))
 
 
-def update_dict_node(node: orm.Dict, content: dict, namespace=None, reuse_if_possible=True) -> orm.Dict:
+def update_dict_node(
+    node: orm.Dict, content: dict, namespace: Optional[str] = None, reuse_if_possible: bool = True
+) -> orm.Dict:
     """
     Update a Dict node with the content
     Optionally update an item of the Dict node.
@@ -658,7 +703,7 @@ def update_dict_node(node: orm.Dict, content: dict, namespace=None, reuse_if_pos
     return node
 
 
-def builder_to_dict(builder, unpack=True):
+def builder_to_dict(builder: ProcessBuilder, unpack: bool = True) -> dict:
     """
     Convert a builder to a dictionary and unpack certain nodes.
 

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -21,6 +21,16 @@ DEFAULT_PRESET = 'VaspPreset'
 DEFAULT_INPUTSET = 'UCLRelaxSet'
 
 
+__all__ = (
+    'VaspBuilderUpdater',
+    'VaspPresetConfig',
+    'VaspRelaxUpdater',
+    'VaspNEBUpdater',
+    'VaspBandUpdater',
+    'VaspHybridBandUpdater',
+)
+
+
 def get_library_path():
     """Get the path where the YAML files are stored within this package"""
     return Path(__file__).parent

--- a/src/aiida_vasp/workchains/v2/common/dictwrap.py
+++ b/src/aiida_vasp/workchains/v2/common/dictwrap.py
@@ -1,5 +1,8 @@
 """
 Wrapper class to simply updating an Node when configuring inputs of a calculation.
+
+This module is currently not used in the code, but kept here for future reference.
+It is not clear such wrapper for Dict would truly benefit the usability of the code.
 """
 
 from collections import UserDict

--- a/src/aiida_vasp/workchains/v2/common/opthold.py
+++ b/src/aiida_vasp/workchains/v2/common/opthold.py
@@ -2,11 +2,9 @@
 Module containing the OptionHolder class
 """
 
-from typing import List, Tuple
-
 from aiida.common.exceptions import InputValidationError
-from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Dict
+from pydantic import BaseModel, ValidationError
 
 # pylint:disable=raise-missing-from
 
@@ -156,172 +154,38 @@ class StringOption(TypedOption):
         )
 
 
-class OptionContainer:
+class OptionContainer(BaseModel):
     """
     Base class for a container of options
     """
 
-    def __init__(self, **kwargs):
-        """
-        A holder of options
-
-        Arguments:
-            kwargs: unpack keyword arguments and set them as the attributes
-        """
-        self._opt_data = {}
-
-        # the key word arguments are interpreted as the options to be set, an we check
-        # If they are valid in the first place
-        (
-            self.valid_options,
-            self.required_options,
-        ) = self._get_valid_and_required_options()
-        for key, value in kwargs.items():
-            if key in self.valid_options:
-                setattr(self, key, value)
-            else:
-                raise ValueError(f'{key} is not a valid option for a {type(self)} instance!')
-
-    def _get_valid_and_required_options(self) -> Tuple[list, list]:
-        """
-        Return a list of valid option names
-
-        This method extracts a tuple of list of the valid option names and those that are
-        marked as `required`.
-        """
-        options = []
-        required = []
-        class_dict = vars(type(self))
-        for name in dir(self):
-            if name.startswith('__'):
-                pass
-            # Check if the name exists in the class's __dict__
-            if name not in class_dict:
-                continue
-            optobj = class_dict.get(name)
-
-            # Check if the name is an Option
-            if isinstance(optobj, Option):
-                options.append(name)
-                if optobj.required:
-                    required.append(name)
-        return options, required
-
-    @property
-    def _invalid_attributes(self) -> List[str]:
-        """Any attribute store inside __dict__ is an invalid option"""
-        known = ['_opt_data', 'valid_options', 'required_options']
-        invalid = []
-        for key in self.__dict__:
-            if key not in known:
-                invalid.append(key)
-        return invalid
-
-    def to_dict(self, check_invalids=True) -> AttributeDict:
-        """Return a python dict representation - including all fields"""
-        # Check for any additional attributes
-        invalid_attrs = self._invalid_attributes
-        if check_invalids and invalid_attrs:
-            raise ValueError(f'The following attributes are not valid options: {invalid_attrs}')
-
-        outdict = {}
-        for key in self.valid_options:
-            value = getattr(self, key)
-            # Note that 'None' is interpreted specially meaning that the option should not be present
-            if value is not None:
-                outdict[key] = value
-        return AttributeDict(outdict)
-
-    def to_aiida_dict(self):
+    def aiida_dict(self):
         """Return an ``aiida.orm.Dict`` presentation"""
 
-        python_dict = self.to_dict()
+        python_dict = self.model_dump()
         return Dict(dict=python_dict)
 
-    def __setitem__(self, key, value) -> None:
-        """Set items - we call the setattr method"""
-        if key not in self.valid_options:
-            raise KeyError(f'{key} is not an valid option for a {type(self)} instance.')
-        setattr(self, key, value)
-
-    def to_string(self) -> str:
-        """In string format"""
-        return self.to_dict(check_invalids=False).__repr__().replace('AttributeDict', '')
-
-    def __getitem__(self, key):
-        """Set items - we just the getattr method"""
-        return getattr(self, key)
-
-    def __repr__(self):
-        string = self.to_string()
-        string = string.replace('\n', ' ')
-        string = string.replace('#', '')
-        string = string.strip()
-        if len(string) > 60:
-            string = string[:60] + '...'
-        return f'{type(self).__name__}<{string}>'
-
     @classmethod
-    def validate_dict(cls, input_dict, port=None) -> None:  # pylint:disable=unused-argument
+    def validate_dict(cls, input_dict) -> None:  # pylint:disable=unused-argument
         """
         Vaildate a dictionary/Dict node, this can be used as the validator for
         the Port accepting the inputs
         """
-        obj = cls(**input_dict)
-        all_options = list(obj.valid_options)  # A copy for all options
-
-        # Are we receiving a Dict object?
-        if not isinstance(input_dict, dict):
-            input_dict = input_dict.get_dict()
-
-        for key in input_dict.keys():
-            if key not in all_options:
-                raise InputValidationError(f"Key '{key}' is not a valid option")
-            all_options.remove(key)
-
-        # Check for any missing required fields
-        missing = [key for key in all_options if key in obj.required_options]
-        if missing:
-            raise InputValidationError(f'There are missing options: {missing}')
-
-        # Check for any problems with obj.to_dict()
         try:
-            obj.to_dict()
-        except ValueError as error:
-            raise InputValidationError(f'Error during validation: {error.args}')
+            cls(**input_dict)
+        except ValidationError as error:
+            raise InputValidationError(f'Input validation failed: {error}') from error
+        return True
 
     @classmethod
-    def serialise(cls, value):
+    def serialize(cls, python_dict: dict):
         """
-        Serialise a dictionary into Dict
+        serialize a dictionary into Dict
 
         This method can be passed as a `serializer` key word parameter of for the `spec.input` call.
         """
-        obj = cls(**value)
-        return obj.to_aiida_dict()
-
-    @classmethod
-    def setup_spec(cls, spec, port_name, **kwargs) -> None:
-        """Setup the spec for this input"""
-        # Check if we have 'required' fields
-        obj = cls()
-        # The constructor is different with/without any required_options
-        # If there are any required options, it does not make any sense to have a default for the port.
-        if obj.required_options:
-            spec.input(
-                port_name,
-                validator=cls.validate_dict,
-                serializer=cls.serialise,
-                **kwargs,
-            )
-        else:
-            spec.input(
-                port_name,
-                validator=cls.validate_dict,
-                default=lambda: cls().to_aiida_dict(),
-                serializer=cls.serialise,
-                **kwargs,
-            )
+        obj = cls(**python_dict)
+        return obj.aiida_dict()
 
     @classmethod
     def get_description(cls):
@@ -332,14 +196,9 @@ class OptionContainer:
         obj = cls()
         template = '{:>{width_name}s}:  {:10s} \n{default:>{width_name2}}: {}'
         entries = []
-        for name in obj.valid_options:
-            if name not in obj.required_options:
-                value = getattr(obj, name)
-                # Each entry is name, type, doc, default value
-                entries.append([name, getattr(cls, name).__doc__, str(type(value)), value])
-            else:
-                entries.append([name, getattr(cls, name).__doc__, 'Undefined', 'None (required)'])
-
+        for name, field in obj.model_fields.items():
+            # Each entry is name, type, doc, default value
+            entries.append([name, str(field.annotation.__name__), field.description, field.default])
         max_width_name = max(len(entry[0]) for entry in entries) + 2
 
         lines = []

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -16,28 +16,12 @@ from aiida import orm
 from aiida.common.utils import classproperty
 from aiida.engine import WorkChain, append_, calcfunction
 from aiida.plugins import WorkflowFactory
-from pydantic import Field
 
-from aiida_vasp.utils.opthold import OptionContainer
+from aiida_vasp.utils.opthold import ConvOptions
 
 from .common import nested_update_dict_node
 
 # pylint:disable=no-member,unused-argument,no-self-argument,import-outside-toplevel
-
-
-class ConvOptions(OptionContainer):
-    """Template for the Dict node controlling the workchain behaviour"""
-
-    cutoff_start: float = Field(description='The starting cut-off energy', default=300.0)
-    cutoff_stop: float = Field(description='The Final cut-off energy', default=700.0)
-    cutoff_step: float = Field(description='Step size of the cut-off energy', default=50.0)
-    kspacing_start: float = Field(description='The starting kspacing', default=0.07)
-    kspacing_stop: float = Field(description='The final kspacing', default=0.02)
-    kspacing_step: float = Field(description='Step size of the cut-off energy', default=0.01)
-    cutoff_kconv: float = Field(description='The cut-off energy used for kpoints convergence tests', default=450.0)
-    kspacing_cutconv: float = Field(
-        description='The kpoints spacing used for cut-off energy convergence tests', default=0.07
-    )
 
 
 class VaspConvergenceWorkChain(WorkChain):
@@ -73,9 +57,9 @@ class VaspConvergenceWorkChain(WorkChain):
         spec.expose_inputs(cls._sub_workchain)
         spec.input(
             'conv_settings',
-            help='Settings of the workchain',
-            validator=OptionContainer.aiida_validate,
-            serializer=OptionContainer.aiida_serialize,
+            help=ConvOptions.aiida_description(),
+            validator=ConvOptions.aiida_validate,
+            serializer=ConvOptions.aiida_serialize,
             valid_type=orm.Dict,
         )
         spec.outline(cls.setup, cls.launch_conv_calcs, cls.analyse)

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -16,11 +16,28 @@ from aiida import orm
 from aiida.common.utils import classproperty
 from aiida.engine import WorkChain, append_, calcfunction
 from aiida.plugins import WorkflowFactory
+from pydantic import Field
+
+from aiida_vasp.utils.opthold import OptionContainer
 
 from .common import nested_update_dict_node
-from .common.opthold import FloatOption, OptionContainer
 
 # pylint:disable=no-member,unused-argument,no-self-argument,import-outside-toplevel
+
+
+class ConvOptions(OptionContainer):
+    """Template for the Dict node controlling the workchain behaviour"""
+
+    cutoff_start: float = Field(description='The starting cut-off energy', default=300.0)
+    cutoff_stop: float = Field(description='The Final cut-off energy', default=700.0)
+    cutoff_step: float = Field(description='Step size of the cut-off energy', default=50.0)
+    kspacing_start: float = Field(description='The starting kspacing', default=0.07)
+    kspacing_stop: float = Field(description='The final kspacing', default=0.02)
+    kspacing_step: float = Field(description='Step size of the cut-off energy', default=0.01)
+    cutoff_kconv: float = Field(description='The cut-off energy used for kpoints convergence tests', default=450.0)
+    kspacing_cutconv: float = Field(
+        description='The kpoints spacing used for cut-off energy convergence tests', default=0.07
+    )
 
 
 class VaspConvergenceWorkChain(WorkChain):
@@ -54,7 +71,13 @@ class VaspConvergenceWorkChain(WorkChain):
         super().define(spec)
 
         spec.expose_inputs(cls._sub_workchain)
-        spec.input('conv_settings', help='Settings of the workchain', valid_type=orm.Dict)
+        spec.input(
+            'conv_settings',
+            help='Settings of the workchain',
+            validator=OptionContainer.aiida_validate,
+            serializer=OptionContainer.aiida_serialize,
+            valid_type=orm.Dict,
+        )
         spec.outline(cls.setup, cls.launch_conv_calcs, cls.analyse)
 
         spec.exit_code(
@@ -266,19 +289,6 @@ class VaspConvergenceWorkChain(WorkChain):
         return cdf, kdf
 
 
-class ConvOptions(OptionContainer):
-    """Template for the Dict node controlling the workchain behaviour"""
-
-    cutoff_start = FloatOption('The starting cut-off energy', 300)
-    cutoff_stop = FloatOption('The Final cut-off energy', 700)
-    cutoff_step = FloatOption('Step size of the cut-off energy', 50)
-    kspacing_start = FloatOption('The starting kspacing', 0.07)
-    kspacing_stop = FloatOption('The final kspacing', 0.02)
-    kspacing_step = FloatOption('Step size of the cut-off energy', 0.01)
-    cutoff_kconv = FloatOption('The cut-off energy used for kpoints convergence tests', 450)
-    kspacing_cutconv = FloatOption('The kpoints spacing used for cut-off energy convergence tests', 0.07)
-
-
 def get_conv_data(conv_work):
     """
     Convenient method for extracting convergence data
@@ -385,5 +395,5 @@ def get_convergence_builder(structure, config):
 
     # Convergence specific options
     conv = ConvOptions(**config.get('conv', {}))
-    upd.builder.conv_settings = conv.to_aiida_dict()
+    upd.builder.conv_settings = conv.aiida_dict()
     return upd

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -199,7 +199,7 @@ class VaspConvergenceWorkChain(WorkChain):
 
                 # Setup the energy key from the first workchain
                 if not energy_key:
-                    energy_key = next(iter(workchain.outputs.misc.get_dict()['total_energies'].values()))
+                    energy_key = next(iter(workchain.outputs.misc.get_dict()['total_energies'].keys()))
 
                 cutoff = workchain.inputs.parameters['incar']['encut']
                 cutoff_data[cutoff] = collect_data(workchain, energy_key)

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -374,7 +374,7 @@ def get_convergence_builder(structure, config):
     upd = VaspBuilderUpdater(conv_builder)
     upd.use_inputset(
         structure,
-        config.get('inputset', VaspBuilderUpdater.DEFAULT_SET),
+        config.get('inputset', VaspBuilderUpdater.DEFAULT_INPUTSET),
         overrides=config.get('overrides', {}),
     )
     upd.set_code(orm.load_code(config['code']))

--- a/src/aiida_vasp/workchains/v2/inputset/MITRelaxSet.yaml
+++ b/src/aiida_vasp/workchains/v2/inputset/MITRelaxSet.yaml
@@ -154,3 +154,6 @@ potcar_mapping:
   Yb: Yb
   Zn: Zn
   Zr: Zr
+
+
+potcar_family: 'PBE'

--- a/src/aiida_vasp/workchains/v2/inputset/MPRelaxSet.yaml
+++ b/src/aiida_vasp/workchains/v2/inputset/MPRelaxSet.yaml
@@ -148,3 +148,5 @@ potcar_mapping:
   Yb: Yb_2
   Zn: Zn
   Zr: Zr_sv
+
+potcar_family: 'PBE'

--- a/src/aiida_vasp/workchains/v2/inputset/UCLRelaxSet.yaml
+++ b/src/aiida_vasp/workchains/v2/inputset/UCLRelaxSet.yaml
@@ -146,3 +146,7 @@ potcar_mapping:
   Yb: Yb_2
   Zn: Zn
   Zr: Zr_sv
+
+potcar_family: PBE.54
+
+kpoints_spacing: 0.05

--- a/src/aiida_vasp/workchains/v2/inputset/base.py
+++ b/src/aiida_vasp/workchains/v2/inputset/base.py
@@ -7,8 +7,7 @@ from math import pi
 from pathlib import Path
 
 import yaml
-from aiida.orm import Dict, KpointsData
-from ase import Atoms
+from aiida.orm import Dict, KpointsData, StructureData
 
 FELEMS = [
     'La',
@@ -58,19 +57,16 @@ class InputSet:
     """
 
     # path from which the set yaml files are read
-    _load_paths = (get_library_path(), Path('~/.inputsets').expanduser())
+    _load_paths = (get_library_path(), Path('~/.aiida-vasp').expanduser())
 
-    def __init__(self, set_name, structure, overrides=None, verbose=True):
+    def __init__(self, set_name, overrides=None, verbose=False):
         """
         Initialise an InputSet
 
         Args:
           set_name: Name of the set to be loaded
-          structure: Structure used for calculation, can be StructureData or Atoms
           overrides: A dictionary of overriding inputs.
-
         """
-        self.structure = structure
         self.set_name = set_name
 
         if overrides is None:
@@ -81,7 +77,7 @@ class InputSet:
         self.verbose = verbose
         self._load_data()
 
-    def get_input_dict(self, raw_python=True):
+    def get_input_dict(self, structure: StructureData, raw_python=True):
         """
         Get a input dictionary for VASP
         """
@@ -89,7 +85,7 @@ class InputSet:
         out_dict = deepcopy(self._presets['global'])
 
         # Set-per atom properties
-        natoms = self.natoms
+        natoms = len(structure.sites)
         for key, value in self._presets.get('per_atom', {}).items():
             out_dict[key] = value * natoms
 
@@ -115,18 +111,6 @@ class InputSet:
         with open(set_path, encoding='utf-8') as fhd:
             self._presets = yaml.load(fhd, Loader=yaml.FullLoader)
 
-    @property
-    def natoms(self):
-        if isinstance(self.structure, Atoms):
-            return len(self.structure)
-        return len(self.structure.sites)
-
-    @property
-    def elements(self):
-        if isinstance(self.structure, Atoms):
-            return self.structure.get_chemical_symbols()
-        return [kind.name for kind in self.structure.kinds]
-
     def apply_overrides(self, out_dict):
         """Apply overrides stored in self.overrides to the dictionary passed"""
         for name, value in self.overrides.items():
@@ -140,7 +124,7 @@ class InputSet:
             else:
                 out_dict[name] = value
 
-    def get_kpoints(self, density):
+    def get_kpoints(self, structure, density=None):
         """
         Return a kpoints object for a given density
 
@@ -151,7 +135,9 @@ class InputSet:
           An KpointsData object with the desired density
         """
 
+        if density is None:
+            density = self._presets['kpoints_spacing']
         kpoints = KpointsData()
-        kpoints.set_cell(self.structure.cell)
+        kpoints.set_cell(structure.cell)
         kpoints.set_kpoints_mesh_from_density(density * 2 * pi)
         return kpoints

--- a/src/aiida_vasp/workchains/v2/inputset/vaspsets.py
+++ b/src/aiida_vasp/workchains/v2/inputset/vaspsets.py
@@ -3,13 +3,15 @@ Default input sets for VASP
 """
 
 from copy import deepcopy
+from typing import Union
+
+from aiida.orm import Dict, StructureData
 
 try:
     from aiida_vasp.parsers.content_parsers.potcar import MultiPotcarIo
 except ImportError:
     from aiida_vasp.parsers.file_parsers.potcar import MultiPotcarIo
 
-from aiida.orm import Dict, StructureData
 
 from .base import FELEMS, InputSet
 
@@ -17,9 +19,11 @@ from .base import FELEMS, InputSet
 class VASPInputSet(InputSet):
     """Input set for VASP"""
 
-    def get_input_dict(self, raw_python=True):
-        """Get a input dictionary"""
-        out_dict = super().get_input_dict(raw_python=True)
+    def get_input_dict(self, structure, raw_python=True) -> Union[dict, Dict]:
+        """
+        Compose the Dict object containing the input settings.
+        """
+        out_dict = super().get_input_dict(structure, raw_python=True)
 
         # Check if there is any magnetic elements
         spin = False
@@ -27,8 +31,9 @@ class VASPInputSet(InputSet):
         # Update with overrides
         mapping.update(self.overrides.get('magmom_mapping', {}))
         default = mapping['default']
+        kind_symbols = [kind.name for kind in structure.kinds]
         for symbol in mapping:
-            if symbol in self.elements:
+            if symbol in kind_symbols:
                 spin = True
                 break
         if 'magmom_mapping' in self.overrides or 'magmom' in self.overrides:
@@ -37,11 +42,11 @@ class VASPInputSet(InputSet):
         # Setup magnetic moments
         magmom = []
         if spin:
-            if isinstance(self.structure, StructureData):
-                for site in self.structure.sites:
+            if isinstance(structure, StructureData):
+                for site in structure.sites:
                     magmom.append(mapping.get(site.kind_name, default))
             else:
-                for atom in self.structure:
+                for atom in structure:
                     magmom.append(mapping.get(atom.symbol, default))
         if magmom:
             out_dict['ispin'] = 2
@@ -54,7 +59,7 @@ class VASPInputSet(InputSet):
         ldaujmap = deepcopy(self._presets['ldauj_mapping'])
         ldaujmap.update(self.overrides.get('ldauj_mapping', {}))
 
-        ldaukeys = get_ldau_keys(self.structure, ldauumap, utype=2, jmapping=ldaujmap)
+        ldaukeys = get_ldau_keys(structure, ldauumap, utype=2, jmapping=ldaujmap)
         out_dict.update(ldaukeys)
 
         # Apply overrides again over the automatically applied keys
@@ -64,9 +69,9 @@ class VASPInputSet(InputSet):
             out_dict = Dict(dict=out_dict)
         return out_dict
 
-    def get_pp_mapping(self):
+    def get_pp_mapping(self, structure: StructureData) -> dict:
         """Return the mapping from element to the POTCAR name"""
-        elms = set(self.elements)
+        elms = [kind.name for kind in structure.kinds]
 
         pmap = deepcopy(self._presets['potcar_mapping'])
         # Update the mapping from override, if any
@@ -74,6 +79,12 @@ class VASPInputSet(InputSet):
 
         out_dict = {key: pmap[key] for key in elms}
         return out_dict
+
+    def get_potcar_family(self) -> str:
+        return self._presets['potcar_family']
+
+    def get_kpoints_spacing(self):
+        return self._presets.get('kpoints_spacing')
 
 
 def get_ldau_keys(structure, mapping, utype=2, jmapping=None, felec=False):
@@ -87,7 +98,7 @@ def get_ldau_keys(structure, mapping, utype=2, jmapping=None, felec=False):
         mapping: a dictionary in the format of  {"Mn": [d, 4]...} for U
         utype: the type of LDA+U, default to 2, which is the one with only one parameter
         jmapping: a dictionary in the format of  {"Mn": [d, 4]...} but for J
-        felec: Wether we are dealing with f electrons, will increase lmaxmix if we are.
+        felec: Whether we are dealing with f electrons, will increase lmaxmix if we are.
 
 
     Returns:

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -25,7 +25,6 @@ CHANGELOG
 """
 
 # pylint: disable=attribute-defined-outside-init
-from typing import Optional
 
 import numpy as np
 from aiida import orm
@@ -35,10 +34,9 @@ from aiida.common.utils import classproperty
 from aiida.engine import ToContext, WorkChain, append_, if_, while_
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import WorkflowFactory
-from pydantic import Field
 
 from aiida_vasp.utils.aiida_utils import get_data_class
-from aiida_vasp.utils.opthold import OptionContainer
+from aiida_vasp.utils.opthold import RelaxOptions
 from aiida_vasp.utils.workchains import compose_exit_code
 
 from .common import OVERRIDE_NAMESPACE, nested_update_dict_node, site_magnetization_to_magmom
@@ -49,96 +47,6 @@ __version__ = '0.5.0'
 # Change log
 # 0.4.0 update such `vasp` namespace in `parameters` is renamed to `incar`
 # 0.5.0 update the logic of convergence checking. Cell comparsion is always done using the input/output structures.
-
-
-class RelaxOptions(OptionContainer):
-    """Options for VaspRelaxWorkChain"""
-
-    algo: str = Field(description='The algorithm to use for relaxation', examples=['cg', 'rd'], default='cg')
-    energy_cutoff: Optional[float] = Field(
-        description='The cut off energy difference when the relaxation is stopped (e.g. EDIFF)',
-        default=None,
-    )
-    force_cutoff: float = Field(
-        description='The maximum force when the relaxation is stopped (e.g. EDIFFG)',
-        default=0.03,
-    )
-    steps: float = Field(description='Number of relaxation steps to perform (eg. NSW)', default=60)
-    positions: bool = Field(description='If True, perform relaxation of the atomic positions', default=True)
-    shape: bool = Field(description='If True, perform relaxation of the cell shape', default=True)
-    volume: bool = Field(description='If True, perform relaxation of the cell volume', default=True)
-    convergence_on: bool = Field(description='If True, perform convergence checks within the workchain', default=True)
-    convergence_absolute: bool = Field(
-        description='If True, use absolute values where possible when performing convergence checks',
-        default=False,
-    )
-    convergence_max_iterations: int = Field(description='Maximum iterations for convergence checking', default=5)
-    convergence_positions: float = Field(
-        description=(
-            'The cutoff value for the convergence check on positions in Angstram.'
-            ' A negative value by pass the check.'
-        ),
-        default=0.1,
-    )
-    convergence_volume: float = Field(
-        description='The cutoff value for the convergence check on volume between the two structures.'
-        ' A negative value by pass the check.',
-        default=0.01,
-    )
-    convergence_shape_lengths: float = Field(
-        description='The cutoff value for the convergence check on the lengths of the unit cell'
-        ' vectors, between input and the outputs structure. A negative value by pass'
-        ' the check.',
-        default=0.1,
-    )
-    convergence_shape_angles: float = Field(
-        description='The cutoff value for the convergence check on the angles of the unit cell vectors, '
-        'between input and the outputs structure. A'
-        ' negative value by pass the check.',
-        default=0.1,
-    )
-    convergence_mode: str = Field(
-        description="Mode of the convergence check for positions. 'inout' for checking input/output structure, "
-        "or 'last' to check only the change of"
-        ' the last step.',
-        examples=['inout', 'last'],
-        default='last',
-    )
-    reuse: bool = Field(
-        description='Whether reuse the previous calculation by copying over the remote folder',
-        default=False,
-    )
-    clean_reuse: bool = Field(
-        description='Whether to perform a final cleaning of the reused calculations', default=True
-    )
-    keep_sp_workdir: bool = Field(
-        description='Whether to keep the workdir of the final singlepoint calculation', default=False
-    )
-    perform: bool = Field(description="Do not perform any relaxation if set to 'False'", default=True)
-    hybrid_calc_bootstrap: bool = Field(
-        description='Whether to bootstrap hybrid calculation by performing standard DFT first', default=False
-    )
-    hybrid_calc_bootstrap_wallclock: int = Field(
-        description='Wall time limit in second for the bootstrap calculation', default=3600
-    )
-    keep_magnetization: bool = Field(
-        description='Whether to keep magnetization from the previous calculation if possible', default=False
-    )
-
-    # TODO: implement pyandtic checks
-
-    # @classmethod
-    # def validate_dict(cls, input_dict, port=None):
-    #     """Check mutually exclusive fields"""
-    #     super().validate_dict(input_dict, port)
-    #     if isinstance(input_dict, orm.Dict):
-    #         input_dict = input_dict.get_dict()
-    #     force_cut = input_dict.get('force_cutoff')
-    #     energy_cut = input_dict.get('energy_cutoff')
-    #     if force_cut is None and energy_cut is None:
-    #         raise InputValidationError("Either 'force_cutoff' or 'energy_cutoff' should be supplied")
-    #     if (force_cut is not None) and (energy_cut is not None):
-    #         raise InputValidationError("Cannot set both 'force_cutoff' and 'energy_cutoff'")
 
 
 class VaspRelaxWorkChain(WorkChain, WithVaspInputSet):

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -64,7 +64,7 @@ class RelaxOptions(OptionContainer):
         default=0.03,
     )
     steps: float = Field(description='Number of relaxation steps to perform (eg. NSW)', default=60)
-    positionn: bool = Field(description='If True, perform relaxation of the atomic positions', default=True)
+    positions: bool = Field(description='If True, perform relaxation of the atomic positions', default=True)
     shape: bool = Field(description='If True, perform relaxation of the cell shape', default=True)
     volume: bool = Field(description='If True, perform relaxation of the cell volume', default=True)
     convergence_on: bool = Field(description='If True, perform convergence checks within the workchain', default=True)

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -25,6 +25,8 @@ CHANGELOG
 """
 
 # pylint: disable=attribute-defined-outside-init
+from typing import Optional
+
 import numpy as np
 from aiida import orm
 from aiida.common.exceptions import InputValidationError
@@ -33,12 +35,13 @@ from aiida.common.utils import classproperty
 from aiida.engine import ToContext, WorkChain, append_, if_, while_
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import WorkflowFactory
+from pydantic import Field
 
 from aiida_vasp.utils.aiida_utils import get_data_class
+from aiida_vasp.utils.opthold import OptionContainer
 from aiida_vasp.utils.workchains import compose_exit_code
 
 from .common import OVERRIDE_NAMESPACE, nested_update_dict_node, site_magnetization_to_magmom
-from .common.opthold import BoolOption, ChoiceOption, FloatOption, IntOption, OptionContainer
 from .mixins import WithVaspInputSet
 
 __version__ = '0.5.0'
@@ -46,6 +49,96 @@ __version__ = '0.5.0'
 # Change log
 # 0.4.0 update such `vasp` namespace in `parameters` is renamed to `incar`
 # 0.5.0 update the logic of convergence checking. Cell comparsion is always done using the input/output structures.
+
+
+class RelaxOptions(OptionContainer):
+    """Options for VaspRelaxWorkChain"""
+
+    algo: str = Field(description='The algorithm to use for relaxation', examples=['cg', 'rd'], default='cg')
+    energy_cutoff: Optional[float] = Field(
+        description='The cut off energy difference when the relaxation is stopped (e.g. EDIFF)',
+        default=None,
+    )
+    force_cutoff: float = Field(
+        description='The maximum force when the relaxation is stopped (e.g. EDIFFG)',
+        default=0.03,
+    )
+    steps: float = Field(description='Number of relaxation steps to perform (eg. NSW)', default=60)
+    positionn: bool = Field(description='If True, perform relaxation of the atomic positions', default=True)
+    shape: bool = Field(description='If True, perform relaxation of the cell shape', default=True)
+    volume: bool = Field(description='If True, perform relaxation of the cell volume', default=True)
+    convergence_on: bool = Field(description='If True, perform convergence checks within the workchain', default=True)
+    convergence_absolute: bool = Field(
+        description='If True, use absolute values where possible when performing convergence checks',
+        default=False,
+    )
+    convergence_max_iterations: int = Field(description='Maximum iterations for convergence checking', default=5)
+    convergence_positions: float = Field(
+        description=(
+            'The cutoff value for the convergence check on positions in Angstram.'
+            ' A negative value by pass the check.'
+        ),
+        default=0.1,
+    )
+    convergence_volume: float = Field(
+        description='The cutoff value for the convergence check on volume between the two structures.'
+        ' A negative value by pass the check.',
+        default=0.01,
+    )
+    convergence_shape_lengths: float = Field(
+        description='The cutoff value for the convergence check on the lengths of the unit cell'
+        ' vectors, between input and the outputs structure. A negative value by pass'
+        ' the check.',
+        default=0.1,
+    )
+    convergence_shape_angles: float = Field(
+        description='The cutoff value for the convergence check on the angles of the unit cell vectors, '
+        'between input and the outputs structure. A'
+        ' negative value by pass the check.',
+        default=0.1,
+    )
+    convergence_mode: str = Field(
+        description="Mode of the convergence check for positions. 'inout' for checking input/output structure, "
+        "or 'last' to check only the change of"
+        ' the last step.',
+        examples=['inout', 'last'],
+        default='last',
+    )
+    reuse: bool = Field(
+        description='Whether reuse the previous calculation by copying over the remote folder',
+        default=False,
+    )
+    clean_reuse: bool = Field(
+        description='Whether to perform a final cleaning of the reused calculations', default=True
+    )
+    keep_sp_workdir: bool = Field(
+        description='Whether to keep the workdir of the final singlepoint calculation', default=False
+    )
+    perform: bool = Field(description="Do not perform any relaxation if set to 'False'", default=True)
+    hybrid_calc_bootstrap: bool = Field(
+        description='Whether to bootstrap hybrid calculation by performing standard DFT first', default=False
+    )
+    hybrid_calc_bootstrap_wallclock: int = Field(
+        description='Wall time limit in second for the bootstrap calculation', default=3600
+    )
+    keep_magnetization: bool = Field(
+        description='Whether to keep magnetization from the previous calculation if possible', default=False
+    )
+
+    # TODO: implement pyandtic checks
+
+    # @classmethod
+    # def validate_dict(cls, input_dict, port=None):
+    #     """Check mutually exclusive fields"""
+    #     super().validate_dict(input_dict, port)
+    #     if isinstance(input_dict, orm.Dict):
+    #         input_dict = input_dict.get_dict()
+    #     force_cut = input_dict.get('force_cutoff')
+    #     energy_cut = input_dict.get('energy_cutoff')
+    #     if force_cut is None and energy_cut is None:
+    #         raise InputValidationError("Either 'force_cutoff' or 'energy_cutoff' should be supplied")
+    #     if (force_cut is not None) and (energy_cut is not None):
+    #         raise InputValidationError("Cannot set both 'force_cutoff' and 'energy_cutoff'")
 
 
 class VaspRelaxWorkChain(WorkChain, WithVaspInputSet):
@@ -90,9 +183,9 @@ class VaspRelaxWorkChain(WorkChain, WithVaspInputSet):
         spec.input(
             'relax_settings',
             valid_type=get_data_class('core.dict'),
-            validator=RelaxOptions.validate_dict,
-            serializer=to_aiida_type,
-            help=RelaxOptions.get_description(),
+            validator=RelaxOptions.aiida_validate,
+            serializer=RelaxOptions.aiida_serialize,
+            help=RelaxOptions.aiida_description(),
         )
         spec.input(
             'verbose',
@@ -849,83 +942,6 @@ def compare_structures(structure_a, structure_b):
     delta.relative.cell_angles = np.absolute(cell_angles_a - np.array(structure_b.cell_angles)) / cell_angles_a
 
     return delta
-
-
-class RelaxOptions(OptionContainer):
-    """Options for VaspRelaxWorkChain"""
-
-    algo = ChoiceOption('The algorithm to use for relaxation', ['cg', 'rd'], default_value='cg')
-    energy_cutoff = FloatOption(
-        'The cut off energy difference when the relaxation is stopped (e.g. EDIFF)',
-        default_value=None,
-        required=False,
-    )
-    force_cutoff = FloatOption(
-        'The maximum force when the relaxation is stopped (e.g. EDIFFG)',
-        default_value=0.03,
-        required=False,
-    )
-    steps = IntOption('Number of relaxation steps to perform (eg. NSW)', 60)
-    positions = BoolOption('If True, perform relaxation of the atomic positions', default_value=True)
-    shape = BoolOption('If True, perform relaxation of the cell shape', default_value=True)
-    volume = BoolOption('If True, perform relaxation of the cell volume', default_value=True)
-    convergence_on = BoolOption('If True, perform convergence checkes withint the workchain', default_value=True)
-    convergence_absolute = BoolOption(
-        'If True, use absolute values where possible when performing convergence checkes',
-        default_value=False,
-    )
-    convergence_max_iterations = IntOption('Maximum interations for convergence checking', 5)
-    convergence_positions = FloatOption(
-        'The cutoff value for the convergence check on positions in Angstram. A negative value by pass the check.',
-        0.1,
-    )
-    convergence_volume = FloatOption(
-        'The cutoff value for the convergence check on volume between the two structures.'
-        ' A negative value by pass the check.',
-        0.01,
-    )
-    convergence_shape_lengths = FloatOption(
-        'The cutoff value for the convergence check on the lengths of the unit cell'
-        ' vectors, between input and the outputs structure. A negative value by pass'
-        ' the check.',
-        0.1,
-    )
-    convergence_shape_angles = FloatOption(
-        'The cutoff value for the convergence check on the angles of the unit cell vectors, '
-        'between input and the outputs structure. A'
-        ' negative value by pass the check.',
-        0.1,
-    )
-    convergence_mode = ChoiceOption(
-        "Mode of the convergence check for positions. 'inout' for checking input/output structure, "
-        "or 'last' to check only the change of"
-        ' the last step.',
-        choices=['inout', 'last'],
-        default_value='last',
-    )
-    reuse = BoolOption(
-        'Whether reuse the previous calculation by copying over the remote folder',
-        default_value=False,
-    )
-    clean_reuse = BoolOption('Whether to perform a final cleaning of the reused calculations', True)
-    keep_sp_workdir = BoolOption('Whether to keep the workdir of the final singlepoint calculation', False)
-    perform = BoolOption("Do not perform any relaxation if set to 'False'", True)
-    hybrid_calc_bootstrap = BoolOption('Wether to bootstrap hybrid calculation by perfroming standard DFT first', None)
-    hybrid_calc_bootstrap_wallclock = IntOption('Wallclock limit in second for the bootstrap calculation', None)
-    keep_magnetization = BoolOption('Wether to keep magnetization from the previous calculation if possible', False)
-
-    @classmethod
-    def validate_dict(cls, input_dict, port=None):
-        """Check mutually exclusive fields"""
-        super().validate_dict(input_dict, port)
-        if isinstance(input_dict, orm.Dict):
-            input_dict = input_dict.get_dict()
-        force_cut = input_dict.get('force_cutoff')
-        energy_cut = input_dict.get('energy_cutoff')
-        if force_cut is None and energy_cut is None:
-            raise InputValidationError("Either 'force_cutoff' or 'energy_cutoff' should be supplied")
-        if (force_cut is not None) and (energy_cut is not None):
-            raise InputValidationError("Cannot set both 'force_cutoff' and 'energy_cutoff'")
 
 
 def get_step_structure(traj, step):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,15 +114,14 @@ def read_file(data_path):
 @pytest.fixture()
 def vasp_code(localhost):
     """Fixture for a vasp code, the executable it points to does not exist."""
-    from aiida.orm import Code
+    from aiida.orm import InstalledCode
 
     if not localhost.pk:
         localhost.store()
-    code = Code()
+    code = InstalledCode(localhost, '/usr/local/bin/vasp')
     code.label = 'vasp'
     code.description = 'VASP code'
-    code.set_remote_computer_exec((localhost, '/usr/local/bin/vasp'))
-    code.set_input_plugin_name('vasp.vasp')
+    code.default_calc_job_plugin = 'vasp.vasp'
     return code
 
 

--- a/tests/utils/test_option_holder.py
+++ b/tests/utils/test_option_holder.py
@@ -1,0 +1,63 @@
+import pytest
+from aiida import orm
+from aiida.common.exceptions import InputValidationError
+from aiida_vasp.utils.opthold import OptionContainer
+from aiida_vasp.workchains.v2.bands import BandOptions
+from aiida_vasp.workchains.v2.converge import ConvOptions
+from aiida_vasp.workchains.v2.relax import RelaxOptions
+
+
+def test_option_container():
+    """Test the base option container"""
+
+    class TestHolder(OptionContainer):
+        x: int = 1
+        y: str = 'test'
+        z: float
+
+    holder = TestHolder(z=1.0)
+    d = holder.aiida_dict()
+    holder2 = TestHolder(**d.get_dict())
+    assert holder == holder2
+    assert holder.model_dump() == holder2.model_dump()
+
+    assert holder.aiida_validate({'x': 2, 'y': 'test2', 'z': 2.0})
+    with pytest.raises(InputValidationError):
+        holder.aiida_validate({'x': 2, 'y': 2.0, 'z': '2'})
+
+    node = holder.aiida_serialize({'x': 2, 'z': 3})
+    assert node['x'] == 2
+    assert node['y'] == 'test'
+    assert node['z'] == 3
+
+
+@pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
+def test_workchain_options_roundtrip(cls):
+    """Test the relax option container"""
+    opt = cls()
+    out = opt.aiida_dict()
+    assert cls(**out.get_dict()) == opt
+
+
+@pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
+def test_workchain_options_validate(cls):
+    """Test the relax option container"""
+    opt = cls()
+    out = opt.model_dump()
+    assert cls.validate_dict(out)
+
+
+@pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
+def test_workchain_options_serialize(cls):
+    """Test the relax option container"""
+    opt = cls()
+    out = opt.model_dump()
+    assert isinstance(cls.serialize(out), orm.Dict)
+
+
+@pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
+def test_workchain_options_description(cls):
+    """Test the relax option container"""
+    opt = cls()
+    desc = opt.get_description()
+    assert desc

--- a/tests/utils/test_option_holder.py
+++ b/tests/utils/test_option_holder.py
@@ -1,6 +1,5 @@
 import pytest
 from aiida import orm
-from aiida.common.exceptions import InputValidationError
 from aiida_vasp.utils.opthold import OptionContainer
 from aiida_vasp.workchains.v2.bands import BandOptions
 from aiida_vasp.workchains.v2.converge import ConvOptions
@@ -21,9 +20,8 @@ def test_option_container():
     assert holder == holder2
     assert holder.model_dump() == holder2.model_dump()
 
-    assert holder.aiida_validate({'x': 2, 'y': 'test2', 'z': 2.0})
-    with pytest.raises(InputValidationError):
-        holder.aiida_validate({'x': 2, 'y': 2.0, 'z': '2'})
+    assert holder.aiida_validate({'x': 2, 'y': 'test2', 'z': 2.0}) is None
+    assert holder.aiida_validate({'x': 2, 'y': 2.0, 'z': '2'}) is not None
 
     node = holder.aiida_serialize({'x': 2, 'z': 3})
     assert node['x'] == 2
@@ -44,7 +42,7 @@ def test_workchain_options_validate(cls):
     """Test the relax option container"""
     opt = cls()
     out = opt.model_dump()
-    assert cls.validate_dict(out)
+    assert cls.aiida_validate(out) is None
 
 
 @pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
@@ -52,12 +50,12 @@ def test_workchain_options_serialize(cls):
     """Test the relax option container"""
     opt = cls()
     out = opt.model_dump()
-    assert isinstance(cls.serialize(out), orm.Dict)
+    assert isinstance(cls.aiida_serialize(out), orm.Dict)
 
 
 @pytest.mark.parametrize('cls', [RelaxOptions, BandOptions, ConvOptions])
 def test_workchain_options_description(cls):
     """Test the relax option container"""
     opt = cls()
-    desc = opt.get_description()
+    desc = opt.aiida_description()
     assert desc

--- a/tests/utils/test_option_holder.py
+++ b/tests/utils/test_option_holder.py
@@ -1,9 +1,6 @@
 import pytest
 from aiida import orm
-from aiida_vasp.utils.opthold import OptionContainer
-from aiida_vasp.workchains.v2.bands import BandOptions
-from aiida_vasp.workchains.v2.converge import ConvOptions
-from aiida_vasp.workchains.v2.relax import RelaxOptions
+from aiida_vasp.utils.opthold import BandOptions, ConvOptions, OptionContainer, RelaxOptions
 
 
 def test_option_container():

--- a/tests/workchains/v2/test_builder_updater.py
+++ b/tests/workchains/v2/test_builder_updater.py
@@ -1,0 +1,80 @@
+import pytest
+from aiida import orm
+from aiida_vasp.workchains.v2.common import builder_updater as bup
+from ase.build import bulk
+
+
+def test_vasp_builder_updater(aiida_profile, vasp_code):
+    structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
+
+    vasp_code.store()
+    upd = bup.VaspBuilderUpdater()
+    upd.apply_preset(structure, code='vasp@localhost')
+    assert upd.builder.structure == structure
+    assert upd.builder.parameters['incar']['algo'] == 'normal'
+    assert upd.builder.options['resources']['tot_num_mpiprocs'] == 1
+    assert upd.builder.code == vasp_code
+    assert upd.builder.settings.get_dict() == {}
+    assert upd.builder.kpoints_spacing.value == 0.05
+    assert upd.builder.potential_family.value == 'PBE.54'
+    assert upd.builder.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
+
+
+def test_vasp_relax_updater(aiida_profile, vasp_code):
+    structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
+    vasp_code.store()
+    upd = bup.VaspRelaxUpdater()
+    upd.apply_preset(structure, code='vasp@localhost')
+    assert upd.builder.structure == structure
+    assert upd.builder.vasp.parameters['incar']['algo'] == 'normal'
+    assert upd.builder.vasp.options['resources']['tot_num_mpiprocs'] == 1
+    assert upd.builder.vasp.code == vasp_code
+    assert upd.builder.vasp.settings.get_dict() == {}
+    assert upd.builder.vasp.kpoints_spacing.value == 0.05
+    assert upd.builder.vasp.potential_family.value == 'PBE.54'
+    assert upd.builder.vasp.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
+    assert upd.builder.relax_settings.get_dict()['algo'] == 'cg'
+
+
+@pytest.mark.parametrize('hybrid', [True, False])
+def test_vasp_band_updater(aiida_profile, vasp_code, hybrid):
+    structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
+    vasp_code.store()
+    if hybrid:
+        upd = bup.VaspHybridBandUpdater()
+    else:
+        upd = bup.VaspBandUpdater()
+    upd.apply_preset(structure, code='vasp@localhost')
+    assert upd.builder.structure == structure
+    assert upd.builder.scf.parameters['incar']['algo'] == 'normal'
+    assert upd.builder.scf.options['resources']['tot_num_mpiprocs'] == 1
+    assert upd.builder.scf.code == vasp_code
+    assert upd.builder.scf.settings.get_dict() == {}
+    assert upd.builder.scf.kpoints_spacing.value == 0.05
+    assert upd.builder.scf.potential_family.value == 'PBE.54'
+    assert upd.builder.scf.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
+    if hybrid:
+        assert upd.builder.symprec.value == 0.01
+        assert upd.builder.kpoints_per_split.value == 80
+
+    if hybrid:
+        upd = bup.VaspHybridBandUpdater()
+    else:
+        upd = bup.VaspBandUpdater()
+    upd.apply_preset(structure, code='vasp@localhost', run_relax=True)
+
+    assert upd.builder.structure == structure
+    assert upd.builder.relax.vasp.parameters['incar']['algo'] == 'normal'
+    assert upd.builder.relax.vasp.options['resources']['tot_num_mpiprocs'] == 1
+    assert upd.builder.relax.vasp.code == vasp_code
+    assert upd.builder.relax.vasp.settings.get_dict() == {}
+    assert upd.builder.relax.vasp.kpoints_spacing.value == 0.05
+    assert upd.builder.relax.vasp.potential_family.value == 'PBE.54'
+    assert upd.builder.relax.vasp.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
+
+
+def test_vasp_neb_updater(aiida_profile, vasp_code):
+    structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
+    vasp_code.store()
+    upd = bup.VaspNEBUpdater()
+    upd.apply_preset(structure, structure, code='vasp@localhost')

--- a/tests/workchains/v2/test_inputset.py
+++ b/tests/workchains/v2/test_inputset.py
@@ -3,6 +3,7 @@ Test for input set specifications
 """
 
 import pytest
+from aiida import orm
 from aiida_vasp.workchains.v2.inputset.base import InputSet
 from aiida_vasp.workchains.v2.inputset.vaspsets import VASPInputSet
 from ase.build import bulk
@@ -11,22 +12,22 @@ from ase.build import bulk
 
 
 @pytest.fixture
-def fe_atoms():
+def fe_atoms(aiida_profile):
     """Get a Fe atoms"""
-    return bulk('Fe', 'fcc', 5.0)
+    return orm.StructureData(ase=bulk('Fe', 'fcc', 5.0))
 
 
 @pytest.fixture
-def mgo_atoms():
+def mgo_atoms(aiida_profile):
     """Get a MgO atoms"""
-    return bulk('MgO', 'rocksalt', 5.0)
+    return orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0))
 
 
 def test_base(fe_atoms):
     """Base test case"""
-    iset = InputSet('MITRelaxSet', fe_atoms, overrides={'ediff': 1.0, 'nsw': None})
+    iset = InputSet('MITRelaxSet', overrides={'ediff': 1.0, 'nsw': None})
 
-    out = iset.get_input_dict()
+    out = iset.get_input_dict(fe_atoms)
     assert out['ediff'] == 1.0
     assert out['ibrion'] == 2
     assert 'nsw' not in out
@@ -34,9 +35,9 @@ def test_base(fe_atoms):
 
 def test_vasp(fe_atoms):
     """Test VASP inputsets"""
-    iset = VASPInputSet('MITRelaxSet', fe_atoms, overrides={'ediff': 1.0, 'nsw': None, 'ldautype': 3})
+    iset = VASPInputSet('MITRelaxSet', overrides={'ediff': 1.0, 'nsw': None, 'ldautype': 3})
 
-    out = iset.get_input_dict()
+    out = iset.get_input_dict(fe_atoms)
     assert out['ediff'] == 1.0
     assert out['ibrion'] == 2
     assert out['magmom'] == [5]
@@ -50,6 +51,6 @@ def test_vasp(fe_atoms):
 
 def test_kpoints(aiida_profile, fe_atoms):
     """Test generating kpoints"""
-    inset = VASPInputSet('MITRelaxSet', fe_atoms)
-    kpoints = inset.get_kpoints(0.05)
+    inset = VASPInputSet('MITRelaxSet')
+    kpoints = inset.get_kpoints(fe_atoms, 0.05)
     assert kpoints.get_kpoints_mesh()[0][0] == 7


### PR DESCRIPTION

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed).
   - [x] Tests
   - [ ] Documentations 
 - [x] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

When I use aiida-vasp a lot of the time was spent to write small boilerplate code to launch calculations/workflows, or search through old scripts/notebook to copy and paste. The problem is that building up a `ProcessBuilder` involves lots of `build.xxx = xxx` calls. Also, the certain settings may be different for different machines, such as `queue_name` and `account` etc. One may also have default settings for different kinds of calculations/systems. It is cumbersome to specify them again and again in the notebook/script. 

This PR adds the `BuilderUpdater` the ability to apply *preset* that the user defines. The these preset extends the input set concept beyond parameters for VASP. One can also predefine what goes into `settings`, `options` and `relax_settings` etc. 

The idea is to have something like:

```python
structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0))
upd = VaspBuilderUpdater()
upd.apply_preset(structure, preset_name='MyPreset', code='vasp@localhost')
# print(upd.builder)  # Check if the inputs are correct
upd.submit()
```