### PR TITLE
📚 Fix POTCAR upload command in `configuration.md`

### DIFF
--- a/docs/source/getting_started/configuration.md
+++ b/docs/source/getting_started/configuration.md
@@ -95,7 +95,7 @@ specific version of the PAW dataset relaxed with VASP.
 Execute the following command to upload the whole potential family to the database:
 
 ```
-% verdi data vasp-potcar uploadfamily --path=$HOME/myaiida/potpaw_PBE.54.tar --name=PBE.54 --description="PBE potentials version 54"
+% verdi data vasp.potcar uploadfamily --path=$HOME/myaiida/potpaw_PBE.54.tar --name=PBE.54 --description="PBE potentials version 54"
 POTCAR files found: 327. New files uploaded: 327, Added to Family: 327
 ```
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [X] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

N/A

## Description

Just a typo in the command, i.e. it shows a hyphen `-` which should be a dot `.`?

Also note that the command failed for a tarball with a `RecursionError: maximum recursion depth exceeded`, see full Traceback below.

<details>
  <summary>Click to expand</summary

```python
❯ verdi data vasp.potcar uploadfamily --path=/Users/mbercx/tmp/potpaw_PBE.64.tgz --name=PBE.64 --description="PBE potentials version 64"
Traceback (most recent call last):
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/aiida/cmdline/groups/verdi.py", line 119, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/.aiida_venvs/defect/lib/python3.12/site-packages/aiida/cmdline/utils/decorators.py", line 104, in wrapper
    return wrapped(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/commands/potcar.py", line 105, in uploadfamily
    num_found, num_added, num_uploaded = potcar_data_cls.upload_potcar_family(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 907, in upload_potcar_family
    potcar_finder.walk()
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 258, in walk
    self.walk()
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 258, in walk
    self.walk()
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 258, in walk
    self.walk()
  [Previous line repeated 970 more times]
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 255, in walk
    extracted = self.file_dispatch(self.path.parent, [], self.path.name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 268, in file_dispatch
    return self.handle_tarfile(dirs, file_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 276, in handle_tarfile
    new_dir = extract_tarfile(file_path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mbercx/project/defect/git/aiida-vasp/src/aiida_vasp/data/potcar.py", line 209, in extract_tarfile
    with tarfile.open(str(file_path)) as archive:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 1852, in open
    return func(name, "r", fileobj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 1927, in gzopen
    t = cls.taropen(name, mode, fileobj, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 1904, in taropen
    return cls(name, mode, fileobj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 1762, in __init__
    self.firstmember = self.next()
                       ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 2765, in next
    raise e
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 2738, in next
    tarinfo = self.tarinfo.fromtarfile(self)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tarfile.py", line 1314, in fromtarfile
    buf = tarfile.fileobj.read(BLOCKSIZE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/gzip.py", line 338, in read
    return self._buffer.read(size)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/gzip.py", line 544, in read
    if not self._read_gzip_header():
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/gzip.py", line 513, in _read_gzip_header
    last_mtime = _read_gzip_header(self._fp)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/gzip.py", line 475, in _read_gzip_header
    (method, flag, last_mtime) = struct.unpack("<BBIxx", _read_exact(fp, 8))
                                                         ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.11/Frameworks/Python.framework/Versions/3.12/lib/python3.12/gzip.py", line 453, in _read_exact
    data = fp.read(n)
           ^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```
</details>