### PR TITLE
Update the output nodes and quantities of the VaspCalculation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Now, one should use:
 
 ```python
 parser_settings = {
-'include_quantity': ['energies', 'forces', 'stress'],
+  include_node: ['energies', 'bands'],
 'electronic_step_energies': True
 }
 builder.settings = Dict({'parser_settings' : parser_settings})
@@ -55,11 +55,14 @@ energies = node.outputs.arrays.get_array("energy_extrapolated")
 forces = node.outputs.misc['forces']
 ```
 
-The new parser system adapts a parse-if-exists principles with some quantities disabled by default, such as
-the eigenvalues and electronic step energies. The `include_quantity` key in the `parser_settings` dictionary
-allows to selectively enable these quantities.
-If a quantity exists, the relavent output node would be created, but again some output nodes are disabled by default, such as `bands` and `dos` and `trajectory`. This is because the underlying quantities exist in almost
-all calculations, but the output are only useful in specific cases.
+The new parser system adapts a parse-if-exists principle with some quantities disabled by default, such as
+the eigenvalues and electronic step energies. The `'include_node'` key in the `parser_settings` dictionary
+allows to selectively enable output nodes.
+This is because some output nodes are disabled by default, such as `'bands'` and `'dos'` and `'trajectory'`. This is because the underlying quantities exist in almost all calculations, but the output are only useful in specific cases.
+
+Previously forces was stored in an `ArrayData` node with link name `forces`.
+Now the last forces and stress are stored in `misc` node (`Dict`) which is **enabled by default**.
+To obtain forces at every structure iteration, add `'trajectory'` to the `'include_node'` field in `parser_settings` as shown above.
 
 
 **Controlling workchains**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,75 @@ and this project adheres to \[Semantic Versioning\](<http://semver.org/spec/v2.0
 - No longer using `tox` for test running.
 - Switched to `ruff` from `pylint` for faster linting.
 
+**Notes for updating from v3.x.x to v4.x.x**
+
+**Configuring the parsers**
+
+The script for launching calculation should be updated. In particular, note that the new parser systems takes a
+different format for the `parser_settings`.
+
+Previously, this looks like:
+```python
+parser_settings = {
+        "add_energies": True,
+        "add_forces": True,
+        "add_stress": True,
+        "add_bands": True,
+        "electronic_step_energies": True,
+    }
+builder.settings = Dict({'parser_settings' : parser_settings})
+```
+
+Now, one should use:
+
+```python
+parser_settings = {
+'include_quantity': ['energies', 'forces', 'stress'],
+'electronic_step_energies': True
+}
+builder.settings = Dict({'parser_settings' : parser_settings})
+# Getting energies
+energies = node.outputs.arrays.get_array("energy_extrapolated")
+forces = node.outputs.misc['forces']
+```
+
+The new parser system adapts a parse-if-exists principles with some quantities disabled by default, such as
+the eigenvalues and electronic step energies. The `include_quantity` key in the `parser_settings` dictionary
+allows to selectively enable these quantities.
+If a quantity exists, the relavent output node would be created, but again some output nodes are disabled by default, such as `bands` and `dos` and `trajectory`. This is because the underlying quantities exist in almost
+all calculations, but the output are only useful in specific cases.
+
+
+**Controlling workchains**
+
+The `VaspConvergenceWorkChain`, `VaspRelaxWorkChain` and `VaspBandsWorkChain` are controlled by special ports
+`conv_settings`, `relax_settings` and `band_settings` respectively. These ports should be used to pass the
+desired settings to the respective workchains.
+Previously, each key is made a single input port, make these workchains takes a large amount of input nodes.
+
+
+**Deploying workchains**
+
+We now recommend using the `BuilderUpdater` system to quickly set up calculation with pre-define default calculation/code specific parameters and remote job launching settings.
+The old approach was to use a dictionary or a `ProcessBuilder` object, which requires the user to explicitly specify all the required inputs.
+
+While `BuilderUpdater` is a convenient way to quickly set up a calculation, it is not recommended to still
+manually verify the inputs in case of unexpected behavior.
+
+**Rerunning workchains**
+
+The workchain nowentry points such as `vasp.vasp` now points to different workchains. Unfortunately,
+this means that the `get_builder_restart` method no longer works.
+
+**Calculation and workchain output**
+
+There are a few notable changes to the calculation and workchain output
+
+- The forces of the calculations are now included in the `misc` output under the key `forces`. This quantities is parsed and stored by default.
+- The `arrays` output includes array-like quantities, such as `energy_extrapolated` of individual ionic steps (excluded by default).
+- The key under which the quantities are stored inside the `ArrayData` node of the `arrays`, `dielectrics` may change. Please refer to the [code](src/aiida_vasp/parsers/vasp.py) for details.
+
+
 ## \[v3.0.1\]
 
 **Changed**

--- a/docs/source/faq.md
+++ b/docs/source/faq.md
@@ -1,0 +1,33 @@
+# Frequently Asked Questions (FAQ)
+
+## How to obtain forces and stress of each ionic step?
+
+By default, only the forces, stress and energies of the last ionic step are stored in the `misc` output.
+If you want those for each ionic step, you can modify the parser to enable the output `trajectory` node:
+
+```python
+from aiida.orm import WorkflowFactory
+VaspWorkChain = WorkflowFactory('vasp.vasp')
+builder = VaspWorkChain.get_builder()
+settings ={'parser_settings': {'include_node': ['trajectory']}}
+builder.settings = settings
+```
+
+## Why the parser system is so complex?
+
+Unfortunately a single DFT calculation generates lots of data, only some of which are useful in most cases (i.e. energy, forces, stress) and it depends on the type of calculations run.
+
+A further complication is that VASP generate multiple output files and some *quantities* are repeated in different files.
+
+The role of the parser is to parse *quantities* from the files and organize them into different output nodes in a meaningful way. In addition, to avoid overfloing the database, some quantities / output nodes are excluded by default, and the user can choose to include them by setting `'include_quantity'` or `'include_node'` in the `'parser_settings'` dictionary inside the `settings` input node of the `VaspCalculation`/`VaspWorkChain`.
+
+The current logic of the parser system works like this:
+
+- Instantiate all content parser for each kind of output file, which essentially parse everything and store them as their own attributes
+- Collect quantities into a nested dictionary. All quantities declared as available by the content parser are collected unless they are explicitly _excluded_.
+    - There is a default list of excluded quantities, and the user can include them by setting `include_quantity: ['<quantitity']` in parser settings
+    - The main reason for having a list of default excluded quantities is because some quantities are not needed in most cases, but the *node* containing them should still be created (e.g. the `misc` output).
+- Try to compose all nodes except those are excluded by default (again, can be overridden by `include_node: ['<node>']`).
+    - If a node cannot be composed due to lack of quantity, we simply skip it, as it is the responsibility of the `CalcJob` and the higher-level workflows to check for required output.
+    - Again the reason for having excluded nodes is that some nodes are only needed in specific cases, but the underlying quantities are always available. For example, the `'eigenvalues'` are avaliable in every single calculation, but they are mostly only needed for constructing the bands structure.
+- Finally, we collect the compose nodes and store them under the `outputs` attribute which is a dictionary.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -165,6 +165,7 @@ howto/index
 developments/index
 apidocs/index
 ./changelog.md
+./faq.md
 ```
 
 

--- a/src/aiida_vasp/__init__.py
+++ b/src/aiida_vasp/__init__.py
@@ -1,3 +1,3 @@
 """AiiDA plugin for running and managing VASP calculations."""
 
-__version__ = '4.0.1'
+__version__ = '4.1.0'

--- a/src/aiida_vasp/__init__.py
+++ b/src/aiida_vasp/__init__.py
@@ -1,3 +1,3 @@
 """AiiDA plugin for running and managing VASP calculations."""
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'

--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -138,6 +138,8 @@ class VaspCalculation(VaspCalcBase):
             valid_type=orm.Dict,
             help='The output parameters containing smaller quantities that do not depend on system size.',
         )
+        # Mark misc as the default output node
+        spec.default_output_node = 'misc'
         spec.output(
             'structure',
             valid_type=orm.StructureData,

--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -187,6 +187,18 @@ class VaspCalculation(VaspCalcBase):
             help='The output dos.',
         )
         spec.output(
+            'energies',
+            valid_type=orm.ArrayData,
+            required=False,
+            help='Energies of the calculation at each ionic/electronic step.',
+        )
+        spec.output(
+            'projectors',
+            valid_type=orm.ArrayData,
+            required=False,
+            help='The projectors for the calculation.',
+        )
+        spec.output(
             'parameters', valid_type=orm.Dict, required=False, help='All input parameters including the default values.'
         )
         # Standalone array quantities

--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -94,7 +94,17 @@ class VasprunParser(BaseFileParser):
             'name': 'stress',
             'prerequisites': [],
         },
+        'all_stress': {
+            'inputs': [],
+            'name': 'forces',
+            'prerequisites': [],
+        },
         'forces': {
+            'inputs': [],
+            'name': 'forces',
+            'prerequisites': [],
+        },
+        'all_forces': {
             'inputs': [],
             'name': 'forces',
             'prerequisites': [],
@@ -299,18 +309,16 @@ class VasprunParser(BaseFileParser):
     @property
     def forces(self):
         """
-        Fetch forces.
-
-        This container should contain all relevant forces.
-        Currently, it only contains the final forces, which can be obtain
-        by the id `final_forces`.
-
+        Fetch final forces.
         """
+        return self.final_forces
 
-        final_forces = self.final_forces
-        forces = {'final': final_forces}
-
-        return forces
+    @property
+    def all_forces(self):
+        """
+        Fetch final forces.
+        """
+        return {str(key): value for key, value in self._content_parser.get_forces('all').items()}
 
     @property
     def maximum_force(self):
@@ -356,9 +364,14 @@ class VasprunParser(BaseFileParser):
 
         """
 
-        final_stress = self.final_stress
-        stress = {'final': final_stress}
-        return stress
+        return self.final_stress
+
+    @property
+    def all_stress(self):
+        """
+        Fetch final forces.
+        """
+        return {str(key): value for key, value in self._content_parser.get_stress('all').items()}
 
     @property
     def maximum_stress(self):

--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -39,8 +39,6 @@ class VasprunParser(BaseFileParser):
             'forces',
             'stress',
             'total_energies',
-            'maximum_force',
-            'maximum_stress',
             'band_properties',
             'version',
             'parameters',
@@ -129,8 +127,6 @@ class VasprunParser(BaseFileParser):
             'name': 'fermi_level',
             'prerequisites': [],
         },
-        'maximum_force': {'inputs': [], 'name': 'maximum_force', 'prerequisites': []},
-        'maximum_stress': {'inputs': [], 'name': 'maximum_stress', 'prerequisites': []},
         'band_properties': {
             'inputs': [],
             'name': 'band_properties',
@@ -321,16 +317,6 @@ class VasprunParser(BaseFileParser):
         return {str(key): value for key, value in self._content_parser.get_forces('all').items()}
 
     @property
-    def maximum_force(self):
-        """Fetch the maximum force of at the last ionic run."""
-
-        forces = self.final_forces
-        if forces is None:
-            return None
-        norm = np.linalg.norm(forces, axis=1)
-        return np.amax(np.abs(norm))
-
-    @property
     def last_stress(self):
         """
         Fetch stess.
@@ -372,16 +358,6 @@ class VasprunParser(BaseFileParser):
         Fetch final forces.
         """
         return {str(key): value for key, value in self._content_parser.get_stress('all').items()}
-
-    @property
-    def maximum_stress(self):
-        """Fetch the maximum stress of at the last ionic run."""
-
-        stress = self.final_stress
-        if stress is None:
-            return None
-        norm = np.linalg.norm(stress, axis=1)
-        return np.amax(np.abs(norm))
 
     @property
     def trajectory(self):

--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -92,17 +92,7 @@ class VasprunParser(BaseFileParser):
             'name': 'stress',
             'prerequisites': [],
         },
-        'all_stress': {
-            'inputs': [],
-            'name': 'forces',
-            'prerequisites': [],
-        },
         'forces': {
-            'inputs': [],
-            'name': 'forces',
-            'prerequisites': [],
-        },
-        'all_forces': {
             'inputs': [],
             'name': 'forces',
             'prerequisites': [],
@@ -310,13 +300,6 @@ class VasprunParser(BaseFileParser):
         return self.final_forces
 
     @property
-    def all_forces(self):
-        """
-        Fetch final forces.
-        """
-        return {str(key): value for key, value in self._content_parser.get_forces('all').items()}
-
-    @property
     def last_stress(self):
         """
         Fetch stess.
@@ -351,13 +334,6 @@ class VasprunParser(BaseFileParser):
         """
 
         return self.final_stress
-
-    @property
-    def all_stress(self):
-        """
-        Fetch final forces.
-        """
-        return {str(key): value for key, value in self._content_parser.get_stress('all').items()}
 
     @property
     def trajectory(self):

--- a/src/aiida_vasp/parsers/neb.py
+++ b/src/aiida_vasp/parsers/neb.py
@@ -29,8 +29,6 @@ DEFAULT_FILE_MAPPING = {
 }
 MISC_QUANTITIES = (
     'total_energies',
-    'maximum_stress',
-    'maximum_force',
     'notifications',
     'run_status',
     'run_stats',

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -54,6 +54,8 @@ class MissingFileError(ParserError):
 
 DEFAULT_EXCLUDED_QUANTITIES = (
     'energies',
+    'all_forces',
+    'all_stress',
     'chgcar',
     'wavecar',
     'projectors',

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -80,8 +80,6 @@ DEFAULT_FILE_MAPPING = {
 }
 MISC_QUANTITIES = (
     'total_energies',
-    'maximum_stress',
-    'maximum_force',
     'notifications',
     'run_status',
     'run_stats',
@@ -108,6 +106,8 @@ STANDALONE_ARRAY_QUANTITIES = {
     'dielectrics': 'vasprun.xml',
     'dynmat': 'vasprun.xml',
     'hessian': 'vasprun.xml',
+    'projectors': 'vasprun.xml',
+    'energies': 'vasprun.xml',
 }
 
 
@@ -384,14 +384,6 @@ class VaspParser(Parser):
     def _compose_arrays(self, quantities_each):
         """Generate the generic `arrays` output node"""
         out_arrays = {}
-        collected_arrays = {}
-        gather_quantities(
-            quantities_each, 'vasprun.xml', collected_arrays, COLLECTED_ARRAY_QUANTITIES, flatten_dict=True
-        )
-        # Remove None values in the arrays
-        collected_arrays = {key: value for key, value in collected_arrays.items() if value is not None}
-        if len(collected_arrays) > 0:
-            out_arrays['arrays'] = orm.ArrayData(collected_arrays)
 
         # Compose the standalone arrays - each corresponds to a single quantity
         for name, file_name in STANDALONE_ARRAY_QUANTITIES.items():

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -53,20 +53,12 @@ class MissingFileError(ParserError):
 
 
 DEFAULT_EXCLUDED_QUANTITIES = (
-    'energies',
-    'all_forces',
-    'all_stress',
-    'chgcar',
-    'wavecar',
-    'projectors',
-    'charge_density',
-    'magnetization_density',
     'elastic_moduli',
     'symmetries',
     'parameters',  # The parameters used for the calculation
 )
 
-DEFAULT_EXCLUDED_NODE = tuple(['bands', 'dos', 'kpoints', 'trajectory'])
+DEFAULT_EXCLUDED_NODE = ('bands', 'dos', 'kpoints', 'trajectory', 'energies', 'wavecar', 'chgcar', 'projectors')
 
 DEFAULT_REQUIRED_QUANTITIES = ('run_status', 'run_stats')
 
@@ -301,12 +293,8 @@ class VaspParser(Parser):
         parse_and_add('vasp_output', StreamParser, required=True)
         parse_and_add('CONTCAR', PoscarParser, required=True)
 
-        # Parse if needed
-        if any(x not in self.quantities_to_exclude for x in ('charge_density', 'magnetization_density')):
-            parse_and_add('CHGCAR', ChgcarParser, required=True)
-
         if user_config.kpoints_from_ibzkpt:
-            parse_and_add('IBZKPT', ChgcarParser, required=True)
+            parse_and_add('IBZKPT', KpointsParser, required=True)
 
         exit_code = self._post_process_quantities()
         if exit_code is not None:
@@ -379,12 +367,38 @@ class VaspParser(Parser):
             raise QuantityMissingError()
         return get_structure_node(data)
 
+    def _compose_wavecar(self, quantities_each):
+        """Compose the `wavecar` output node"""
+
+        # Check if WAVECAR is present in the retrieved folder
+        if 'WAVECAR' in self.retrieve_object_names:
+            from aiida_vasp.data.wavefun import WavefunData
+
+            with self.retrieved.base.repository.open('WAVECAR', 'rb') as handler:
+                self.outputs['wavecar'] = WavefunData(file=handler, filename='WAVECAR')
+        else:
+            self.logger.warning('WAVECAR is not present in the retrieved folder.')
+
+    def _compose_chgcar(self, quantities_each):
+        """Compose the `chgcar` output node"""
+
+        # Check if WAVECAR is present in the retrieved folder
+        if 'CHGCAR' in self.retrieve_object_names:
+            from aiida_vasp.data.chargedensity import ChargedensityData
+
+            with self.retrieved.base.repository.open('CHGCAR', 'rb') as handler:
+                self.outputs['chgcar'] = ChargedensityData(file=handler, filename='CHGCAR')
+        else:
+            self.logger.warning('CHGCAR is not present in the retrieved folder.')
+
     def _compose_arrays(self, quantities_each):
         """Generate the generic `arrays` output node"""
         out_arrays = {}
 
         # Compose the standalone arrays - each corresponds to a single quantity
         for name, file_name in STANDALONE_ARRAY_QUANTITIES.items():
+            if name in self.nodes_to_exclude:
+                continue
             array_node = self._make_standalone_array(quantities_each, name, file_name)
             if array_node is not None:
                 out_arrays[name] = array_node
@@ -438,6 +452,8 @@ class VaspParser(Parser):
                     self.logger.warning(f'Cannot set array {key}: {value} in TrajectoryData as it is not numerical.')
                 else:
                     node.set_array(key, value)
+            for key, value in quantities_each['vasprun.xml']['energies'].items():
+                node.set_array(key, value)
             return node
         return None
 

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -98,9 +98,7 @@ MISC_QUANTITIES = (
 
 ALLOW_EMPTY = ('notifications',)
 
-# Miscellaneous quantities that should be collected into an `arrays`` node
-COLLECTED_ARRAY_QUANTITIES = ('projectors', 'energies')
-# Standalone array quantities that should be stored in a separate node
+# Quantities that should be stored inside separate nodes
 STANDALONE_ARRAY_QUANTITIES = {
     'born_charges': 'vasprun.xml',
     'dielectrics': 'vasprun.xml',

--- a/src/aiida_vasp/utils/__init__.py
+++ b/src/aiida_vasp/utils/__init__.py
@@ -1,0 +1,10 @@
+"""
+Utility functions for VASP calculations.
+"""
+
+import numpy as np
+
+
+def get_maximum_force(forces):
+    norm = np.linalg.norm(forces, axis=1)
+    return np.amax(np.abs(norm))

--- a/src/aiida_vasp/utils/export.py
+++ b/src/aiida_vasp/utils/export.py
@@ -50,7 +50,7 @@ def export_vasp_calc(node, folder, decompress=False, include_potcar=True):
     elif isinstance(node, WorkChainNode):
         # In this case the node is an workchain we export the
         # 'retrieved' output link and trace to its ancestor
-        calcjob = retrieved.get_incoming(link_label_filter='retrieved', link_type=LinkType.CREATE).one().node
+        calcjob = retrieved.base.links.get_incoming(link_label_filter='retrieved', link_type=LinkType.CREATE).one().node
     else:
         raise RuntimeError(f'The node {node} is not a valid calculation')
     info_file = folder / ('aiida_info')
@@ -218,7 +218,7 @@ def copy_from_aiida(name: str, node, dst: Path, decompress=False, exclude=None):
             copy_from_aiida(os.path.join(name, sub_obj.name), node, dst, exclude=exclude)
     else:
         # It is a file
-        with node.open(name, mode='rb') as fsource:
+        with node.base.repository.open(name, mode='rb') as fsource:
             # Make parent directory if needed
             frepo_path = dst / name
             Path(frepo_path.parent).mkdir(exist_ok=True, parents=True)

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -125,7 +125,7 @@ class BaseBuilderUpdater:
         preset_name: Union[None, str] = None,
         builder: Union[ProcessBuilder, None] = None,
         verbose=False,
-        inputset=None,
+        set_name=None,
     ):
         """Instantiate a pipeline"""
         # Configure the builder
@@ -140,7 +140,7 @@ class BaseBuilderUpdater:
             preset_name = DEFAULT_PRESET
         self.preset_name = preset_name
         self.preset = VaspPresetConfig.from_file(preset_name)
-        self.inputset = inputset if inputset is not None else self.preset.inputset
+        self.set_name = set_name if set_name is not None else self.preset.inputset
 
     @property
     def builder(self) -> ProcessBuilder:
@@ -205,6 +205,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         root_namespace: Optional[str] = None,
         code: Optional[str] = None,
         verbose: bool = False,
+        set_name: Optional[str] = None,
     ):
         """
         Initialise the update object.
@@ -215,7 +216,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         :param root_namespace: The namespace to be assumed to be the *root*, e.g. where the input structure
           should be specified.
         """
