### PR TITLE
Adding parameters output node and parsing all parameters inputs

### DIFF
--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -184,10 +184,7 @@ class VaspCalculation(VaspCalcBase):
             help='The output dos.',
         )
         spec.output(
-            'parameters',
-            valid_type=orm.Dict,
-            required=False,
-            help='All input parameters including the default values.'
+            'parameters', valid_type=orm.Dict, required=False, help='All input parameters including the default values.'
         )
         # Standalone array quantities
         for name in ['hessian', 'dynmat', 'born_charges', 'dielectrics']:

--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -183,6 +183,12 @@ class VaspCalculation(VaspCalcBase):
             required=False,
             help='The output dos.',
         )
+        spec.output(
+            'parameters',
+            valid_type=orm.Dict,
+            required=False,
+            help='All input parameters including the default values.'
+        )
         # Standalone array quantities
         for name in ['hessian', 'dynmat', 'born_charges', 'dielectrics']:
             spec.output(

--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -43,7 +43,7 @@ class VasprunParser(BaseFileParser):
             'maximum_stress',
             'band_properties',
             'version',
-            'parameters'
+            'parameters',
         ],
         'energy_type': ['energy_extrapolated'],
         'electronic_step_energies': False,
@@ -135,7 +135,7 @@ class VasprunParser(BaseFileParser):
             'inputs': [],
             'name': 'parameters',
             'prerequesites': [],
-        }
+        },
     }
 
     # Mapping of the energy names to those returned by parsevasp.vasprunl.Xml
@@ -672,7 +672,7 @@ class VasprunParser(BaseFileParser):
             occ = np.array([occupancies['up'], occupancies['down']])
 
         return get_band_properties(eig, occ)
