### PR TITLE
Fix CI and update the minimum python version to be 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda activate test
-          conda install --yes -c conda-forge python=${{ matrix.python-version }}
+          conda install --yes -c conda-forge python=${{ matrix.python }}
           conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
       - name: Setup parsevasp
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Framework :: AiiDA",
 ]
 keywords = ["aiida", "plugin"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aiida-core>=2.3",
     "ase",

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -445,15 +445,14 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater):
             else:
                 dos_input = AttributeDict(
                     {
-                        'settings': orm.Dict(dict={'add_dos': True}),
                         'parameters': orm.Dict(dict={'charge': {'constant_charge': True}}),
                     }
                 )
-            # Use the supplied kpoints density for DOS
-            dos_kpoints = orm.KpointsData()
-            dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
-            dos_kpoints.set_kpoints_mesh_from_density(self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi)
-            dos_input.kpoints = dos_kpoints
+                # Use the supplied kpoints density for DOS
+                dos_kpoints = orm.KpointsData()
+                dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
+                dos_kpoints.set_kpoints_mesh_from_density(self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi)
+                dos_input.kpoints = dos_kpoints
 
             # Special treatment - combine the parameters
             parameters = inputs.parameters.get_dict()


### PR DESCRIPTION
Change `python-versino` to `python` as the name of the variable in the `matrix`. This result in empty version string for python resulting in conda picking the latest version, but python=3.13 is incompatible with `aiida-core>=2.6`.

Also includes a minor update to input generation code for the DOS workchain. We should improve the handing of the DOS/bands inputs in future. 
