### PR TITLE
Added detection for inconsistent INCAR key cases

### DIFF
--- a/src/aiida_vasp/utils/aiida_utils.py
+++ b/src/aiida_vasp/utils/aiida_utils.py
@@ -7,7 +7,7 @@ historical reasons when AiiDA was rapidly developed. In the future most routines
 that have now standardized in AiiDA will be removed.
 """
 
-# pylint: disable=import-outside-toplevel
+import warnings
 from functools import wraps
 
 import numpy as np
@@ -188,3 +188,33 @@ def ensure_node_kwargs(func):
         return func(node, *args, **new_kwargs)
 
     return wrapper
+
+
+def convert_dict_case(dict_in: dict, recursive=True, warn=False, lower=True, raise_convert=False):
+    """
+    Recursively convert the keys of a dictionary to lower or upper cases, returns a new dictionary.
+
+    :param dict_in: The input dictionary whose keys need to be converted.
+    :param recursive: If True, the function will recursively convert keys in nested dictionaries.
+    :param warn: If True, the function will print a warning if a key is converted.
+    :param lower: If True, convert keys to lowercase; otherwise, convert to uppercase.
+    :param raise_convert: If True, raise an error if a key is converted.
+    :return: A new dictionary with keys converted to the specified case.
+    """
+
+    converted_dict = {}
+    for key, value in dict_in.items():
+        new_key = key.lower() if lower else key.upper()
+        if new_key != key:
+            expected = 'upper' if lower is False else 'lower'
+            if warn:
+                expected = 'upper' if lower is False else 'lower'
+                warnings.warn(f"Key '{key}' converted to '{new_key}' - please use {expected} case keys")
+            if raise_convert:
+                raise ValueError(f"Key '{key}' converted to '{new_key}' - please use {expected} case keys")
+
+        if recursive and isinstance(value, dict):
+            converted_dict[new_key] = convert_dict_case(value, recursive, warn, lower, raise_convert)
+        else:
+            converted_dict[new_key] = value
+    return converted_dict

--- a/src/aiida_vasp/workchains/v2/common/__init__.py
+++ b/src/aiida_vasp/workchains/v2/common/__init__.py
@@ -12,6 +12,7 @@ from aiida.common.exceptions import InputValidationError
 from aiida.common.extendeddicts import AttributeDict
 
 from aiida_vasp.assistant.parameters import _BASE_NAMESPACES, ParametersMassage
+from aiida_vasp.utils.aiida_utils import convert_dict_case
 
 OVERRIDE_NAMESPACE = 'incar'
 
@@ -54,6 +55,13 @@ def parameters_validator(node, port=None):
         return
 
     pdict = node.get_dict()
+    try:
+        convert_dict_case(pdict, lower=True, raise_convert=True)
+    except ValueError as error:
+        raise InputValidationError(
+            'Case inconsistency found in the parameters dictionary ' f'please use lower case keys: {error}'
+        )
+
     if OVERRIDE_NAMESPACE not in pdict:
         raise InputValidationError(f'Would expect some incar tags supplied under {OVERRIDE_NAMESPACE} key!')
 

--- a/src/aiida_vasp/workchains/v2/vasp.py
+++ b/src/aiida_vasp/workchains/v2/vasp.py
@@ -151,6 +151,7 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
             valid_type=orm.Dict,
             required=True,
             validator=parameters_validator,
+            serializer=to_aiida_type,
         )
         spec.input(
             'options',

--- a/tests/utils/test_aiida_utils.py
+++ b/tests/utils/test_aiida_utils.py
@@ -1,10 +1,10 @@
 """Test aiida_utils functionss."""
 
+import warnings
+
 import pytest
 
-from aiida_vasp.utils.aiida_utils import (
-    get_current_user,
-)
+from aiida_vasp.utils.aiida_utils import convert_dict_case, get_current_user
 from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
 
 
@@ -40,3 +40,42 @@ def test_pmg_adaptor(fresh_aiida_env, tmp_path, run_vasp_process):
     assert get_kpoints(node)
     assert get_vasprun(node)
     assert get_outcar(node)
+
+
+def test_convert_dict_case_lowercase():
+    input_dict = {'KeyOne': 1, 'KEYTWO': 2}
+    expected_output = {'keyone': 1, 'keytwo': 2}
+    assert convert_dict_case(input_dict) == expected_output
+
+
+def test_convert_dict_case_uppercase():
+    input_dict = {'keyone': 1, 'keytwo': 2}
+    expected_output = {'KEYONE': 1, 'KEYTWO': 2}
+    assert convert_dict_case(input_dict, lower=False) == expected_output
+
+
+def test_convert_dict_case_nested():
+    input_dict = {'KeyOne': {'SubKeyOne': 1, 'SUBKEYTWO': 2}, 'KEYTWO': 2}
+    expected_output = {'keyone': {'subkeyone': 1, 'subkeytwo': 2}, 'keytwo': 2}
+    assert convert_dict_case(input_dict) == expected_output
+
+
+def test_convert_dict_case_warning(caplog):
+    input_dict = {'KeyOne': 1, 'KEYTWO': 2}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        convert_dict_case(input_dict, warn=True)
+        assert len(w) == 2
+        assert "Key 'KeyOne' converted to 'keyone' - please use lower case keys" in str(w[0].message)
+        assert "Key 'KEYTWO' converted to 'keytwo' - please use lower case keys" in str(w[1].message)
+
+
+def test_convert_dict_case_raise():
+    input_dict = {'KeyOne': 1, 'KEYTWO': 2}
+    with pytest.raises(ValueError, match="Key 'KeyOne' converted to 'keyone' - please use lower case keys"):
+        convert_dict_case(input_dict, raise_convert=True)
+
+
+def test_convert_dict_case_no_conversion():
+    input_dict = {'keyone': 1, 'keytwo': 2}
+    assert convert_dict_case(input_dict) == input_dict

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -11,8 +11,11 @@ from __future__ import print_function
 import numpy as np
 import pytest
 from aiida import orm
+from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report
+from aiida.common.exceptions import InputValidationError
 from aiida.common.extendeddicts import AttributeDict
-from aiida.orm import load_code
+from aiida.engine import run
+from aiida.plugins import WorkflowFactory
 from aiida.plugins.factories import DataFactory
 
 
@@ -114,18 +117,25 @@ def setup_vasp_workchain(structure, incar, nkpts, potcar_family_name, potcar_map
 
     # If code is not passed, use the mock code
     if code is None:
-        mock = load_code('mock-vasp@localhost')
+        mock = orm.load_code('mock-vasp@localhost')
         inputs.code = mock
     else:
         inputs.code = code
     return inputs
 
 
+def test_vasp_incar_case(fresh_aiida_env):
+    """Test catching inconsistent incar key cases"""
+    from aiida.plugins import WorkflowFactory
+
+    workchain = WorkflowFactory('vasp.vasp')
+    builder = workchain.get_builder()
+    with pytest.raises(InputValidationError):
+        builder.parameters = orm.Dict(dict={'incar': {'ALGO': 21}})
+
+
 def test_vasp_wc_nelm(fresh_aiida_env, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict):
     """Test with mocked vasp code for handling electronic convergence issues"""
-    from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report
-    from aiida.engine import run
-    from aiida.plugins import WorkflowFactory
 
     workchain = WorkflowFactory('vasp.vasp')
 


### PR DESCRIPTION

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

The plugin already assumes that all keys should be in lower case. Using upper case keys may result in unexpected behavior 
during the workchain operation. 
This PR adds detection and catches any upper case key when validating the inputs for VaspWorkChain.