-    
+
     @property
     def parameters(self):
         """
@@ -683,8 +683,6 @@ class VasprunParser(BaseFileParser):
         parameters = self._content_parser.get_parameters()
 
         return parameters
-
-
 
 
 def _build_structure(lattice):

--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -43,6 +43,7 @@ class VasprunParser(BaseFileParser):
             'maximum_stress',
             'band_properties',
             'version',
+            'parameters'
         ],
         'energy_type': ['energy_extrapolated'],
         'electronic_step_energies': False,
@@ -130,6 +131,11 @@ class VasprunParser(BaseFileParser):
             'name': 'version',
             'prerequisites': [],
         },
+        'parameters': {
+            'inputs': [],
+            'name': 'parameters',
+            'prerequesites': [],
+        }
     }
 
     # Mapping of the energy names to those returned by parsevasp.vasprunl.Xml
@@ -666,6 +672,19 @@ class VasprunParser(BaseFileParser):
             occ = np.array([occupancies['up'], occupancies['down']])
 
         return get_band_properties(eig, occ)
+    
+    @property
+    def parameters(self):
+        """
+        Fetch the parsed input parameters which will include default values
+        defined in the XML file.
+        """
+
+        parameters = self._content_parser.get_parameters()
+
+        return parameters
+
+
 
 
 def _build_structure(lattice):

--- a/src/aiida_vasp/parsers/neb.py
+++ b/src/aiida_vasp/parsers/neb.py
@@ -4,18 +4,6 @@ from aiida_vasp.parsers.content_parsers import *
 
 from .vasp import MissingFileError, NotificationComposer, QuantityMissingError, VaspParser, get_structure_node
 
-DEFAULT_QUANTITIES = (
-    'total_energies',
-    'maximum_stress',
-    'maximum_force',
-    'notifications',
-    'run_status',
-    'run_stats',
-    'version',
-    'band_properties',
-)
-
-
 DEFAULT_EXCLUDED_QUANTITIES = (
     'energies',
     'chgcar',

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -344,14 +344,6 @@ class VaspParser(Parser):
             error = self._check_vasp_errors(self.parser_notifications)
             return error
 
-    # def _compose_parameters(self, quantities_each):
-    #     """
-    #     Compose the `parameters` output node.
-    #     """
-    #     out_dict = {}
-    #     gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
-    #     return orm.Dict(dict=out_dict)
-
     def _compose_misc(self, quantities_each):
         """Compose the `misc` output node"""
 

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -545,7 +545,6 @@ def gather_quantities(quantities_each, namespace, dst, fields, flatten_dict=Fals
     """
     Gather quantities and put them into the target dictionary
     """
-    print('Gather Quantities')
     for key, value in quantities_each.get(namespace, {}).items():
         if key in fields:
             if isinstance(value, dict) and flatten_dict:

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -52,17 +52,6 @@ class MissingFileError(ParserError):
     pass
 
 
-DEFAULT_QUANTITIES = (
-    'total_energies',
-    'maximum_stress',
-    'maximum_force',
-    'notifications',
-    'run_status',
-    'run_stats',
-    'version',
-    'band_properties',
-)
-
 DEFAULT_EXCLUDED_QUANTITIES = (
     'energies',
     'chgcar',
@@ -72,6 +61,7 @@ DEFAULT_EXCLUDED_QUANTITIES = (
     'magnetization_density',
     'elastic_moduli',
     'symmetries',
+    'parameters',  # The parameters used for the calculation
 )
 
 DEFAULT_EXCLUDED_NODE = tuple(['bands', 'dos', 'kpoints', 'trajectory'])
@@ -103,6 +93,7 @@ MISC_QUANTITIES = (
     'fermi_level',
     'band_properties',
     'magnetization',
+    'parameters',
 )
 
 # Miscellaneous quantities that should be collected into an `arrays`` node
@@ -353,13 +344,13 @@ class VaspParser(Parser):
             error = self._check_vasp_errors(self.parser_notifications)
             return error
 
-    def _compose_parameters(self, quantities_each):
-        """
-        Compose the `parameters` output node.
-        """
-        out_dict = {}
-        gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
-        return orm.Dict(dict=out_dict)
+    # def _compose_parameters(self, quantities_each):
+    #     """
+    #     Compose the `parameters` output node.
+    #     """
+    #     out_dict = {}
+    #     gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
+    #     return orm.Dict(dict=out_dict)
 
     def _compose_misc(self, quantities_each):
         """Compose the `misc` output node"""

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -353,6 +353,14 @@ class VaspParser(Parser):
             error = self._check_vasp_errors(self.parser_notifications)
             return error
 
+    def _compose_parameters(self, quantities_each):
+        """
+        Compose the `parameters` output node.
+        """
+        out_dict = {}
+        gather_quantities(quantities_each, self.user_config.file_mapping['vasprun.xml'], out_dict, ('parameters'))
+        return orm.Dict(dict=out_dict)
+
     def _compose_misc(self, quantities_each):
         """Compose the `misc` output node"""
 
@@ -537,6 +545,7 @@ def gather_quantities(quantities_each, namespace, dst, fields, flatten_dict=Fals
     """
     Gather quantities and put them into the target dictionary
     """
+    print('Gather Quantities')
     for key, value in quantities_each.get(namespace, {}).items():
         if key in fields:
             if isinstance(value, dict) and flatten_dict:

--- a/tests/parsers/test_new_parser.py
+++ b/tests/parsers/test_new_parser.py
@@ -22,6 +22,14 @@ def test_parser_bare(calc_with_retrieved, request):
     assert 'arrays' in parser.outputs
     assert 'dielectrics`' not in parser.outputs
     assert 'born_charges' not in parser.outputs
+    assert 'parameters' not in parser.outputs['misc']
+
+    # Test the parameters outputs
+    node = calc_with_retrieved(file_path, {'parser_settings': {'include_quantity': ['parameters']}})
+    parser = VaspParser(node)
+    parser.parse(retrieved_tempoary_folder=file_path)
+    assert 'parameters' in parser.outputs['misc']
+    assert 'system' in parser.outputs['misc']['parameters']
 
 
 @pytest.fixture


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Description
I have modified the parsevasp module to parse all the input parameters which I need for a project. This includes all default values defined by VASP and printed in the XML file. The parsevasp changes have a pull request as well.