-        super().__init__(preset_name=preset_name, builder=builder, verbose=verbose)
+        super().__init__(preset_name=preset_name, builder=builder, verbose=verbose, set_name=set_name)
         # Define the root namespace - e.g. the VaspWorkChain namespace where structure should be specified
         if root_namespace is None:
             self.root_namespace = self._builder
@@ -223,8 +224,6 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             self.root_namespace = root_namespace
 
         self.namespace_vasp = self._builder
-        # Defult
-        self.inputset = None
         self.code = self.preset.default_code if code is None else code
 
     @property
@@ -253,7 +252,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             logging.info(f'Using code {code}')
         self.use_inputset(
             initial_structure,
-            set_name=self.inputset,
+            set_name=self.set_name,
             overrides=overrides,
             apply_preset=True,
             code=code,
@@ -293,7 +292,6 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.namespace_vasp.potential_mapping = orm.Dict(dict=inset.get_pp_mapping(structure))
         self.namespace_vasp.kpoints_spacing = orm.Float(inset.get_kpoints_spacing())
         setattr(self.root_namespace, structure_node_name, structure)
-        self.inputset = inset
         return self
 
     def set_kspacing(self, kspacing: float) -> 'VaspBuilderUpdater':

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -12,6 +12,7 @@ Inputs
 No added wrapper etc.
 """
 
+import numpy as np
 from aiida import orm
 from aiida.engine import WorkChain, append_, calcfunction
 from aiida.plugins import WorkflowFactory
@@ -168,16 +169,22 @@ class VaspConvergenceWorkChain(WorkChain, WithBuilderUpdater):
         Collect data to be plotted/analysed against the cut off energy and kpoints spacing
         """
 
+        def get_maximum(forces):
+            if forces is None:
+                return None
+            norm = np.linalg.norm(forces, axis=1)
+            return np.amax(np.abs(norm))
+
         def collect_data(workchain, energy_key):
             """Collect the data from workchain output"""
             output = workchain.outputs.misc.get_dict()
             data = {}
-            data['maximum_force'] = output.get('maximum_force')
+            data['maximum_force'] = get_maximum(output.get('forces'))
             # Extract the magnetization
             magnetization = output.get('magnetization')
             if magnetization:
                 data['magnetization'] = magnetization[0]
-            data['maximum_stress'] = output.get('maximum_stress', None)
+            data['maximum_stress'] = get_maximum(output.get('stress'))
             data['energy'] = output['total_energies'][energy_key]
             return data
 

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -173,7 +173,7 @@ class VaspConvergenceWorkChain(WorkChain, WithBuilderUpdater):
             if forces is None:
                 return None
             norm = np.linalg.norm(forces, axis=1)
-            return np.amax(np.abs(norm))
+            return np.amax(norm)
 
         def collect_data(workchain, energy_key):
             """Collect the data from workchain output"""

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -450,11 +450,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater):
         next_workchain_exit_message = workchain.exit_message
         if not next_workchain_exit_status:
             self.ctx.exit_code = self.exit_codes.NO_ERROR  # pylint: disable=no-member
