### PR TITLE
Add support for vdw kernel file 

### DIFF
--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -130,6 +130,12 @@ class VaspCalculation(VaspCalcBase):
             'metadata.options.parser_name',
             default='vasp.vasp',
         )
+        spec.input(
+            'vdw_kernel',
+            valid_type=orm.SinglefileData,
+            required=False,
+            help='The vdw_kerenl.bindat file to be used for vdw calculations.',
+        )
 
         # Define outputs.
         # remote_folder and retrieved are passed automatically
@@ -422,6 +428,12 @@ class VaspCalculation(VaspCalcBase):
                 remote_folder = self.inputs.restart_folder
                 if 'WAVECAR' not in remote_copy_fnames:
                     raise FileNotFoundError(f'Could not find WAVECAR in {remote_folder.get_remote_path()}')
+
+        # Process the vdw_kernel input
+        if 'vdw_kernel' in self.inputs:
+            calcinfo.local_copy_list.append(
+                (self.inputs.vdw_kernel.uuid, self.inputs.vdw_kernel.filename, 'vdw_kernel.bindat')
+            )
 
     def write_incar(self, dst, validate_tags=True):  # pylint: disable=unused-argument
         """

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -243,7 +243,9 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.root_namespace.structure = None
         self.root_namespace.metadata.label = None
 
-    def apply_preset(self, initial_structure, code=None, label=None, overrides=None) -> 'VaspBuilderUpdater':
+    def apply_preset(
+        self, initial_structure, code=None, label=None, overrides=None, set_name=None
+    ) -> 'VaspBuilderUpdater':
         """
         Apply the preset
         """
@@ -252,7 +254,7 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             logging.info(f'Using code {code}')
         self.use_inputset(
             initial_structure,
-            set_name=self.set_name,
+            set_name=self.set_name if set_name is None else set_name,
             overrides=overrides,
             apply_preset=True,
             code=code,

--- a/src/aiida_vasp/workchains/v2/vasp.py
+++ b/src/aiida_vasp/workchains/v2/vasp.py
@@ -252,6 +252,12 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
             Site dependent flag for selective dynamics when performing relaxation
             """,
         )
+        spec.input(
+            'vdw_kernel',
+            valid_type=orm.SinglefileData,
+            required=False,
+            help='The vdw_kerenl.bindat file to be used for vdw calculations.',
+        )
         spec.outline(
             cls.setup,
             cls.init_inputs,
@@ -552,6 +558,9 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
         # Set the wave functions (wavecar)
         if 'wavecar' in self.inputs:
             self.ctx.inputs.wavefunctions = self.inputs.wavecar
+
+        if 'vdw_kernel' in self.inputs:
+            self.ctx.inputs.vdw_kernel = self.inputs.vdw_kernel
 
         ##### END OF THE COPY from VaspWorkChain   #####
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#85 
blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Added a `vdw_kernel` input to the calculation and work chains which is needed for vdW-DF functionals. This input should be a `SingleFileData` that contains a `vdw_kernel.bindat` file to be included in the calculation folder. 

Note: This file may be generated by VASP if not supplied. So it can be a calculation _output_ . Hence, I assume that it is not subject to the license restriction. Though I can be wrong.  