### PR TITLE
Fix docs building - added pymatgen as test and docs dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install aiida-vasp
         run: |
           conda activate test
-          pip install pymatgen
           pip install -e . -vvv
       - name: Run tests with codecov
         run: |
@@ -84,7 +83,6 @@ jobs:
       - name: Install aiida-vasp
         run: |
           conda activate test
-          pip install pymatgen
           pip install -e .[docs] -vvv
       - name: Build the documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cd ..
       - name: Install aiida-vasp
         run: |
-          [tests]conda activate test
+          conda activate test
           pip install -e .[tests] -vvv
       - name: Run tests with codecov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
           cd ..
       - name: Install aiida-vasp
         run: |
-          conda activate test
-          pip install -e . -vvv
+          [tests]conda activate test
+          pip install -e .[tests] -vvv
       - name: Run tests with codecov
         run: |
           conda activate test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 Source = "https://github.com/aiida-vasp/aiida-vasp"
 
 [project.optional-dependencies]
-tests = ["aiida-core>=2.6", "pytest", "PyCifRW"]
+tests = ["aiida-core>=2.6", "pytest", "PyCifRW", "pymatgen"]
 pre-commit = ["pre-commit"]
 docs = [
     "aiida-core[docs]~=2.4",
@@ -58,6 +58,7 @@ docs = [
     "sphinx_design",
     "sphinx_togglebutton",
     "sphinxext.remoteliteralinclude",
+    "pymatgen"
 ]
 graphs = ["matplotlib"]
 

--- a/src/aiida_vasp/commands/potcar.py
+++ b/src/aiida_vasp/commands/potcar.py
@@ -16,7 +16,6 @@ from click_spinner import spinner as cli_spinner
 from aiida_vasp.commands import options
 from aiida_vasp.data.potcar import PotcarData, migrate_potcar_group
 from aiida_vasp.utils.aiida_utils import cmp_load_verdi_data
-from aiida_vasp.utils.pmg import convert_pymatgen_potcar_folder, temporary_folder
 
 VERDI_DATA = cmp_load_verdi_data()
 
@@ -136,6 +135,8 @@ def upload_from_pymatgen(functional, name, description, stop_if_existing, dry_ru
     you can use this command to upload a family of VASP potcar files into aiida-vasp.
     """
     from pymatgen.io.vasp.inputs import SETTINGS, PotcarSingle  # noqa: PLC0415
+
+    from aiida_vasp.utils.pmg import convert_pymatgen_potcar_folder, temporary_folder  # noqa: PLC0415
 
     funcdir = PotcarSingle.functional_dir[functional]
     pmg_vasp_psp_dir = SETTINGS.get('PMG_VASP_PSP_DIR')

--- a/src/aiida_vasp/utils/pmg.py
+++ b/src/aiida_vasp/utils/pmg.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Generator, List, Optional
 try:
     import pymatgen.io.vasp as pvasp
 except ImportError:
-    raise ImportError('You need to install pymatgen to use this feature.')
+    raise ImportError('You need to install pymatgen to use this module.')
 
 
 import gzip

--- a/src/aiida_vasp/workchains/v2/inputset/pmgset.py
+++ b/src/aiida_vasp/workchains/v2/inputset/pmgset.py
@@ -11,7 +11,7 @@ from .base import InputSet
 
 try:
     import pymatgen.io.vasp.sets as pmg_sets
-    from pymatgen.io.vasp.inputs import Kpoints, KpointsSupportedModes
+    from pymatgen.io.vasp.inputs import KpointsSupportedModes
 except ImportError:
     pmg_sets = None
 
@@ -191,7 +191,7 @@ class PymatgenInputSet(InputSet):
         return None
 
 
-def pmg_kpoints2kpointsdata(pmg_kpoints: Kpoints, structure: orm.StructureData) -> orm.KpointsData:
+def pmg_kpoints2kpointsdata(pmg_kpoints, structure: orm.StructureData) -> orm.KpointsData:
     """
     Convert a pymatgen Kpoints object to an AiiDA KpointsData object.
 

--- a/tests/utils/test_aiida_utils.py
+++ b/tests/utils/test_aiida_utils.py
@@ -5,7 +5,13 @@ import warnings
 import pytest
 
 from aiida_vasp.utils.aiida_utils import convert_dict_case, get_current_user
-from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
+
+try:
+    from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
+except ImportError:
+    PMG_INSTALLED = False
+else:
+    PMG_INSTALLED = True
 
 
 def test_get_current_user(fresh_aiida_env):
@@ -17,6 +23,7 @@ def test_get_current_user(fresh_aiida_env):
     assert user.email
 
 
+@pytest.mark.skipif(not PMG_INSTALLED, reason='pymatgen not installed')
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 def test_pmg_adaptor(fresh_aiida_env, tmp_path, run_vasp_process):
     """


### PR DESCRIPTION
The building of documents requires pymatgen to be installed for the evaluation of the code-cells.

**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Add pymatgen as docs and tests dependencies - otherwise the documentation build by readthedocs will have problem. 