-        elif (
-            'misc' in workchain.outputs
-            and 'structure' in workchain.outputs
-            and 'maximum_force' in workchain.outputs.misc.get_dict()
-        ):
+        elif 'misc' in workchain.outputs and 'structure' in workchain.outputs and 'forces' in workchain.outputs.misc:
             self.ctx.exit_code = self.exit_codes.NO_ERROR  # pylint: disable=no-member
             self.report(
                 f'The called {workchain.__class__.__name__}<{workchain.pk}> returned a non-zero exit status.'
@@ -562,7 +558,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater):
             # BONAN: Check force - this is because the underlying VASP calculation may not have finished with
             # fully converge geometry, and the vasp plugin does not check it.
             force_cut_off = relax_settings.get('force_cutoff')
-            max_force = workchain.outputs.misc.base.attributes.get('maximum_force')
+            max_force = get_maximum_force(workchain.outputs.misc.get('forces'))
             if force_cut_off is not None and max_force > force_cut_off:
                 self.report(
                     f'Maximum force in the structure {max_force:.4g} excess the cut-off limit {force_cut_off:.4g}'
@@ -719,7 +715,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater):
         # Try to get the smearing type, there is no point to perform check if the tetrahedral smearing is used.
         if not detect_tetrahedral_method(workchain.inputs.parameters.get_dict()):
             max_force_threshold = self.ctx.relax_settings.get('force_cutoff', 0.03)
