### PR TITLE
Added option to have additional restart files

### DIFF
--- a/src/aiida_vasp/calcs/base.py
+++ b/src/aiida_vasp/calcs/base.py
@@ -117,6 +117,7 @@ class VaspCalcBase(CalcJob):
         restart_folder = self.inputs.restart_folder
         computer = self.node.computer
         included = ['CHGCAR', 'WAVECAR']
+        included += self.inputs.settings.base.attributes.get('ADDITIONAL_REMOTE_COPY_LIST', [])
         existing_objects = restart_folder.listdir()
         to_copy = []
         for name in included:

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -72,22 +72,6 @@ class OptionContainer(BaseModel):
         return '\n'.join(lines)
 
 
-class CalcSettingsConfig(OptionContainer):
-    """Schema for the .setting port"""
-
-    parser_setting: Optional[dict] = Field(description='Settings for the parser')
-    ADDITIONAL_RETRIEVE_LIST: Optional[list] = Field(description='Additional list of files to be retrieved')
-    ADDITIONAL_RETRIEVE_TEMPORARY_LIST: Optional[list] = Field(
-        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
-    )
-    PROVENANCE_EXCLUDE_LIST: Optional[list] = Field(
-        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
-    )
-    ALWAYS_STORE: Optional[list] = Field(
-        description=('Additional list of files to be retrieved, ' 'but not store in the storage')
-    )
-
-
 class RelaxOptions(OptionContainer):
     """Options for VaspRelaxWorkChain"""
 
@@ -235,4 +219,26 @@ class BandOptions(OptionContainer):
     kpoints_per_split: int = Field(
         description='Number of kpoints per split for the band structure calculation',
         default=80,
+    )
+
+
+class CalcSettings(OptionContainer):
+    """Schema for the .setting port"""
+
+    parser_setting: Optional[dict] = Field(description='Settings for the parser')
+    ADDITIONAL_RETRIEVE_LIST: Optional[list] = Field(description='Additional list of files to be retrieved')
+    ADDITIONAL_RETRIEVE_TEMPORARY_LIST: Optional[list] = Field(
+        description=('Additional list of files to be retrieved, ' 'but not store in the storage'),
+    )
+    PROVENANCE_EXCLUDE_LIST: Optional[list] = Field(
+        description='Files to be excluded from the provenance storage, e.g. large files or large directories',
+    )
+    ALWAYS_STORE: Optional[list] = Field(
+        description=('Always store the retrieved files'),
+    )
+    PER_IMAGE_ADDITIONAL_RETRIEVE_LIST: Optional[list] = Field(
+        description=('Additional list of files to be retrieved per image for NEB calculations.'),
+    )
+    ADDITIONAL_REMOTE_COPY_LIST: Optional[list] = Field(
+        description=('Additional list of files to be copied when restarting calculations on a remote machine.'),
     )

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -223,7 +223,7 @@ class BandOptions(OptionContainer):
 
 
 class CalcSettings(OptionContainer):
-    """Schema for the .setting port"""
+    """Schema for the .settings port"""
 
     parser_setting: Optional[dict] = Field(description='Settings for the parser')
     ADDITIONAL_RETRIEVE_LIST: Optional[list] = Field(description='Additional list of files to be retrieved')


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes: #678

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Allow additional remote files to be copied when restarting a calculation using a `restart_folder` input.