-            actual_max_force = workchain.outputs.misc['maximum_force']
+            actual_max_force = get_maximum_force(workchain.outputs.misc['forces'])
             if (
                 actual_max_force > max(max_force_threshold * 1.5, max_force_threshold + 0.001)
                 and self.perform_relaxation()
@@ -881,3 +877,9 @@ def detect_tetrahedral_method(input_dict: dict) -> bool:
     if input_dict.get('smearing', {}).get('tetra') and not incar.get('ismear'):
         return True
     return False
+
+
+def get_maximum_force(forces):
+    """Return the maximum value of an array of forces with size (N, 3)"""
+    norm = np.linalg.norm(forces, axis=1)
+    return np.amax(norm)

--- a/tests/calcs/test_vasp.py
+++ b/tests/calcs/test_vasp.py
@@ -208,7 +208,7 @@ def test_vasp_calc(fresh_aiida_env, run_vasp_process):
     # None if parsing somehow failed.
     misc = results['misc'].get_dict()
     assert 'total_energies' in misc
-    assert 'maximum_stress' in misc
+    assert 'stress' in misc
     assert 'run_status' in misc
     assert 'run_stats' in misc
 

--- a/tests/parsers/content_parsers/test_vasprun_parser.py
+++ b/tests/parsers/content_parsers/test_vasprun_parser.py
@@ -96,8 +96,6 @@ def test_parse_vasprun_final_force(vasprun_parser):
     np.testing.assert_allclose(forces[0], forces_check[0], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(forces[2], forces_check[2], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(forces[7], forces_check[7], atol=0.0, rtol=1.0e-7)
-    all_forces = vasprun_parser.all_forces
-    assert '1' in all_forces
 
 
 @pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
@@ -116,9 +114,6 @@ def test_parse_vasprun_final_stress(vasprun_parser):
     np.testing.assert_allclose(stress[0], stress_check[0], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(stress[1], stress_check[1], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(stress[2], stress_check[2], atol=0.0, rtol=1.0e-7)
-
-    all_stress = vasprun_parser.all_stress
-    assert '1' in all_stress
 
 
 @pytest.mark.parametrize(['vasprun_parser'], [('dielectric',)], indirect=True)

--- a/tests/parsers/content_parsers/test_vasprun_parser.py
+++ b/tests/parsers/content_parsers/test_vasprun_parser.py
@@ -80,7 +80,6 @@ def test_parse_vasprun_structure(vasprun_parser):
 def test_parse_vasprun_final_force(vasprun_parser):
     """Load a reference vasprun.xml and test that the forces are returned correctly."""
     forces = vasprun_parser.get_quantity('forces')
-    forces = forces['final']
     forces_check = np.array(
         [
             [-0.24286901, 0.0, 0.0],
@@ -97,13 +96,14 @@ def test_parse_vasprun_final_force(vasprun_parser):
     np.testing.assert_allclose(forces[0], forces_check[0], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(forces[2], forces_check[2], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(forces[7], forces_check[7], atol=0.0, rtol=1.0e-7)
+    all_forces = vasprun_parser.all_forces
+    assert '1' in all_forces
 
 
 @pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
 def test_parse_vasprun_final_stress(vasprun_parser):
     """Load a reference vasprun.xml and test that the stress are returned correctly."""
     stress = vasprun_parser.get_quantity('stress')
-    stress = stress['final']
     stress_check = np.array(
         [
             [-0.38703740, 0.00000000, 0.00000000],
@@ -111,10 +111,14 @@ def test_parse_vasprun_final_stress(vasprun_parser):
             [0.00000000, -25.93894358, 12.52362644],
         ]
     )
+
     # Check entries
     np.testing.assert_allclose(stress[0], stress_check[0], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(stress[1], stress_check[1], atol=0.0, rtol=1.0e-7)
     np.testing.assert_allclose(stress[2], stress_check[2], atol=0.0, rtol=1.0e-7)
+
+    all_stress = vasprun_parser.all_stress
+    assert '1' in all_stress
 
 
 @pytest.mark.parametrize(['vasprun_parser'], [('dielectric',)], indirect=True)

--- a/tests/parsers/test_new_parser.py
+++ b/tests/parsers/test_new_parser.py
@@ -35,7 +35,6 @@ def test_parser_bare(calc_with_retrieved, request):
     node = calc_with_retrieved(file_path, {'parser_settings': {'include_quantity': ['projectors']}})
     parser = VaspParser(node)
     parser.parse(retrieved_tempoary_folder=file_path)
-    assert 'arrays' in parser.outputs
     assert 'dielectrics`' not in parser.outputs
     assert 'born_charges' not in parser.outputs
     assert 'parameters' not in parser.outputs['misc']
@@ -184,8 +183,8 @@ def test_parser_disp_details(parser_with_retrieved):
     assert data_dict['run_status']['nelm'] == 60
     assert data_dict['run_status']['nsw'] == 61
     assert data_dict['fermi_level'] == pytest.approx(6.17267267)
-    assert data_dict['maximum_stress'] == pytest.approx(42.96872956444064)
-    assert data_dict['maximum_force'] == pytest.approx(0.21326679)
+    assert np.amax(np.linalg.norm(data_dict['stress'], axis=1)) == pytest.approx(42.96872956444064)
+    assert np.amax(np.abs(np.linalg.norm(data_dict['forces'], axis=1))) == pytest.approx(0.21326679)
     assert data_dict['total_energies']['energy_extrapolated'] == pytest.approx(-10.823296)
 
 
@@ -194,7 +193,7 @@ def test_vasprun_parsing(parser_with_vasprun):
         {'parser_settings': {'check_completeness': False, 'required_quantity': [], 'critical_objects': []}}
     )
     misc = parser.outputs['misc'].get_dict()
-    shoud_exists = ['fermi_level', 'forces', 'maximum_force', 'stress', 'maximum_stress', 'band_properties']
+    shoud_exists = ['fermi_level', 'forces', 'stress', 'band_properties']
     for name in shoud_exists:
         assert name in misc
 
@@ -221,8 +220,8 @@ def test_basic_run(parser_with_retrieved):
     assert not misc['band_properties']['is_direct_gap']
     assert misc['version'] == '5.3.5'
     assert misc['total_energies']['energy_extrapolated'] == pytest.approx(-36.09616894)
-    assert misc['maximum_stress'] == pytest.approx(8.50955439)
-    assert misc['maximum_force'] == pytest.approx(0.0)
+    assert np.amax(np.linalg.norm(misc['stress'], axis=1)) == pytest.approx(8.50955439)
+    assert np.amax(np.linalg.norm(misc['forces'], axis=1)) == pytest.approx(0.0)
     assert misc['run_status']['nelm'] == 60
     assert misc['run_status']['last_iteration_index'] == [1, 2]
     assert misc['run_status']['nsw'] == 0
@@ -261,10 +260,10 @@ def test_relax_run(parser_with_retrieved):
         },
     )
 
-    array = parser.outputs['arrays']
-    energies_ext = array.get_array('energies_energy_extrapolated')
-    energies_ext_elec = array.get_array('energies_energy_extrapolated_electronic')
-    energies_elec_steps = array.get_array('energies_electronic_steps')
+    array = parser.outputs['energies']
+    energies_ext = array.get_array('energy_extrapolated')
+    energies_ext_elec = array.get_array('energy_extrapolated_electronic')
+    energies_elec_steps = array.get_array('electronic_steps')
     test_array_energies = [
         np.array(
             [

--- a/tests/parsers/test_new_parser.py
+++ b/tests/parsers/test_new_parser.py
@@ -38,6 +38,8 @@ def test_parser_bare(calc_with_retrieved, request):
     assert 'dielectrics`' not in parser.outputs
     assert 'born_charges' not in parser.outputs
     assert 'parameters' not in parser.outputs['misc']
+    assert 'trajectory' not in parser.outputs
+    assert 'energies' not in parser.outputs
 
     # Test the parameters outputs
     node = calc_with_retrieved(file_path, {'parser_settings': {'include_quantity': ['parameters']}})
@@ -251,7 +253,8 @@ def test_relax_run(parser_with_retrieved):
         'relax',
         {
             'parser_settings': {
-                'include_quantity': ['born_charges', 'energies'],
+                'include_quantity': ['born_charges'],
+                'include_node': ['energies', 'trajectory'],
                 'check_completeness': False,
                 'required_quantity': [],
                 'electronic_step_energies': True,
@@ -366,6 +369,17 @@ def test_relax_run(parser_with_retrieved):
         ]
     )
     np.testing.assert_allclose(test_array, energies_ext, atol=0.0, rtol=1.0e-7)
+
+    traj = parser.outputs['trajectory']
+    assert 'energy_extrapolated' in traj.get_arraynames()
+    assert 'forces' in traj.get_arraynames()
+    assert 'stress' in traj.get_arraynames()
+    assert traj.get_array('forces').shape == (19, 8, 3)
+    traj.get_stepids()
+    traj.get_cells()
+    traj.get_positions()
+    traj.get_step_data(1)
+    assert isinstance(traj.get_step_structure(1), orm.StructureData)
 
 
 def test_basic(parser_with_retrieved):

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -25,7 +25,7 @@ def test_vasp_wc(fresh_aiida_env, run_vasp_process):
     assert 'misc' in results
     assert 'remote_folder' in results
     misc = results['misc'].get_dict()
-    assert np.amax(np.linalg.norm(misc['stress'], aixs=1)) == pytest.approx(22.8499295)
+    assert np.amax(np.linalg.norm(misc['stress'], axis=1)) == pytest.approx(22.8499295)
     assert misc['total_energies']['energy_extrapolated'] == pytest.approx(-14.16209692)
 
 

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -25,7 +25,7 @@ def test_vasp_wc(fresh_aiida_env, run_vasp_process):
     assert 'misc' in results
     assert 'remote_folder' in results
     misc = results['misc'].get_dict()
-    assert misc['maximum_stress'] == pytest.approx(22.8499295)
+    assert np.amax(np.linalg.norm(misc['stress'], aixs=1)) == pytest.approx(22.8499295)
     assert misc['total_energies']['energy_extrapolated'] == pytest.approx(-14.16209692)
 
 

--- a/tests/workchains/v2/test_builder_updater.py
+++ b/tests/workchains/v2/test_builder_updater.py
@@ -19,6 +19,8 @@ def test_vasp_builder_updater(aiida_profile, vasp_code):
     assert upd.builder.kpoints_spacing.value == 0.05
     assert upd.builder.potential_family.value == 'PBE.54'
     assert upd.builder.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
+    # Re-apply the preset - this should work without any errors
+    upd.apply_preset(structure, code='vasp@localhost')
 
 
 def test_vasp_relax_updater(aiida_profile, vasp_code):


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description


Update the output schema based on the feedback:

- The maximum_force and maximum_stress will be removed from the misc as they are redundant information
- remove COLLECTED_ARRAY_QUANTITIES and the arrays output which collects arrays together. The STANDALONE_ARRAY_QUANTITIES will just contain the quantities that gets converted into an `ArrayData` node. 
- Remove the `final` subkey under `forces` and `stress` in `misc` output node. 
- Added `all_forces` and `all_stress` quantities which can be activated to include forces and stress in all ionic steps. 