### PR TITLE
Implement monitors for VaspCalculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,16 @@ jobs:
       - name: Setup venv
         run: |
           uv venv --python=${{ matrix.python }}
-      - name: Install parsevasp development
+      - name: Install parsevasp development and pytest-cov
         run: |
-          uv pip install git+https://github.com/aiida-vasp/parsevasp.git@develop
+          uv pip install git+https://github.com/aiida-vasp/parsevasp.git@develop pytest-cov
       - name: Install aiida-vasp
         run: |
-          uv pip install -e .[tests] -vvv
+          uv pip install -v -e .[tests]
       - name: Run tests with codecov
         run: |
-          uv run pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
+          source .venv/bin/activate
+          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -67,7 +68,7 @@ jobs:
           uv pip install git+https://github.com/aiida-vasp/parsevasp.git@develop
       - name: Install aiida-vasp
         run: |
-          uv pip install -e .[tests] -vvv
+          uv pip install -v -e .[docs]
       - name: Build the documentation
         run: |
           cd docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install aiida-vasp
         run: |
           conda activate test
-          pip install pymatgen
           pip install -e . -vvv
       - name: Run tests with codecov
         run: |
@@ -84,7 +83,6 @@ jobs:
       - name: Install aiida-vasp
         run: |
           conda activate test
-          pip install pymatgen
           pip install -e .[docs] -vvv
       - name: Build the documentation
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           uv venv --python=${{ matrix.python }}
       - name: Install parsevasp development
         run: |
-          uv pip install https://github.com/aiida-vasp/parsevasp.git@develop
+          uv pip install git+https://github.com/aiida-vasp/parsevasp.git@develop
       - name: Install aiida-vasp
         run: |
           uv pip install -e .[tests] -vvv
@@ -64,7 +64,7 @@ jobs:
           uv venv --python=${{ matrix.python }}
       - name: Install parsevasp development
         run: |
-          uv pip install https://github.com/aiida-vasp/parsevasp.git@develop
+          uv pip install git+https://github.com/aiida-vasp/parsevasp.git@develop
       - name: Install aiida-vasp
         run: |
           uv pip install -e .[tests] -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           cd ..
       - name: Install aiida-vasp
         run: |
-          [tests]conda activate test
+          conda activate test
           pip install -e .[tests] -vvv
       - name: Run tests with codecov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,29 +14,20 @@ jobs:
         python: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniforge-version: latest
-      - name: Install dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+      - name: Setup venv
         run: |
-          conda activate test
-          conda install --yes -c conda-forge python=${{ matrix.python }}
-          conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
-      - name: Setup parsevasp
+          uv venv --python=${{ matrix.python }}
+      - name: Install parsevasp development
         run: |
-          conda activate test
-          git clone --depth 1 https://github.com/aiida-vasp/parsevasp.git
-          cd parsevasp
-          pip install -e . -vvv
-          cd ..
+          uv pip install https://github.com/aiida-vasp/parsevasp.git@develop
       - name: Install aiida-vasp
         run: |
-          conda activate test
-          pip install -e .[tests] -vvv
+          uv pip install -e .[tests] -vvv
       - name: Run tests with codecov
         run: |
-          conda activate test
-          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
+          uv run pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
@@ -65,26 +56,19 @@ jobs:
         python: ['3.10']
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniforge-version: latest
-      - name: Install dependencies
+      - uses: actions/checkout@v4
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+      - name: Setup venv
         run: |
-          conda activate test
-          conda install --yes -c conda-forge python=${{ matrix.python }}
-          conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
-      - name: Setup parsevasp
+          uv venv --python=${{ matrix.python }}
+      - name: Install parsevasp development
         run: |
-          conda activate test
-          git clone --depth 1 https://github.com/aiida-vasp/parsevasp.git
-          cd parsevasp
-          pip install -e . -vvv
-          cd ..
+          uv pip install https://github.com/aiida-vasp/parsevasp.git@develop
       - name: Install aiida-vasp
         run: |
-          conda activate test
-          pip install -e .[docs] -vvv
+          uv pip install -e .[tests] -vvv
       - name: Build the documentation
         run: |
           cd docs
-          make html
+          uv run make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
           cd ..
       - name: Install aiida-vasp
         run: |
-          conda activate test
-          pip install -e . -vvv
+          [tests]conda activate test
+          pip install -e .[tests] -vvv
       - name: Run tests with codecov
         run: |
           conda activate test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
           uv pip install -v -e .[tests]
       - name: Run tests with codecov
         run: |
-          source .venv/bin/activate
-          pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
+          uv run pytest --cov=aiida_vasp --cov-append --cov-report=xml --cov-report=term-missing -k 'not converge_wc' tests
       - name: Archive error mock calculations
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}

--- a/docs/source/getting_started/configuration.md
+++ b/docs/source/getting_started/configuration.md
@@ -1,11 +1,17 @@
+---
+myst:
+  substitutions:
+    InstalledCode: "{external:py:class}`InstalledCode <aiida.orm.InstalledCode>`"
+---
+
 (configuration)=
 # Configurations
 
 Here we explain the post-installation configuration steps for [AiiDA-VASP].
 
-## Setting up a `InstalledCode` for your VASP executable
+## Setting up a {{ InstalledCode }} for your VASP executable
 
-A `InstalledCode` is a pointer to a VASP executable that is installed on a remote computer. In this example, we assume that the VASP executable is installed on a remote computer `mycluster`. We will now set up a `InstalledCode` for this executable in [AiiDA].
+A {{ InstalledCode  }} is a pointer to a VASP executable that is installed on a remote computer. In this example, we assume that the VASP executable is installed on a remote computer `mycluster`. We will now set up a {{ InstalledCode }} for this executable in [AiiDA].
 
 The `verdi code` commands allow one to setup/update/duplicate `InstalledCode` objects in [AiiDA].
 Please consult the [AiiDA documentation] for more details.
@@ -32,10 +38,16 @@ Very often one needs to utilize different versions/executables VASP, for instanc
 One can add multiple `InstalledCode` objects to AiiDA for different versions of VASP with different labels.
 
 :::{tip}
-Use
+You can first create a Code for the `vasp_std` executable, then use:
+
+```
+verdi code duplicate vasp-std@mycluster vasp-ncl@mycluster
+```
+
+to create a new {{ InstalledCode }} for `vasp_ncl`. The previous configurations will be used as default and the only one you need to change is the *Absolute filepath executable* field.
 :::
 
-During the end of the setup, the user will be  asked to enter the prepend and append text.
+During the end of the setup, the user will be asked to enter the prepend and append text.
 The prepend section is any command that should run before the VASP executed.
 For most cluster systems, they corresponds to loading the correct modules.
 
@@ -57,8 +69,9 @@ One may want to enter cleanup routines etc, or just keep it empty.
 
 
 :::{note}
-For local VASP installation, just create a compute with `localhost` as the hostname, `core.local` transport and `core.direct` scheduler.
-Then create a `InstalledCode` with the absolute path to the VASP executable and label `vasp`.
+For local VASP installation, just create a computer with `localhost` as the hostname, `core.local` transport and `core.direct` scheduler.
+The `localhost` computer should be created already if you used the `verdi presto` command to initialize the profile.
+Then create a {{ InstalledCode }}  with the absolute path to the VASP executable and label `vasp`.
 :::
 
 
@@ -103,6 +116,12 @@ Execute the following command to upload the whole potential family to the databa
 POTCAR files found: 327. New files uploaded: 327, Added to Family: 327
 ```
 
+:::{tip}
+For historical reasons we used `PBE.54` as the name for the `PBE_54` PAW dataset.
+Any name can be used of course, but some of the presets of the workflows expect the naming convention with
+a `.` instead of `_`.
+:::
+
 
 The `name` and `description` are not optional and have to be specified.
 The `path` could be either an archive, or one could use a folder name.
@@ -114,7 +133,7 @@ We use the POTCAR parser from [pymatgen] to get the metadata and sometimes this 
 
 :::{note}
 A *potential family* here can have multiple potential for a single element.
-This is different from the same terminologies used in [aiida-quantumespresso] and [aiida-castep] where a *potential family* provides a one-to-one mapping between elements and pseudopotentials.
+This is different from the same terminologies used in [aiida-pseudo] and [aiida-castep] where a *potential family* provides a one-to-one mapping between elements and pseudopotentials.
 Hence, a *potential mapping* is also need when running calculations/workflows, to provided the one-to-one  mapping between the symbols and the potentials with the *potential family*.
 :::
 
@@ -122,5 +141,5 @@ Hence, a *potential mapping* is also need when running calculations/workflows, t
 [aiida-vasp]: https://github.com/aiida-vasp/aiida-vasp
 [vasp]: https://www.vasp.at
 [pymatgen]: https://pymatgen.org
-[aiida-quantumespresso]: https://github.com/aiidateam/aiida-quantumespresso
+[aiida-quantumespresso]: https://aiida-pseudo.readthedocs.io/en/latest/design.html#families
 [aiida-castep]: https://github.com/zhubonan/aiida-castep

--- a/docs/source/getting_started/configuration.md
+++ b/docs/source/getting_started/configuration.md
@@ -19,9 +19,9 @@ To add a code with label `vasp`:
 Report: enter ? for help.
 Report: enter ! to ignore the default and set no value.
 Computer: mycluster
-Absolute filepath executable: /cluster/software/vasp/vasp6.3.2/vasp
-Label: vasp
-Description: VASP 6.3.2 standard version
+Absolute filepath executable: /cluster/software/vasp/vasp6.3.2/vasp_std
+Label: vasp-std
+Description: VASP 6.3.2 standard version (complex)
 Default `CalcJob` plugin: vasp.vasp
 Escape using double quotes [y/N]:
 Success: Created InstalledCode<6>
@@ -29,7 +29,11 @@ Success: Created InstalledCode<6>
 
 The `Absolute filepath executable` is the full path to the VASP executable installed on the remote computer.
 Very often one needs to utilize different versions/executables VASP, for instance, running calculations with the gamma only or non-collinear configurations or with additional auxiliary libraries, like BEEF included.
-One can add multiple `InstalledCode` objects to [AiiDA] for different versions of VASP with different labels.
+One can add multiple `InstalledCode` objects to AiiDA for different versions of VASP with different labels.
+
+:::{tip}
+Use
+:::
 
 During the end of the setup, the user will be  asked to enter the prepend and append text.
 The prepend section is any command that should run before the VASP executed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ graphs = ["matplotlib"]
 "vasp.vasp" = "aiida_vasp.parsers.vasp:VaspParser"
 "vasp.neb" = "aiida_vasp.parsers.neb:NebParser"
 
+[project.entry-points."aiida.calculations.monitors"]
+"vasp.loop_time" = "aiida_vasp.calcs.monitors:monitor_loop_time"
+"vasp.stdout" = "aiida_vasp.calcs.monitors:monitor_stdout"
+
 [project.entry-points."aiida.workflows"]
 "vasp.vasp" = "aiida_vasp.workchains.v2.vasp:VaspWorkChain"
 "vasp.converge" = "aiida_vasp.workchains.v2.converge:VaspConvergenceWorkChain"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ docs = [
     "sphinx_design",
     "sphinx_togglebutton",
     "sphinxext.remoteliteralinclude",
+    "matplotlib",
     "pymatgen"
 ]
 graphs = ["matplotlib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 Source = "https://github.com/aiida-vasp/aiida-vasp"
 
 [project.optional-dependencies]
-tests = ["aiida-core>=2.6", "pytest", "PyCifRW"]
+tests = ["aiida-core>=2.6", "pytest", "PyCifRW", "pymatgen"]
 pre-commit = ["pre-commit"]
 docs = [
     "aiida-core[docs]~=2.4",
@@ -58,6 +58,7 @@ docs = [
     "sphinx_design",
     "sphinx_togglebutton",
     "sphinxext.remoteliteralinclude",
+    "pymatgen"
 ]
 graphs = ["matplotlib"]
 

--- a/src/aiida_vasp/assistant/parameters.py
+++ b/src/aiida_vasp/assistant/parameters.py
@@ -8,13 +8,14 @@ Contains utils and definitions that are used together with the parameters.
 from __future__ import annotations
 
 import enum
-from os import path  # pylint: disable=import-outside-toplevel
+from copy import deepcopy
+from pathlib import Path
 from typing import Any
 from warnings import warn
 
+from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
-from aiida.plugins import DataFactory
-from yaml import safe_load  # pylint: disable=import-outside-toplevel
+from yaml import safe_load
 
 from aiida_vasp.utils.extended_dicts import update_nested_dict
 
@@ -152,6 +153,8 @@ class ParametersMassage:  # pylint: disable=too-many-instance-attributes
     depending on what is needed in those plugins and how you construct your workchains.
     """
 
+    _valid_parameters_and_mtime: tuple[list[str], int] = None
+
     def __init__(
         self,
         parameters: Any,
@@ -208,10 +211,20 @@ class ParametersMassage:  # pylint: disable=too-many-instance-attributes
     def _load_valid_params(self) -> None:
         """Import a list of valid parameters for VASP. This is generated from the manual."""
 
-        with open(path.join(path.dirname(path.realpath(__file__)), 'parameters.yml'), 'r', encoding='utf8') as handler:
-            tags_data = safe_load(handler)
-        self._valid_parameters = list(tags_data.keys())
+        # Cache the valid parameters as class attributes to void repeated loading
+        filepath = Path(__file__).parent / 'parameters.yml'
+        mtime = Path(filepath).stat().st_mtime
+
+        if (
+            ParametersMassage._valid_parameters_and_mtime is None
+            or mtime != ParametersMassage._valid_parameters_and_mtime[1]
+        ):
+            with open(filepath, 'r', encoding='utf8') as handler:
+                tags_data = safe_load(handler)
+                ParametersMassage._valid_parameters_and_mtime = (list(tags_data.keys()), mtime)
+
         # Now add any unsupported parameter to the list
+        self._valid_parameters = deepcopy(ParametersMassage._valid_parameters_and_mtime[0])
         for key, _ in self._unsupported_parameters.items():
             if key.lower() not in self._valid_parameters:
                 self._valid_parameters.append(key.lower())
@@ -543,12 +556,12 @@ class ParameterSetFunctions:
             pass
 
 
-def check_inputs(supplied_inputs: Any) -> AttributeDict:
+def check_inputs(supplied_inputs: None | AttributeDict | orm.Dict | dict) -> AttributeDict:
     """Check that the inputs are of some correct type and returned as AttributeDict."""
     inputs = None
     if supplied_inputs is None:
         inputs = AttributeDict()
-    elif isinstance(supplied_inputs, DataFactory('core.dict')):
+    elif isinstance(supplied_inputs, orm.Dict):
         inputs = AttributeDict(supplied_inputs.get_dict())
     elif isinstance(supplied_inputs, dict):
         inputs = AttributeDict(supplied_inputs)
@@ -578,7 +591,7 @@ def inherit_and_merge_parameters(inputs: dict[str, Any]) -> AttributeDict:
         parameters[namespace] = AttributeDict()
         try:
             for key, item in inputs[namespace].items():
-                if isinstance(item, DataFactory('core.array')):
+                if isinstance(item, orm.ArrayData):
                     # Only allow one array per input
                     if len(item.get_arraynames()) > 1:
                         raise IndexError(
@@ -587,9 +600,9 @@ def inherit_and_merge_parameters(inputs: dict[str, Any]) -> AttributeDict:
                         )
                     for array in item.get_arraynames():
                         parameters[namespace][key] = item.get_array(array)
-                elif isinstance(item, DataFactory('core.dict')):
+                elif isinstance(item, orm.Dict):
                     parameters[namespace][key] = item.get_dict()
-                elif isinstance(item, DataFactory('core.list')):
+                elif isinstance(item, orm.List):
                     parameters[namespace][key] = item.get_list()
                 else:
                     parameters[namespace][key] = item.value

--- a/src/aiida_vasp/calcs/monitors.py
+++ b/src/aiida_vasp/calcs/monitors.py
@@ -114,8 +114,8 @@ def monitor_loop_time(
     :rtype: str or None
     """
 
-    stdout_path = str(Path(node.get_remote_workdir(), node.process_class._VASP_OUTPUT))
     outcar_path = str(Path(node.get_remote_workdir(), 'OURCAR'))
+    stdout_path = str(Path(node.get_remote_workdir()) / node.process_class._VASP_OUTPUT)
     walltime_limit = node.get_option('max_wallclock_seconds')
     if walltime_limit is None:
         # Cannot monitor timing without a walltime limit

--- a/src/aiida_vasp/calcs/monitors.py
+++ b/src/aiida_vasp/calcs/monitors.py
@@ -1,0 +1,168 @@
+"""
+VASP Calculation Monitoring Functions.
+
+This module provides monitoring functions for detecting and handling problems that may occur
+during VASP calculations running on remote machines. These monitors are designed to identify
+issues early and take preventive actions to avoid system crashes or resource waste.
+
+The monitoring functions can detect:
+
+* Stdout file overflow that could crash the AiiDA daemon
+* Electronic loop timing issues that indicate inefficient calculations
+* Stalled calculations that are no longer making progress
+
+These monitors are typically used by AiiDA's calculation monitoring system to provide
+real-time feedback about running VASP calculations and automatically handle problematic
+situations.
+
+.. note::
+   These monitors operate on the remote machine where the VASP calculation is running
+   and require a transport connection to access files and execute commands.
+"""
+
+import time
+
+from aiida.orm import CalcJobNode
+from aiida.transports import Transport
+
+
+def monitor_stdout(node: CalcJobNode, transport: Transport, size_threshold_mb: float = 5) -> str | None:
+    """
+    Monitor stdout file size to prevent overflow crashes.
+
+    This function monitors the size of the VASP stdout file during calculation execution.
+    If the file becomes too large, it indicates a potential problem (such as excessive
+    output from convergence issues) that could crash the AiiDA daemon when attempting
+    to retrieve and parse the file.
+
+    When an oversized stdout file is detected, the function automatically truncates it
+    to prevent system crashes, though this means the calculation is considered lost.
+
+    :param node: The CalcJobNode representing the running VASP calculation
+    :type node: CalcJobNode
+    :param transport: Transport connection to the remote machine where VASP is running
+    :type transport: Transport
+    :param size_threshold_mb: Maximum allowed stdout file size in megabytes before
+                             truncation occurs
+    :type size_threshold_mb: int
+    :returns: None if no overflow detected, otherwise an error message describing
+              the overflow condition
+    :rtype: str or None
+
+    .. warning::
+       When stdout overflow is detected, the calculation is automatically terminated
+       by truncating the output file. This prevents system crashes but results in
+       loss of the calculation.
+
+    .. note::
+       The default threshold of 5 MB is typically sufficient for normal VASP
+       calculations. Larger thresholds may be needed for very large systems or
+       calculations with verbose output.
+    """
+
+    # Check the current size of the VASP stdout file
+    stdout_name = node.process_class._VASP_OUTPUT
+    file_stat = transport.get_attribute(stdout_name)
+    if file_stat.st_size > 1024 * 1024 * size_threshold_mb:
+        # Stdout file is dangerously large - truncate it to prevent system crashes
+        # This typically indicates convergence problems or infinite loops in VASP
+        # The calculation is lost, but we prevent the AiiDA daemon from crashing
+        # when attempting to retrieve and parse the oversized file
+        transport.exec_command_wait(f'truncate -s {size_threshold_mb}M {stdout_name}')
+        return f'Very large stdout detected: {file_stat.st_size / (1024 * 1024):.2f} MB, potential critical crash.'
+    # TODO: add detection of critical messages emitted when vasp got stuck
+
+
+def monitor_loop_time(
+    node: CalcJobNode,
+    transport: Transport,
+    minimum_electronic_loops: int = 10,
+    patience_num_loops: int = 5,
+    patience_minimum_time: float = 1800,
+) -> str | None:
+    """
+    Monitor electronic loop timing to detect inefficient or stalled calculations.
+
+    This function analyzes the timing of electronic self-consistency loops in VASP
+    calculations to identify potential problems:
+
+    1. **Slow convergence**: If electronic loops take too long relative to the walltime
+       limit, the calculation may not complete within the allocated time.
+
+    2. **Stalled calculations**: If the stdout file hasn't been updated for an
+       extended period, the calculation may have crashed or become stuck.
+
+    The function examines the OUTCAR file to extract loop timing information and
+    compares it against the walltime limits and recent file modification times.
+
+    :param node: The CalcJobNode representing the running VASP calculation
+    :type node: CalcJobNode
+    :param transport: Transport connection to the remote machine where VASP is running
+    :type transport: Transport
+    :param minimum_electronic_loops: Minimum number of electronic loops that should
+                                   be completable within the walltime limit
+    :type minimum_electronic_loops: int
+    :param patience_num_loops: Number of loop times to wait before considering
+                             a calculation stalled
+    :type patience_num_loops: int
+    :param patience_minimum_time: Minimum time in seconds to wait before checking
+                                for stalled calculations
+    :type patience_minimum_time: int
+    :returns: None if timing is acceptable, otherwise an error message describing
+              the detected problem (slow loops or stalled calculation)
+    :rtype: str or None
+    """
+
+    stdout_name = node.process_class._VASP_OUTPUT
+    walltime_limit = node.get_option('max_wallclock_seconds')
+    if walltime_limit is None:
+        # Cannot monitor timing without a walltime limit
+        return None
+
+    # Extract electronic loop timings from OUTCAR file
+    # LOOP entries contain timing information for each self-consistency cycle
+    returncode, stdout, stderr = transport.exec_command_wait("grep 'LOOP:' OUTCAR")
+
+    # Skip monitoring if no LOOP entries found (calculation hasn't started electronic steps)
+    if returncode != 0:
+        return None
+
+    # Parse the last loop time from the grep output
+    # Each LOOP line format: "LOOP:  CPU time  real time  (sec)  real time"
+    last_loop_time = 0
+    for line in stdout.splitlines():
+        # Extract the real time (4th column) from each LOOP line
+        # Keep updating to get the most recent loop time
+        last_loop_time = float(line.strip().split()[-1])
+
+    # Check if electronic loops are too slow relative to walltime
+    # If each loop takes more than walltime/minimum_loops, we won't finish in time
+
+    # Check for the presence of NELM
+    incar = {key.lower(): value for key, value in node.inputs.get('parameters', {}).items()}
+    nelm = incar.get('nelm', 60)
+    # Remove none-scf loops for hybrid calculation
+    if 'lhfcalc' in incar:
+        nelm -= abs(incar.get('nelmdl', 5))
+
+    # Take the minimum of the nelm and supplied minimum_electronic_loops
+    # This is useful to avoid killing benchmarking calculations a low NELM setting
+    minimum_electronic_loops = max(1, min(minimum_electronic_loops, nelm))
+
+    if last_loop_time > walltime_limit / minimum_electronic_loops:
+        return (
+            f'Less than {minimum_electronic_loops} electronic loop can be run in this calculation due to '
+            f'long electronic loop time: {last_loop_time:.2f} seconds.'
+        )
+
+    # Monitor for stalled calculations by checking stdout file modification time
+    file_stat = transport.get_attribute(stdout_name)
+    elapsed = time.time() - file_stat.st_mtime
+    # Consider calculation stalled if:
+    # 1. Minimum patience time has elapsed AND
+    # 2. Time since last update exceeds expected time for several loops
+    if elapsed > patience_minimum_time and elapsed > last_loop_time * patience_num_loops:
+        return (
+            f'Last update of the {stdout_name} file is more than {last_loop_time * patience_num_loops:.2f} '
+            'seconds ago. It is very likely that the calculation is stalled or crashed.'
+        )

--- a/src/aiida_vasp/calcs/monitors.py
+++ b/src/aiida_vasp/calcs/monitors.py
@@ -21,6 +21,7 @@ situations.
 """
 
 import time
+from pathlib import Path
 
 from aiida.orm import CalcJobNode
 from aiida.transports import Transport
@@ -61,14 +62,14 @@ def monitor_stdout(node: CalcJobNode, transport: Transport, size_threshold_mb: f
     """
 
     # Check the current size of the VASP stdout file
-    stdout_name = node.process_class._VASP_OUTPUT
-    file_stat = transport.get_attribute(stdout_name)
+    stdout_path = str(Path(node.get_remote_workdir()) / node.process_class._VASP_OUTPUT)
+    file_stat = transport.get_attribute(stdout_path)
     if file_stat.st_size > 1024 * 1024 * size_threshold_mb:
         # Stdout file is dangerously large - truncate it to prevent system crashes
         # This typically indicates convergence problems or infinite loops in VASP
         # The calculation is lost, but we prevent the AiiDA daemon from crashing
         # when attempting to retrieve and parse the oversized file
-        transport.exec_command_wait(f'truncate -s {size_threshold_mb}M {stdout_name}')
+        transport.exec_command_wait(f'truncate -s {size_threshold_mb}M {stdout_path}')
         return f'Very large stdout detected: {file_stat.st_size / (1024 * 1024):.2f} MB, potential critical crash.'
     # TODO: add detection of critical messages emitted when vasp got stuck
 
@@ -113,7 +114,8 @@ def monitor_loop_time(
     :rtype: str or None
     """
 
-    stdout_name = node.process_class._VASP_OUTPUT
+    stdout_path = str(Path(node.get_remote_workdir(), node.process_class._VASP_OUTPUT))
+    outcar_path = str(Path(node.get_remote_workdir(), 'OURCAR'))
     walltime_limit = node.get_option('max_wallclock_seconds')
     if walltime_limit is None:
         # Cannot monitor timing without a walltime limit
@@ -121,7 +123,7 @@ def monitor_loop_time(
 
     # Extract electronic loop timings from OUTCAR file
     # LOOP entries contain timing information for each self-consistency cycle
-    returncode, stdout, stderr = transport.exec_command_wait("grep 'LOOP:' OUTCAR")
+    returncode, stdout, stderr = transport.exec_command_wait(f"grep 'LOOP:' {outcar_path}")
 
     # Skip monitoring if no LOOP entries found (calculation hasn't started electronic steps)
     if returncode != 0:
@@ -156,13 +158,13 @@ def monitor_loop_time(
         )
 
     # Monitor for stalled calculations by checking stdout file modification time
-    file_stat = transport.get_attribute(stdout_name)
+    file_stat = transport.get_attribute(stdout_path)
     elapsed = time.time() - file_stat.st_mtime
     # Consider calculation stalled if:
     # 1. Minimum patience time has elapsed AND
     # 2. Time since last update exceeds expected time for several loops
     if elapsed > patience_minimum_time and elapsed > last_loop_time * patience_num_loops:
         return (
-            f'Last update of the {stdout_name} file is more than {last_loop_time * patience_num_loops:.2f} '
+            f'Last update of the {stdout_path} file is more than {last_loop_time * patience_num_loops:.2f} '
             'seconds ago. It is very likely that the calculation is stalled or crashed.'
         )

--- a/src/aiida_vasp/commands/potcar.py
+++ b/src/aiida_vasp/commands/potcar.py
@@ -16,7 +16,6 @@ from click_spinner import spinner as cli_spinner
 from aiida_vasp.commands import options
 from aiida_vasp.data.potcar import PotcarData, migrate_potcar_group
 from aiida_vasp.utils.aiida_utils import cmp_load_verdi_data
-from aiida_vasp.utils.pmg import convert_pymatgen_potcar_folder, temporary_folder
 
 VERDI_DATA = cmp_load_verdi_data()
 
@@ -136,6 +135,8 @@ def upload_from_pymatgen(functional, name, description, stop_if_existing, dry_ru
     you can use this command to upload a family of VASP potcar files into aiida-vasp.
     """
     from pymatgen.io.vasp.inputs import SETTINGS, PotcarSingle  # noqa: PLC0415
+
+    from aiida_vasp.utils.pmg import convert_pymatgen_potcar_folder, temporary_folder  # noqa: PLC0415
 
     funcdir = PotcarSingle.functional_dir[functional]
     pmg_vasp_psp_dir = SETTINGS.get('PMG_VASP_PSP_DIR')

--- a/src/aiida_vasp/data/potcar.py
+++ b/src/aiida_vasp/data/potcar.py
@@ -628,12 +628,12 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
     def get_or_create(cls, file_node: Any) -> tuple[Any, bool]:
         """Get or create (store) a PotcarData node."""
 
-        if cls.exists(sha512=file_node.sha512):
-            created = False
+        created = False
+        try:
             node = cls.find_one(sha512=file_node.sha512)
-        else:
-            created = True
+        except NotExistent:
             node = cls(potcar_file_node=file_node)
+            created = True
             node.store()
         return node, created
 
@@ -641,11 +641,10 @@ class PotcarData(Data, PotcarMetadataMixin, VersioningMixin):
     def get_or_create_from_file(cls, file_path: str | Path) -> tuple[Data, bool]:
         """Get or create (store) a PotcarData node from a POTCAR file."""
         sha512 = PotcarFileData.get_file_sha512(file_path)
-        file_node = (
-            PotcarFileData.find_one(sha512=sha512)
-            if PotcarFileData.exists(sha512=sha512)
-            else PotcarFileData(file=file_path)
-        )
+        try:
+            file_node = PotcarFileData.find_one(sha512=sha512)
+        except NotExistent:
+            file_node = PotcarFileData(file=file_path)
         node, created = cls.get_or_create(file_node)
         if not file_node.is_stored:
             file_node.store()

--- a/src/aiida_vasp/utils/bands.py
+++ b/src/aiida_vasp/utils/bands.py
@@ -5,25 +5,15 @@ Utilities for working with band structures. Currently this is legacy and will be
 rewritten or moved.
 """
 
+# ruff: noqa: PLC0415
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-# pylint: disable=import-outside-toplevel
-try:
-    import matplotlib
-
-    matplotlib.use('TKAgg')
-    from matplotlib import pyplot as plt
-except ImportError as no_matplotlib:
-    raise ImportError('Error: matplotlib must be ' + 'installed to use this functionality') from no_matplotlib
-
 import itertools
+from typing import Any
 
 import numpy as np
-
-if TYPE_CHECKING:
-    from aiida import orm
+from aiida import orm
 
 
 def get_bs_dims(bands_array: np.ndarray) -> tuple[int, int, int]:
@@ -112,7 +102,7 @@ def plot_bstr(
     efermi: float | None = None,
     use_parent_calc: bool = False,
     **kwargs: Any,
-) -> plt.Figure:
+):
     """
     Use matplotlib to plot the bands stored in a BandsData node.
 
@@ -128,6 +118,8 @@ def plot_bstr(
         present on the BandsData node. No consistency checks are performed.
     :return: the matplotlib figure containing the plot
     """
+    import matplotlib.pyplot as plt
+
     fig = plt.figure()
     title = title or f'Band Structure (pk={bands_node.pk})'
     bands = bands_node.get_bands()
@@ -161,6 +153,8 @@ def plot_bstr(
 def plot_bands(bands_node: orm.BandsData, **kwargs: Any) -> None:
     """Plot a bandstructure node using matplotlib."""
 
+    import matplotlib.pyplot as plt
+
     bands = bands_node.get_bands()
     nbands, nkp, nspin = get_bs_dims(bands)
     if nspin > 0:
@@ -172,6 +166,6 @@ def plot_bands(bands_node: orm.BandsData, **kwargs: Any) -> None:
     if 'colors' in kwargs:
         colors = itertools.cycle(kwargs.pop('colors'))
         for b_idx in range(bands.shape[1]):
-            plt.plot(bands[:, b_idx], color=colors.next(), **kwargs)  # pylint: disable=no-member, not-callable
+            plt.plot(bands[:, b_idx], color=colors.next(), **kwargs)
     else:
         plt.plot(bands, **kwargs)

--- a/src/aiida_vasp/utils/pmg.py
+++ b/src/aiida_vasp/utils/pmg.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Generator, List, Optional
 try:
     import pymatgen.io.vasp as pvasp
 except ImportError:
-    raise ImportError('You need to install pymatgen to use this feature.')
+    raise ImportError('You need to install pymatgen to use this module.')
 
 
 import gzip

--- a/src/aiida_vasp/workchains/v2/common/builder_updater.py
+++ b/src/aiida_vasp/workchains/v2/common/builder_updater.py
@@ -40,6 +40,7 @@ from typing import Any, Union
 from warnings import warn
 
 from aiida import orm
+from aiida.common.exceptions import InputValidationError
 from aiida.common.extendeddicts import AttributeDict
 from aiida.engine import run_get_node, submit
 from aiida.engine.processes.builder import ProcessBuilder, ProcessBuilderNamespace
@@ -475,7 +476,13 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
             self.namespace_vasp.kpoints_spacing = orm.Float(inset.get_kpoints_spacing())
 
         self.namespace_vasp.parameters = orm.Dict(dict={'incar': inset.get_input_dict(structure, raw_python=True)})
-        self.namespace_vasp.potential_family = orm.Str(inset.get_potcar_family())
+        try:
+            self.namespace_vasp.potential_family = orm.Str(inset.get_potcar_family())
+        except InputValidationError:
+            warn(
+                f'Error validating potential family {inset.get_potcar_family()} for input set {set_name}. '
+                'Potential family will not be set. '
+            )
         self.namespace_vasp.potential_mapping = orm.Dict(dict=inset.get_pp_mapping(structure))
         setattr(self.root_namespace, structure_port_name, structure)
         return self
@@ -493,6 +500,32 @@ class VaspBuilderUpdater(BaseBuilderUpdater):
         self.namespace_vasp.kpoints_spacing = orm.Float(kspacing)
         if self.namespace_vasp.kpoints:
             del self.namespace_vasp.kpoints
+        return self
+
+    def set_potential_family(self, family: str) -> VaspBuilderUpdater:
+        """
+        Set the potential family for the VASP calculation.
+
+        :param family: Name of the potential family
+        :type family: str
+
+        :returns: Self for method chaining
+        :rtype: VaspBuilderUpdater
+        """
+        self.namespace_vasp.potential_family = orm.Str(family)
+        return self
+
+    def set_potential_mapping(self, mapping: dict[str, str]) -> VaspBuilderUpdater:
+        """
+        Set the potential mapping for the VASP calculation.
+
+        :param mapping: Dictionary mapping element symbols to potential names
+        :type mapping: dict[str, str]
+
+        :returns: Self for method chaining
+        :rtype: VaspBuilderUpdater
+        """
+        self.namespace_vasp.potential_mapping = orm.Dict(dict=mapping)
         return self
 
     update_kspacing = set_kspacing

--- a/src/aiida_vasp/workchains/v2/converge.py
+++ b/src/aiida_vasp/workchains/v2/converge.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import matplotlib.pyplot as plt
 import numpy as np
 from aiida import orm
 from aiida.engine import ProcessSpec, WorkChain, append_, calcfunction
@@ -344,6 +343,8 @@ def plot_conv_data(cdf: Any, kdf: Any, **kwargs: Any) -> list[Any]:
     """
     Make two combined plots for the convergence test results.
     """
+
+    import matplotlib.pyplot as plt  # noqa: PLC0415
 
     # Create a subplot
     figs = []

--- a/src/aiida_vasp/workchains/v2/inputset/base.py
+++ b/src/aiida_vasp/workchains/v2/inputset/base.py
@@ -119,7 +119,7 @@ class InputSet:
         for name, value in self.overrides.items():
             # Keys ends with '_mapping' are treated differently here
             # Those valuse should have been applied already implemented in the `get_input_dict` method.
-            if '_mapping' in name or '_list' in name:
+            if '_mapping' in name or '_list' in name or '_family' in name:
                 continue
             # Delete the key
             if value is None:

--- a/src/aiida_vasp/workchains/v2/inputset/pmgset.py
+++ b/src/aiida_vasp/workchains/v2/inputset/pmgset.py
@@ -11,7 +11,7 @@ from .base import InputSet
 
 try:
     import pymatgen.io.vasp.sets as pmg_sets
-    from pymatgen.io.vasp.inputs import Kpoints, KpointsSupportedModes
+    from pymatgen.io.vasp.inputs import KpointsSupportedModes
 except ImportError:
     pmg_sets = None
 
@@ -191,7 +191,7 @@ class PymatgenInputSet(InputSet):
         return None
 
 
-def pmg_kpoints2kpointsdata(pmg_kpoints: Kpoints, structure: orm.StructureData) -> orm.KpointsData:
+def pmg_kpoints2kpointsdata(pmg_kpoints, structure: orm.StructureData) -> orm.KpointsData:
     """
     Convert a pymatgen Kpoints object to an AiiDA KpointsData object.
 

--- a/src/aiida_vasp/workchains/v2/vasp.py
+++ b/src/aiida_vasp/workchains/v2/vasp.py
@@ -143,6 +143,7 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
             valid_type=orm.Str,
             required=True,
             serializer=to_aiida_type,
+            validator=potential_family_validator,
         )
         spec.input(
             'potential_mapping',
@@ -472,6 +473,7 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
         # Set settings
         unsupported_parameters = None
         skip_parameters_validation = False
+        settings_dict = {}
         if self.inputs.get('settings'):
             self.ctx.inputs.settings = self.inputs.settings
             # Also check if the user supplied additional tags that is not in the supported file.
@@ -586,6 +588,13 @@ class VaspWorkChain(BaseRestartWorkChain, WithBuilderUpdater):
             ldau_keys = get_ldau_keys(self.ctx.inputs.structure, **ldau_settings)
             # Directly update the raw inputs passed to VaspCalculation
             self.ctx.inputs.parameters.update(ldau_keys)
+
+        # Attach default monitors if not provided by the user
+        if not self.inputs.get('monitors') and not settings_dict.get('no_default_monitors', False):
+            self.ctx.inputs.monitors = {
+                'stdout': Dict(dict={'entry_point': 'vasp.stdout'}),
+                'loop_time': Dict(dict={'entry_point': 'vasp.loop_time', 'minimum_poll_interval': 600}),
+            }
         return None
 
     def run_auto_parallel(self) -> bool:
@@ -1365,3 +1374,21 @@ def list_valid_objects_in_remote(remote: orm.RemoteData, path: str = '.', size_t
         if obj['attributes'].st_size > size_threshold and not obj['isdir']:
             none_empty.append(obj['name'])
     return none_empty
+
+
+def potential_family_validator(family: orm.Str, _) -> None:
+    """
+    Validate the potential family input.
+
+    :param faimly: The potential family to be validated.
+    :raises ValueError: If the potential family is not valid.
+    """
+    if not family.value:
+        raise InputValidationError('The potential family cannot be empty.')
+
+    group = PotcarData.get_potcar_group(family.value)
+    if group is None:
+        raise InputValidationError(
+            f'The potential family "{family.value}" is not found. '
+            'Please use verdi data vasp.potcars tool to verify your settings.'
+        )

--- a/tests/calcs/conftest.py
+++ b/tests/calcs/conftest.py
@@ -32,7 +32,7 @@ def sandbox_folder():
 
 
 @pytest.fixture()
-def base_calc(fresh_aiida_env, vasp_code):
+def base_calc(aiida_profile, vasp_code):
     """An instance of a VaspCalcBase Process."""
 
     manager = get_manager()
@@ -63,7 +63,7 @@ def vasp_calc(vasp_inputs):
 
 
 @pytest.fixture()
-def vasp_neb_inputs(fresh_aiida_env, vasp_params, vasp_kpoints, vasp_structure, potentials, vasp_code):
+def vasp_neb_inputs(aiida_profile, vasp_params, vasp_kpoints, vasp_structure, potentials, vasp_code):
     """Inputs dictionary for CalcJob Processes."""
 
     def inner(settings=None, parameters=None):
@@ -161,7 +161,7 @@ def vasp2w90_calc_and_ref(vasp2w90_calc, vasp_kpoints, vasp2w90_inputs, ref_inca
 
 
 @pytest.fixture()
-def vasp_chgcar(fresh_aiida_env, data_path):
+def vasp_chgcar(aiida_profile, data_path):
     """CHGCAR node and reference fixture."""
 
     chgcar_path = data_path('chgcar', 'CHGCAR')
@@ -186,7 +186,7 @@ def vasp_nscf_and_ref(vasp_calc_and_ref, vasp_chgcar, vasp_wavecar):
 
 
 @pytest.fixture()
-def vasp_inputs(fresh_aiida_env, vasp_params, vasp_kpoints, vasp_structure, potentials, vasp_code):
+def vasp_inputs(aiida_profile, vasp_params, vasp_kpoints, vasp_structure, potentials, vasp_code):
     """Inputs dictionary for CalcJob Processes."""
 
     def inner(settings=None, parameters=None):
@@ -223,7 +223,7 @@ def ref_incar(data_path):
 
 
 @pytest.fixture()
-def vasp_wavecar(fresh_aiida_env, data_path):
+def vasp_wavecar(aiida_profile, data_path):
     """WAVECAR node and reference fixture."""
 
     wavecar_path = data_path('wavecar', 'WAVECAR')
@@ -235,7 +235,7 @@ def vasp_wavecar(fresh_aiida_env, data_path):
 
 @pytest.fixture()
 def vasp2w90_inputs(
-    fresh_aiida_env,
+    aiida_profile,
     vasp_params,
     vasp_kpoints,
     vasp_structure,

--- a/tests/calcs/test_immigrant.py
+++ b/tests/calcs/test_immigrant.py
@@ -11,7 +11,7 @@ from aiida_vasp.utils.aiida_utils import create_authinfo
 
 @pytest.fixture
 def immigrant_with_builder(
-    fresh_aiida_env, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
+    aiida_profile_clean, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
 ):
     """Provide process class and inputs for importing a AiiDA-external VASP run.
 
@@ -31,7 +31,7 @@ def immigrant_with_builder(
 
 @pytest.mark.skip(reason='This immigrant not working with the new parser code')
 def test_immigrant_additional(
-    fresh_aiida_env, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
+    aiida_profile_clean, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
 ):
     """Provide process class and inputs for importing a AiiDA-external VASP run."""
     create_authinfo(localhost, store=True)
@@ -68,7 +68,7 @@ def test_vasp_immigrant(immigrant_with_builder):
 
 @pytest.fixture
 def immigrant_with_builder_example_3(
-    fresh_aiida_env, upload_potcar, potcar_family_name, potcar_mapping, phonondb_run, localhost, mock_vasp
+    aiida_profile_clean, upload_potcar, potcar_family_name, potcar_mapping, phonondb_run, localhost, mock_vasp
 ):
     """Provide process class and inputs for importing a AiiDA-external VASP run. This will be obsolete at v3."""
 
@@ -85,7 +85,7 @@ def immigrant_with_builder_example_3(
 
 @pytest.mark.skip(reason='This immigrant not working with the new parser code')
 def test_immigrant_additional_example_3(
-    fresh_aiida_env, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
+    aiida_profile_clean, upload_potcar, phonondb_run, localhost, mock_vasp, potcar_family_name, potcar_mapping
 ):  # pylint: disable=invalid-name
     """Provide process class and inputs for importing a AiiDA-external VASP run. This will be obsolete at v3."""
     create_authinfo(localhost, store=True)

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -1,11 +1,14 @@
 """Unit tests for VASP calculation monitoring functions."""
 
+import os
 import time
+from pathlib import Path
 
 import pytest
 from aiida.common.extendeddicts import AttributeDict
 
 from aiida_vasp.calcs.monitors import monitor_loop_time, monitor_stdout
+from aiida_vasp.calcs.vasp import VaspCalculation
 
 
 class MockFileStatResult:
@@ -72,6 +75,10 @@ class MockNode:
         """Mocked get_option method"""
         return self.options[key]
 
+    def get_remote_workdir(self):
+        """Mocked get_remote_workdir method"""
+        return os.getcwd()  # Use current working directory for simplicity
+
 
 @pytest.fixture
 def mock_transport():
@@ -97,8 +104,9 @@ class TestMonitorStdout:
         result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=5)
 
         # Assertions
+        stdout_path = str(Path(os.getcwd()) / VaspCalculation._VASP_OUTPUT)
         assert result is None
-        assert mock_transport.get_attribute_calls == ['vasp_output']
+        assert mock_transport.get_attribute_calls == [stdout_path]
         assert mock_transport.exec_command_wait_calls == []
 
     def test_monitor_stdout_oversized_file(self, mock_node, mock_transport):
@@ -116,8 +124,9 @@ class TestMonitorStdout:
         assert '10.00 MB' in result
         assert 'potential critical crash' in result
 
-        assert mock_transport.get_attribute_calls == ['vasp_output']
-        assert mock_transport.exec_command_wait_calls == ['truncate -s 5M vasp_output']
+        stdout_path = str(Path(os.getcwd()) / VaspCalculation._VASP_OUTPUT)
+        assert mock_transport.get_attribute_calls == [stdout_path]
+        assert mock_transport.exec_command_wait_calls == [f'truncate -s 5M {stdout_path}']
 
         # Apply a custom threshold
         mock_transport.reset()
@@ -162,7 +171,8 @@ class TestMonitorLoopTime:
 
         # Assertions
         assert result is None
-        assert mock_transport.exec_command_wait_calls == ["grep 'LOOP:' OUTCAR"]
+        outcar_path = Path(os.getcwd()) / 'OURCAR'
+        assert mock_transport.exec_command_wait_calls == [f"grep 'LOOP:' {outcar_path}"]
 
     def test_monitor_loop_time_fast_loops(self, mock_transport):
         """Test monitor_loop_time with fast electronic loops."""
@@ -235,7 +245,7 @@ class TestMonitorLoopTime:
         result = monitor_loop_time(mock_node, mock_transport)
 
         assert result is not None
-        assert 'Last update of the vasp_output file is more than 500.00 seconds ago' in result
+        assert 'file is more than 500.00 seconds ago' in result
 
     def test_monitor_loop_time_recent_update(self, mock_transport, monkeypatch):
         """Test monitor_loop_time with recent file update."""

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -236,7 +236,6 @@ class TestMonitorLoopTime:
 
         assert result is not None
         assert 'Last update of the vasp_output file is more than 500.00 seconds ago' in result
-        assert 'suspicious for a VASP calculation' in result
 
     def test_monitor_loop_time_recent_update(self, mock_transport, monkeypatch):
         """Test monitor_loop_time with recent file update."""

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -1,0 +1,282 @@
+"""Unit tests for VASP calculation monitoring functions."""
+
+import time
+
+import pytest
+from aiida.common.extendeddicts import AttributeDict
+
+from aiida_vasp.calcs.monitors import monitor_loop_time, monitor_stdout
+
+
+class MockFileStatResult:
+    """Mock object for file stat results."""
+
+    def __init__(self, size=1024, mtime=None):
+        """Initialize mock file stat result.
+
+        :param size: File size in bytes
+        :param mtime: File modification time (defaults to current time)
+        """
+        self.st_size = size
+        self.st_mtime = mtime if mtime is not None else time.time()
+
+
+class MockTransport:
+    """Mock transport object for testing."""
+
+    def __init__(self):
+        """Initialize mock transport."""
+        self.get_attribute_return = None
+        self.exec_command_wait_return = None
+        self.get_attribute_calls = []
+        self.exec_command_wait_calls = []
+
+    def reset(self):
+        """Reset the status"""
+        self.get_attribute_return = None
+        self.exec_command_wait_return = None
+        self.get_attribute_calls = []
+        self.exec_command_wait_calls = []
+
+    def get_attribute(self, filename):
+        """Mock get_attribute method."""
+        self.get_attribute_calls.append(filename)
+        return self.get_attribute_return
+
+    def exec_command_wait(self, command):
+        """Mock exec_command_wait method."""
+        self.exec_command_wait_calls.append(command)
+        if self.exec_command_wait_return is None:
+            return (0, '', '')
+        return self.exec_command_wait_return
+
+
+class MockProcessClass:
+    """Mock process class with VASP output name."""
+
+    def __init__(self, vasp_output='vasp_output'):
+        """Initialize with VASP output filename."""
+        self._VASP_OUTPUT = vasp_output
+
+
+class MockNode:
+    """Mock CalcJobNode for testing."""
+
+    def __init__(self, walltime_limit=None, vasp_output='vasp_output'):
+        """Initialize mock node."""
+        self.process_class = MockProcessClass(vasp_output)
+        self.inputs = AttributeDict()
+        self.options = {'max_wallclock_seconds': walltime_limit}
+
+    def get_option(self, key):
+        """Mocked get_option method"""
+        return self.options[key]
+
+
+@pytest.fixture
+def mock_transport():
+    """Provide a mock transport object."""
+    return MockTransport()
+
+
+@pytest.fixture
+def mock_node():
+    """Provide a mock CalcJobNode."""
+    return MockNode()
+
+
+class TestMonitorStdout:
+    """Test cases for monitor_stdout function."""
+
+    def test_monitor_stdout_normal_size(self, mock_node, mock_transport):
+        """Test monitor_stdout with normal file size."""
+        # Setup mocks
+        mock_transport.get_attribute_return = MockFileStatResult(size=1024 * 1024)  # 1MB
+
+        # Call function
+        result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=5)
+
+        # Assertions
+        assert result is None
+        assert mock_transport.get_attribute_calls == ['vasp_output']
+        assert mock_transport.exec_command_wait_calls == []
+
+    def test_monitor_stdout_oversized_file(self, mock_node, mock_transport):
+        """Test monitor_stdout with oversized file triggering truncation."""
+        # Setup mocks
+        file_size = 10 * 1024 * 1024  # 10MB
+        mock_transport.get_attribute_return = MockFileStatResult(size=file_size)
+
+        # Call function
+        result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=5)
+
+        # Assertions
+        assert result is not None
+        assert 'Very large stdout detected' in result
+        assert '10.00 MB' in result
+        assert 'potential critical crash' in result
+
+        assert mock_transport.get_attribute_calls == ['vasp_output']
+        assert mock_transport.exec_command_wait_calls == ['truncate -s 5M vasp_output']
+
+        # Apply a custom threshold
+        mock_transport.reset()
+        mock_transport.get_attribute_return = MockFileStatResult(size=file_size)
+        result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=15)
+
+        assert result is None
+        assert not mock_transport.exec_command_wait_calls
+
+        # Also pass if exactly at threshold
+        # Apply a custom threshold
+        mock_transport.reset()
+        mock_transport.get_attribute_return = MockFileStatResult(size=file_size)
+        result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=10)
+        assert result is None
+        assert not mock_transport.exec_command_wait_calls
+
+
+class TestMonitorLoopTime:
+    """Test cases for monitor_loop_time function."""
+
+    def test_monitor_loop_time_no_walltime_limit(self, mock_transport):
+        """Test monitor_loop_time when no walltime limit is set."""
+        # Setup node without walltime limit
+        mock_node = MockNode(walltime_limit=None)
+
+        # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        # Assertions
+        assert result is None
+        assert mock_transport.exec_command_wait_calls == []
+
+    def test_monitor_loop_time_no_loop_entries(self, mock_transport):
+        """Test monitor_loop_time when no LOOP entries are found in OUTCAR."""
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=3600)  # 1 hour
+        mock_transport.exec_command_wait_return = (1, '', 'grep: no match')
+
+        # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        # Assertions
+        assert result is None
+        assert mock_transport.exec_command_wait_calls == ["grep 'LOOP:' OUTCAR"]
+
+    def test_monitor_loop_time_fast_loops(self, mock_transport):
+        """Test monitor_loop_time with fast electronic loops."""
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=3600)  # 1 hour
+
+        # Mock grep output with LOOP entries (fast loops - 10 seconds each)
+        # Format: "LOOP:  CPU time  real_time"
+        grep_output = 'LOOP:  cpu time    4.0: real time    4.0\nLOOP:  cpu time    4.0: real time    4.0'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=time.time())
+
+        # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        # Assertions - should be fine as 12.3s < 3600s/10 = 360s
+        assert result is None
+
+    def test_monitor_loop_time_slow_loops(self, mock_transport):
+        """Test monitor_loop_time with slow electronic loops."""
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=3600)  # 1 hour
+
+        # Mock grep output with LOOP entries (slow loops - 400 seconds each)
+        grep_output = 'LOOP:  cpu time    400.0: real time    400\nLOOP:  cpu time    400.0: real time    400.0'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=time.time())
+
+        # Call function (default minimum_electronic_loops=10)
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        # Assertions - should detect slow loops as 450.3s > 3600s/10 = 360s
+        assert result is not None
+        assert 'Less than 10 electronic loop can be run' in result
+        assert '400.00 seconds' in result
+
+    def test_monitor_loop_time_custom_minimum_loops(self, mock_transport):
+        """Test monitor_loop_time with custom minimum electronic loops."""
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=3600)  # 1 hour
+
+        # Mock grep output with LOOP entries (200 seconds each)
+        grep_output = 'LOOP:  cpu time    400.0: real time    400\nLOOP:  cpu time    400.0: real time    400.0'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=time.time())
+
+        # Call function with minimum_electronic_loops=20
+        result = monitor_loop_time(mock_node, mock_transport, minimum_electronic_loops=20)
+
+        assert result is not None
+        assert 'Less than 20 electronic loop can be run' in result
+        assert '400.00 seconds' in result
+
+    def test_monitor_loop_time_stalled_calculation(self, mock_transport, monkeypatch):
+        """Test monitor_loop_time detecting stalled calculation."""
+        # Setup time mock - current time is much later than file modification time
+        current_time = 10000
+        file_mtime = 8000  # File last modified 2000 seconds ago
+        monkeypatch.setattr(time, 'time', lambda: current_time)
+
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=7200)  # 2 hour
+
+        # Mock grep output with LOOP entries (100 seconds each loop)
+        grep_output = 'LOOP:  cpu time    100.0: real time    100\nLOOP:  cpu time    100.0: real time    100.0'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=file_mtime)
+
+        # Call function (default patience_num_loops=5, patience_minimum_time=1800)
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        assert result is not None
+        assert 'Last update of the vasp_output file is more than 500.00 seconds ago' in result
+        assert 'suspicious for a VASP calculation' in result
+
+    def test_monitor_loop_time_recent_update(self, mock_transport, monkeypatch):
+        """Test monitor_loop_time with recent file update."""
+        # Setup time mock - file was modified recently
+        current_time = 10000
+        file_mtime = 9900  # File last modified 100 seconds ago
+        monkeypatch.setattr(time, 'time', lambda: current_time)
+
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=7200)  # 2 hour
+
+        # Mock grep output with LOOP entries (50 seconds each loop)
+        grep_output = 'LOOP:  cpu time    50.5: real time    50.5\nLOOP:  cpu time    50.5: real time    50.5'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=file_mtime)
+
+        # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        # Assertions
+        # elapsed = 10000 - 9900 = 100s
+        # last_loop_time * patience_num_loops = 50.5 * 5 = 252.5s > 100s (not stalled)
+        assert result is None
+
+    def test_monitor_loop_time_minimum_patience_not_met(self, mock_transport, monkeypatch):
+        """Test monitor_loop_time when minimum patience time is not met."""
+        # Setup time mock
+        current_time = 10000
+        file_mtime = 8500  # File last modified 1500 seconds ago
+        monkeypatch.setattr(time, 'time', lambda: current_time)
+
+        # Setup node with walltime
+        mock_node = MockNode(walltime_limit=7200)  # 2 hour
+
+        # Mock grep output with LOOP entries
+        grep_output = 'LOOP:  cpu time    100.5: real time    100.5\nLOOP:  cpu time    100.5: real time    100.5'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_return = MockFileStatResult(mtime=file_mtime)
+
+        # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        assert result is None

--- a/tests/calcs/test_neb.py
+++ b/tests/calcs/test_neb.py
@@ -10,7 +10,7 @@ from aiida_vasp.calcs.neb import VaspNEBCalculation
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('cif', 'mesh')], indirect=True)
 def test_prepare(
-    fresh_aiida_env,
+    aiida_profile,
     vasp_neb_calc,
     vasp_neb_inputs,
     sandbox_folder,

--- a/tests/calcs/test_vasp.py
+++ b/tests/calcs/test_vasp.py
@@ -179,7 +179,7 @@ def managed_temp_object():
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_vasp_calc_only_output(fresh_aiida_env, run_vasp_process):
+def test_vasp_calc_only_output(run_vasp_process):
     """Test a run of a basic VASP calculation which misses critical files."""
     _, node = run_vasp_process(test_case='stdout')
     assert node.exit_status == 352
@@ -189,7 +189,7 @@ def test_vasp_calc_only_output(fresh_aiida_env, run_vasp_process):
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_vasp_calc(fresh_aiida_env, run_vasp_process):
+def test_vasp_calc(run_vasp_process):
     """Test a run of a basic VASP calculation and its details."""
 
     results, node = run_vasp_process(settings={'parser_settings': {'check_errors': False}})

--- a/tests/commands/test_potcar_cmd.py
+++ b/tests/commands/test_potcar_cmd.py
@@ -42,7 +42,7 @@ def test_no_subcmd():
     assert result.exception is None
 
 
-def test_uploadfamily_withpath(fresh_aiida_env, cmd_params):
+def test_uploadfamily_withpath(aiida_profile_clean, cmd_params):
     """Upload the test potcar family and check it is there."""
 
     result = run_cmd(
@@ -58,7 +58,7 @@ def test_uploadfamily_withpath(fresh_aiida_env, cmd_params):
     assert [g.label for g in potcar_cls.get_potcar_groups()] == [cmd_params.FAMILY_NAME]
 
 
-def test_uploadfamily_tar(fresh_aiida_env, cmd_params):
+def test_uploadfamily_tar(aiida_profile_clean, cmd_params):
     """Give a tar file as the source."""
     path_option = f'--path={Path(cmd_params.POTCAR_PATH) / "Ga.tar"!s}'
     result = run_cmd('uploadfamily', [path_option, cmd_params.NAME_OPTION, cmd_params.DESC_OPTION])
@@ -69,7 +69,7 @@ def test_uploadfamily_tar(fresh_aiida_env, cmd_params):
     assert [g.label for g in potcar_cls.get_potcar_groups()] == [cmd_params.FAMILY_NAME]
 
 
-def test_uploadfamily_inworkdir(fresh_aiida_env, cmd_params):
+def test_uploadfamily_inworkdir(aiida_profile_clean, cmd_params):
     """Upload the test potcar family from the working env."""
 
     potcar_dir = Path(cmd_params.POTCAR_PATH)
@@ -90,7 +90,7 @@ def test_uploadfamily_inworkdir(fresh_aiida_env, cmd_params):
     assert str(old_work_dir) == str(Path().cwd())
 
 
-def test_uploadfamily_again(fresh_aiida_env, upload_potcar, cmd_params):
+def test_uploadfamily_again(aiida_profile_clean, upload_potcar, cmd_params):
     """
     Re-upload a potcar family.
 
@@ -116,7 +116,7 @@ def test_uploadfamily_again(fresh_aiida_env, upload_potcar, cmd_params):
     assert group_count == group_qb.count()
 
 
-def test_uploadfamily_dryrun(fresh_aiida_env, cmd_params):
+def test_uploadfamily_dryrun(aiida_profile_clean, cmd_params):
     """Make sure --dry-run does not affect the db."""
     node_qb = QueryBuilder(path=[Node])
     node_count = node_qb.count()
@@ -148,7 +148,7 @@ def test_listfamilies_existence():
     assert result.output
 
 
-def test_listfamilies_nofilter(fresh_aiida_env, upload_potcar, potcar_family_name):
+def test_listfamilies_nofilter(aiida_profile_clean, upload_potcar, potcar_family_name):
     """Test typical usecases without filtering."""
     result = run_cmd('listfamilies')
     assert not result.exception
@@ -161,7 +161,7 @@ def test_listfamilies_nofilter(fresh_aiida_env, upload_potcar, potcar_family_nam
     assert family_group.description in result.output
 
 
-def test_listfamilies_filtering(fresh_aiida_env, upload_potcar, potcar_family_name):
+def test_listfamilies_filtering(aiida_profile_clean, upload_potcar, potcar_family_name):
     """Test filtering families by elements & symbols."""
     result = run_cmd('listfamilies', ['--element', 'In', '--element', 'As'])
     assert potcar_family_name in result.output
@@ -182,7 +182,7 @@ def test_listfamilies_filtering(fresh_aiida_env, upload_potcar, potcar_family_na
     assert potcar_family_name not in result.output
 
 
-def test_exportfamilies(fresh_aiida_env, upload_potcar, potcar_family_name, tmp_path):
+def test_exportfamilies(aiida_profile_clean, upload_potcar, potcar_family_name, tmp_path):
     """Test exporting potcar family."""
     result = run_cmd('exportfamily', ['--name', potcar_family_name, '--path', str(tmp_path)])
     assert not result.exception
@@ -218,7 +218,7 @@ def test_call_from_vasp():
     assert 'Usage: verdi data vasp.potcar' in output  # pylint: disable=unsupported-membership-test
 
 
-def test_migrate_command(fresh_aiida_env, legacy_potcar_family):
+def test_migrate_command(aiida_profile_clean, legacy_potcar_family):
     """Test the migration command"""
 
     legacy_name, legacy_group_class = legacy_potcar_family

--- a/tests/commands/test_tools.py
+++ b/tests/commands/test_tools.py
@@ -22,7 +22,7 @@ def run_cmd(command=None, args=None, **kwargs):
 # TODO - add tests for other commands
 # Combine export test with workflow execution test to save time
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_uploadfamily_withpath(fresh_aiida_env, tmp_path, run_vasp_process):
+def test_uploadfamily_withpath(aiida_profile_clean, tmp_path, run_vasp_process):
     """
     Test export vasp calculation
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def localhost_dir(tmp_path_factory):
 
 
 @pytest.fixture()
-def localhost(fresh_aiida_env, localhost_dir):
+def localhost(aiida_profile, localhost_dir):
     """Fixture for a local computer called localhost. This is currently not in the AiiDA fixtures."""
     try:
         computer = Computer.collection.get(label='localhost')
@@ -58,7 +58,7 @@ def localhost(fresh_aiida_env, localhost_dir):
 
 
 @pytest.fixture()
-def mock_vasp(fresh_aiida_env, localhost):
+def mock_vasp(aiida_profile, localhost):
     """
     Give an mock-up of the VASP executable
 
@@ -66,11 +66,11 @@ def mock_vasp(fresh_aiida_env, localhost):
     calculations from the registry is found. This makes it suitable for simple
     tests.
     """
-    return _mock_vasp(fresh_aiida_env, localhost, 'mock-vasp-loose')
+    return _create_mock_vasp_code(aiida_profile, localhost, 'mock-vasp-loose')
 
 
 @pytest.fixture()
-def mock_vasp_strict(fresh_aiida_env, localhost):
+def mock_vasp_strict(aiida_profile, localhost):
     """
     Give an mock-up of the VASP executable with strict input matching.
 
@@ -78,7 +78,7 @@ def mock_vasp_strict(fresh_aiida_env, localhost):
     registry is found. It is suitable for testsing complex multi-step workchains.
     tests.
     """
-    return _mock_vasp(fresh_aiida_env, localhost, 'mock-vasp')
+    return _create_mock_vasp_code(aiida_profile, localhost, 'mock-vasp')
 
 
 @pytest.fixture()
@@ -130,13 +130,13 @@ def vasp_code(localhost):
 
 
 @pytest.fixture
-def vasp_params(fresh_aiida_env):
+def vasp_params(aiida_profile):
     incar_data = orm.Dict(dict={'gga': 'PE', 'gga_compat': False, 'lorbit': 11, 'sigma': 0.5, 'magmom': '30 * 2*0.'})
     return incar_data
 
 
 @pytest.fixture(params=['cif', 'str'])
-def vasp_structure(request, fresh_aiida_env, data_path):
+def vasp_structure(request, aiida_profile, data_path):
     """Fixture: StructureData or CifData."""
     if request.param == 'cif':
         cif_path = data_path('cif', 'EntryWithCollCode43360.cif')
@@ -168,7 +168,7 @@ def vasp_structure(request, fresh_aiida_env, data_path):
 
 
 @pytest.fixture(params=['mesh', 'list'])
-def vasp_kpoints(request, fresh_aiida_env, data_path):
+def vasp_kpoints(request, aiida_profile, data_path):
     """Fixture: (kpoints object, resulting KPOINTS)."""
 
     def _ref_kp_list():
@@ -231,8 +231,11 @@ def temp_pot_folder(tmp_path, data_path):
 
 
 @pytest.fixture
-def upload_potcar(fresh_aiida_env, temp_pot_folder, potcar_family_name, data_path):
+def upload_potcar(aiida_profile, temp_pot_folder, potcar_family_name, data_path):
     """Upload a POTCAR family to DB."""
+    if PotcarData.get_potcar_group(potcar_family_name) is not None:
+        # Already uploaded, so we do not need to do it again.
+        return
 
     def duplicate_potcar_data(potcar_node):
         """Create and store (and return) a duplicate of a given PotcarData node."""
@@ -304,7 +307,7 @@ def phonondb_run(tmp_path, data_path):
 
 @pytest.fixture()
 def run_vasp_process(
-    fresh_aiida_env,
+    aiida_profile,
     upload_potcar,
     vasp_params,
     potcar_family_name,
@@ -376,7 +379,7 @@ def run_vasp_process(
 
 
 @pytest.fixture()
-def mock_potcars(fresh_aiida_env, temp_pot_folder):
+def mock_potcars(aiida_profile, temp_pot_folder):
     """Create family of potcars for mock-vasp"""
     path = os.environ.get('MOCK_VASP_POTCAR_PATH', None)
     if path:
@@ -391,7 +394,7 @@ def mock_potcars(fresh_aiida_env, temp_pot_folder):
 
 @pytest.fixture()
 def builder_updater(
-    fresh_aiida_env,
+    aiida_profile,
     mock_potcars,
     mock_vasp,
 ):
@@ -465,7 +468,7 @@ def get_call_root(node):
     return caller
 
 
-def _mock_vasp(fresh_aiida_env, localhost, exec_name):
+def _create_mock_vasp_code(aiida_profile, localhost, exec_name):
     """
     Points to a mock-up of a VASP executable.
 

--- a/tests/data/conftest.py
+++ b/tests/data/conftest.py
@@ -16,14 +16,14 @@ from aiida_vasp.data.potcar import PotcarData, PotcarFileData
 
 
 @pytest.fixture
-def vasp2w90_params(fresh_aiida_env, vasp_params):
+def vasp2w90_params(aiida_profile, vasp_params):
     vasp_params_data = vasp_params()
     incar_data = orm.Dict(dict=vasp_params_data.code.get_dict().update({'lwannier90': True}))
     return incar_data
 
 
 @pytest.fixture
-def potcar_node_pair(fresh_aiida_env, data_path):
+def potcar_node_pair(aiida_profile, data_path):
     """Create a POTCAR node pair."""
     potcar_path = data_path('potcar', 'As', 'POTCAR')
     potcar_file_node = PotcarFileData(file=potcar_path)

--- a/tests/data/test_potcar.py
+++ b/tests/data/test_potcar.py
@@ -11,7 +11,7 @@ from aiida.common.exceptions import NotExistent, UniquenessError
 from aiida_vasp.data.potcar import PotcarData, PotcarFileData, PotcarGroup, migrate_potcar_group
 
 
-def test_creation(fresh_aiida_env, potcar_node_pair):
+def test_creation(aiida_profile_clean, potcar_node_pair):
     """Test creating a data node pair."""
     potcar_node = PotcarData.find_one(symbol='As')
     file_node = potcar_node.find_file_node()
@@ -19,7 +19,7 @@ def test_creation(fresh_aiida_env, potcar_node_pair):
     assert file_node.pk == potcar_node_pair['file'].pk
 
 
-def test_hashing(aiida_profile, data_path, read_file):
+def test_hashing(aiida_profile_clean, data_path, read_file):
     """Ensure the file and content sha512 hash equivalently for the same POTCAR."""
     potcar_file_cls = PotcarFileData
     potcar_path = ['potcar', 'As', 'POTCAR']
@@ -30,7 +30,7 @@ def test_hashing(aiida_profile, data_path, read_file):
 
 
 # pylint: disable=protected-access
-def test_store_duplicate(fresh_aiida_env, potcar_node_pair, data_path):
+def test_store_duplicate(aiida_profile_clean, potcar_node_pair, data_path):
     """
     Storing a duplicate POTCAR node must fail.
 
@@ -65,7 +65,7 @@ def test_store_duplicate(fresh_aiida_env, potcar_node_pair, data_path):
     assert PotcarFileData.find_one(symbol='As')
 
 
-def test_export_import(fresh_aiida_env, potcar_node_pair, tmp_path, data_path):
+def test_export_import(aiida_profile_clean, potcar_node_pair, tmp_path, data_path):
     """Exporting and importing back may not store duplicates."""
     tempfile = tmp_path / 'potcar.aiida'
 
@@ -84,24 +84,24 @@ def test_export_import(fresh_aiida_env, potcar_node_pair, tmp_path, data_path):
     assert PotcarFileData.find_one(symbol='As')
 
 
-def test_exists(fresh_aiida_env, potcar_node_pair):
+def test_exists(aiida_profile_clean, potcar_node_pair):
     assert PotcarFileData.exists(element='As')
     assert not PotcarData.exists(element='Xe')
 
 
-def test_find(fresh_aiida_env, potcar_node_pair):
+def test_find(aiida_profile_clean, potcar_node_pair):
     assert PotcarData.find_one(element='As').uuid == potcar_node_pair['potcar'].uuid
     with pytest.raises(NotExistent):
         _ = PotcarFileData.find_one(element='Xe')
 
 
-def test_file_get_content(fresh_aiida_env, potcar_node_pair, data_path):
+def test_file_get_content(aiida_profile_clean, potcar_node_pair, data_path):
     file_node_as = potcar_node_pair['file']
     original_file = pathlib.Path(data_path(file_node_as.original_file_name))
     assert original_file.read_text(encoding='utf8') == file_node_as.get_content().decode()
 
 
-def test_file_get_or_create(fresh_aiida_env, potcar_node_pair, data_path):
+def test_file_get_or_create(aiida_profile_clean, potcar_node_pair, data_path):
     """Test get_or_create of PotcarFileData."""
     potcar_as_path = data_path('potcar', 'As', 'POTCAR')
     potcar_file_cls = PotcarFileData
@@ -116,7 +116,7 @@ def test_file_get_or_create(fresh_aiida_env, potcar_node_pair, data_path):
     assert potcar_file_cls.exists(sha512=node_file_in.sha512)
 
 
-def test_potcar_get_or_create(fresh_aiida_env, potcar_node_pair, data_path):
+def test_potcar_get_or_create(aiida_profile_clean, potcar_node_pair, data_path):
     """Test get_or_create method of PotcarData."""
     potcar_cls = PotcarData
     file_cls = PotcarFileData
@@ -132,7 +132,7 @@ def test_potcar_get_or_create(fresh_aiida_env, potcar_node_pair, data_path):
     assert potcar_cls.exists(sha512=node_potcar_in.sha512)
 
 
-def test_potcar_from_file(fresh_aiida_env, data_path):
+def test_potcar_from_file(aiida_profile_clean, data_path):
     """Test creating a node pair from a file, creating the data node first."""
     potcar_cls = PotcarData
     _, created = potcar_cls.get_or_create_from_file(data_path('potcar', 'As', 'POTCAR'))
@@ -141,7 +141,7 @@ def test_potcar_from_file(fresh_aiida_env, data_path):
     assert not created
 
 
-def test_potcar_from_structure(fresh_aiida_env, upload_potcar, potcar_family_name):
+def test_potcar_from_structure(aiida_profile_clean, upload_potcar, potcar_family_name):
     """Test getting POTCARS from a family for a structure."""
     indium_2 = orm.StructureData()
     indium_2.append_atom(position=[0, 0, 0], symbols='In')
@@ -154,7 +154,7 @@ def test_potcar_from_structure(fresh_aiida_env, upload_potcar, potcar_family_nam
     assert in2_potcars['In'].uuid == in_d_potcar.uuid == in2_potcars['In1'].uuid
 
 
-def test_upload(fresh_aiida_env, temp_pot_folder, data_path):
+def test_upload(aiida_profile_clean, temp_pot_folder, data_path):
     """Test uploading a family of POTCAR files."""
     family_name = 'test_family'
     family_desc = 'Test Family'
@@ -188,7 +188,7 @@ def test_upload(fresh_aiida_env, temp_pot_folder, data_path):
     assert not potcar_ga.exists()
 
 
-def test_export_family_folder(fresh_aiida_env, upload_potcar, potcar_family_name, tmp_path):
+def test_export_family_folder(aiida_profile_clean, upload_potcar, potcar_family_name, tmp_path):
     """Test exporting to folder."""
     export_dir = tmp_path / 'export'
     export_dir.mkdir()
@@ -217,7 +217,7 @@ def test_export_family_folder(fresh_aiida_env, upload_potcar, potcar_family_name
     assert new_dir.exists()
 
 
-def test_export_family_archive(fresh_aiida_env, upload_potcar, potcar_family_name, tmp_path):
+def test_export_family_archive(aiida_profile_clean, upload_potcar, potcar_family_name, tmp_path):
     """Test exporting to archive."""
     export_dir = tmp_path / 'export'
     export_dir.mkdir()
@@ -280,7 +280,7 @@ def test_family_migrate(upload_potcar, legacy_potcar_family):
     assert uuids_migrated == uuids_original
 
 
-def test_old_style_detect(potcar_family_name, potcar_mapping, legacy_potcar_family):
+def test_old_style_detect(aiida_profile_clean, potcar_family_name, potcar_mapping, legacy_potcar_family):
     """Test the assestion that the potcars are found old in the legacy group not the new"""
     potcar_cls = PotcarData
     elements = potcar_mapping.keys()

--- a/tests/data/test_potcar_walker.py
+++ b/tests/data/test_potcar_walker.py
@@ -23,7 +23,7 @@ def temp_data_folder(tmpdir, data_path):
 
 
 @pytest.fixture
-def potcar_walker_cls(fresh_aiida_env):
+def potcar_walker_cls(aiida_profile):
     return PotcarWalker
 
 

--- a/tests/parsers/content_parsers/test_outcar_parser.py
+++ b/tests/parsers/content_parsers/test_outcar_parser.py
@@ -130,7 +130,7 @@ def test_parse_outcar_status_extended(outcar_parser, expected):
     ],
     indirect=True,
 )
-def test_parse_outcar_magnetizationr(fresh_aiida_env, outcar_parser):
+def test_parse_outcar_magnetizationr(aiida_profile, outcar_parser):
     """Load a reference OUTCAR parser.
 
     We check that it parses and provides the correct content for the magnetization.
@@ -174,7 +174,7 @@ def test_parse_outcar_magnetizationr(fresh_aiida_env, outcar_parser):
     ],
     indirect=True,
 )
-def test_parse_outcar_magnetization_single(fresh_aiida_env, outcar_parser):  # pylint: disable=invalid-name
+def test_parse_outcar_magnetization_single(aiida_profile, outcar_parser):  # pylint: disable=invalid-name
     """Load a reference OUTCAR parser.
 
     We check that it parses and provides the correct content for the magnetization
@@ -204,7 +204,7 @@ def test_parse_outcar_magnetization_single(fresh_aiida_env, outcar_parser):  # p
 
 
 @pytest.mark.parametrize('neb_outcar_parser', ['neb/01'], indirect=True)
-def test_neb(fresh_aiida_env, neb_outcar_parser):
+def test_neb(aiida_profile, neb_outcar_parser):
     """
     Test that the parameter node is a ParametersData instance.
 

--- a/tests/parsers/content_parsers/test_potcar_parser.py
+++ b/tests/parsers/content_parsers/test_potcar_parser.py
@@ -12,7 +12,7 @@ def verify_potcario(potcario):
     assert potcario.content
 
 
-def test_potcar_from_path(fresh_aiida_env, data_path):
+def test_potcar_from_path(aiida_profile, data_path):
     """Create a PotcarIo instance from a file path."""
     potcar_path_as = data_path('potcar', 'As', 'POTCAR')
     from_ctor = PotcarIo(path=potcar_path_as)
@@ -49,7 +49,7 @@ def test_potcar_from_contents(upload_potcar, read_file):
     assert from_ctor == from_from
 
 
-def test_file_contents_equivalence(fresh_aiida_env, data_path, read_file):
+def test_file_contents_equivalence(aiida_profile, data_path, read_file):
     potcar_path_as = ['potcar', 'As', 'POTCAR']
     from_file = PotcarIo(path=data_path(*potcar_path_as))
     from_contents = PotcarIo(contents=read_file(*potcar_path_as).encode('utf-8'))

--- a/tests/parsers/content_parsers/test_vasprun_parser.py
+++ b/tests/parsers/content_parsers/test_vasprun_parser.py
@@ -789,7 +789,7 @@ def test_parse_vasprun_dynmat(vasprun_parser):
 
 
 @pytest.mark.parametrize(['vasprun_parser'], [('spin',)], indirect=True)
-def test_band_properties(fresh_aiida_env, vasprun_parser):
+def test_band_properties(aiida_profile, vasprun_parser):
     """Load a reference vasprun.xml and check that key properties of the electric structure
     are returned correctly."""
     data = vasprun_parser.get_quantity('band_properties')

--- a/tests/utils/test_aiida_utils.py
+++ b/tests/utils/test_aiida_utils.py
@@ -8,7 +8,7 @@ from aiida_vasp.utils.aiida_utils import convert_dict_case, get_current_user
 from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
 
 
-def test_get_current_user(fresh_aiida_env):
+def test_get_current_user(aiida_profile_clean):
     """Assert that get_current_user returns a user."""
     user = get_current_user()
     assert user.pk
@@ -18,7 +18,7 @@ def test_get_current_user(fresh_aiida_env):
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_pmg_adaptor(fresh_aiida_env, tmp_path, run_vasp_process):
+def test_pmg_adaptor(aiida_profile_clean, tmp_path, run_vasp_process):
     """
     Test export vasp calculation
     """

--- a/tests/utils/test_aiida_utils.py
+++ b/tests/utils/test_aiida_utils.py
@@ -5,7 +5,13 @@ import warnings
 import pytest
 
 from aiida_vasp.utils.aiida_utils import convert_dict_case, get_current_user
-from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
+
+try:
+    from aiida_vasp.utils.pmg import PymatgenAdapator, get_incar, get_kpoints, get_outcar, get_vasprun
+except ImportError:
+    PMG_INSTALLED = False
+else:
+    PMG_INSTALLED = True
 
 
 def test_get_current_user(fresh_aiida_env):
@@ -17,6 +23,7 @@ def test_get_current_user(fresh_aiida_env):
     assert user.email
 
 
+@pytest.mark.skipif(not PMG_INSTALLED, reason='pymatgen not installed')
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 def test_pmg_adaptor(fresh_aiida_env, tmp_path, run_vasp_process):
     """

--- a/tests/utils/test_band_info.py
+++ b/tests/utils/test_band_info.py
@@ -12,7 +12,7 @@ from aiida_vasp.utils.compare_bands import (
 
 
 @pytest.fixture
-def example_bands(fresh_aiida_env):
+def example_bands(aiida_profile_clean):
     """Example eigen values and occupations"""
 
     bdata = BandsData()
@@ -24,7 +24,7 @@ def example_bands(fresh_aiida_env):
 
 
 @pytest.fixture
-def example_bands_v2(fresh_aiida_env):
+def example_bands_v2(aiida_profile_clean):
     """Example eigen values and occupations"""
     bdata = BandsData()
     bdata.set_kpoints([[0, 0, 0], [0.25, 0.25, 0.25]])

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -20,7 +20,7 @@ from aiida.plugins.factories import DataFactory
 
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
-def test_vasp_wc(fresh_aiida_env, run_vasp_process):
+def test_vasp_wc(run_vasp_process):
     """Test submitting only, not correctness, with mocked vasp code."""
     results, node = run_vasp_process(process_type='workchain')
     assert node.exit_status == 0
@@ -127,7 +127,7 @@ def setup_vasp_workchain(structure, incar, nkpts, potcar_family_name, potcar_map
     return inputs
 
 
-def test_vasp_incar_case(fresh_aiida_env):
+def test_vasp_incar_case(aiida_profile):
     """Test catching inconsistent incar key cases"""
     workchain = WorkflowFactory('vasp.vasp')
     builder = workchain.get_builder()
@@ -135,7 +135,7 @@ def test_vasp_incar_case(fresh_aiida_env):
         builder.parameters = orm.Dict(dict={'incar': {'ALGO': 21}})
 
 
-def test_vasp_wc_nelm(fresh_aiida_env, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict):
+def test_vasp_wc_nelm(aiida_profile, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict):
     """Test with mocked vasp code for handling electronic convergence issues"""
 
     workchain = WorkflowFactory('vasp.vasp')
@@ -193,7 +193,7 @@ def test_vasp_wc_nelm(fresh_aiida_env, upload_potcar, potcar_family_name, potcar
     [[INCAR_IONIC_CONV, 8, [702, 0]], [INCAR_IONIC_UNFINISHED, 16, [700, 0]]],
 )
 def test_vasp_wc_ionic_continue(
-    fresh_aiida_env, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict, incar, nkpts, exit_codes
+    aiida_profile, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict, incar, nkpts, exit_codes
 ):
     """Test with mocked vasp code for handling ionic convergence issues"""
     workchain = WorkflowFactory('vasp.vasp')
@@ -224,9 +224,7 @@ def test_vasp_wc_ionic_continue(
 
 
 @pytest.mark.skip(reason='This test is not working yet')
-def test_vasp_wc_ionic_magmom_carry(
-    fresh_aiida_env, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict
-):
+def test_vasp_wc_ionic_magmom_carry(aiida_profile, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict):
     """Test with mocked vasp code for handling ionic convergence issues"""
 
     workchain = WorkflowFactory('vasp.vasp')

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -31,6 +31,9 @@ def test_vasp_wc(fresh_aiida_env, run_vasp_process):
     assert np.amax(np.linalg.norm(misc['stress'], axis=1)) == pytest.approx(22.8499295)
     assert misc['total_energies']['energy_extrapolated'] == pytest.approx(-14.16209692)
 
+    assert 'stdout' in node.called[0].inputs.monitors
+    assert 'loop_time' in node.called[0].inputs.monitors
+
 
 def si_structure():
     """

--- a/tests/workchains/test_vasp_wc_mock.py
+++ b/tests/workchains/test_vasp_wc_mock.py
@@ -33,7 +33,7 @@ from aiida_vasp.workchains import (
 )
 
 
-def test_silicon_sp(mock_potcars, mock_vasp_strict, builder_updater):
+def test_silicon_sp(fresh_aiida_env, mock_potcars, mock_vasp_strict, builder_updater):
     """Test running a VASP workchain on silicon using the mock code."""
     si = bulk('Si', 'diamond', 5.4)
     si_node = orm.StructureData(ase=si)
@@ -47,7 +47,7 @@ def test_silicon_sp(mock_potcars, mock_vasp_strict, builder_updater):
     assert results.node.is_finished_ok
 
 
-def test_silicon_relax(mock_potcars, mock_vasp_strict, builder_updater):
+def test_silicon_relax(fresh_aiida_env, mock_potcars, mock_vasp_strict, builder_updater):
     """Test running a VASP workchain on silicon using the mock code."""
     si = bulk('Si', 'diamond', 5.4)
     si_node = orm.StructureData(ase=si)
@@ -60,7 +60,7 @@ def test_silicon_relax(mock_potcars, mock_vasp_strict, builder_updater):
     assert results.node.is_finished_ok
 
 
-def test_silicon_converge(mock_potcars, mock_vasp_strict):
+def test_silicon_converge(fresh_aiida_env, mock_potcars, mock_vasp_strict):
     """Test running a VASP workchain on silicon using the mock code."""
     si = bulk('Si', 'diamond', 5.4)
     si_node = orm.StructureData(ase=si)
@@ -74,7 +74,7 @@ def test_silicon_converge(mock_potcars, mock_vasp_strict):
     assert results.node.is_finished_ok
 
 
-def test_silicon_band(mock_potcars, mock_vasp_strict):
+def test_silicon_band(fresh_aiida_env, mock_potcars, mock_vasp_strict):
     """Test running a VASP workchain on silicon using the mock code."""
     si = bulk('Si', 'diamond', 5.4)
     si_node = orm.StructureData(ase=si)
@@ -87,7 +87,7 @@ def test_silicon_band(mock_potcars, mock_vasp_strict):
     assert results.node.is_finished_ok
 
 
-def test_silicon_band_hybrid(mock_potcars, mock_vasp_strict):
+def test_silicon_band_hybrid(fresh_aiida_env, mock_potcars, mock_vasp_strict):
     """Test the hybrid (split-path) SCF  band structure workchain"""
 
     si = bulk('Si', 'diamond', 5.4)
@@ -101,7 +101,7 @@ def test_silicon_band_hybrid(mock_potcars, mock_vasp_strict):
     assert results.node.is_finished_ok
 
 
-def test_silicon_band_hybrid_no_relax(mock_potcars, mock_vasp_strict):
+def test_silicon_band_hybrid_no_relax(fresh_aiida_env, mock_potcars, mock_vasp_strict):
     """Test the hybrid (split-path) SCF  band structure workchain"""
 
     si = bulk('Si', 'diamond', 5.4)
@@ -115,7 +115,7 @@ def test_silicon_band_hybrid_no_relax(mock_potcars, mock_vasp_strict):
     assert results.node.is_finished_ok
 
 
-def test_silicon_relax_staged(mock_potcars, mock_vasp_strict, builder_updater):
+def test_silicon_relax_staged(fresh_aiida_env, mock_potcars, mock_vasp_strict, builder_updater):
     """Test running a VASP workchain on silicon using the mock code."""
 
     si = bulk('Si', 'diamond', 5.4)

--- a/tests/workchains/v2/test_builder_updater.py
+++ b/tests/workchains/v2/test_builder_updater.py
@@ -5,9 +5,8 @@ from ase.build import bulk
 from aiida_vasp.workchains.v2.common import builder_updater as bup
 
 
-def test_vasp_builder_updater(aiida_profile, vasp_code):
+def test_vasp_builder_updater(aiida_profile_clean, vasp_code, upload_potcar, potcar_family_name):
     structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
-
     vasp_code.store()
     upd = bup.VaspBuilderUpdater()
     upd.apply_preset(structure, code='vasp@localhost')
@@ -17,13 +16,15 @@ def test_vasp_builder_updater(aiida_profile, vasp_code):
     assert upd.builder.code == vasp_code
     assert upd.builder.settings.get_dict() == {}
     assert upd.builder.kpoints_spacing.value == 0.05
-    assert upd.builder.potential_family.value == 'PBE.54'
     assert upd.builder.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
-    # Re-apply the preset - this should work without any errors
-    upd.apply_preset(structure, code='vasp@localhost')
+    # The default family is not uploaded - this should remain None
+    assert upd.builder.potential_family is None
+
+    upd.set_potential_family(potcar_family_name)
+    assert upd.builder.potential_family.value == potcar_family_name
 
 
-def test_vasp_relax_updater(aiida_profile, vasp_code):
+def test_vasp_relax_updater(aiida_profile_clean, vasp_code):
     structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
     vasp_code.store()
     upd = bup.VaspRelaxUpdater()
@@ -34,14 +35,13 @@ def test_vasp_relax_updater(aiida_profile, vasp_code):
     assert upd.builder.vasp.code == vasp_code
     assert upd.builder.vasp.settings.get_dict() == {}
     assert upd.builder.vasp.kpoints_spacing.value == 0.05
-    assert upd.builder.vasp.potential_family.value == 'PBE.54'
+    assert upd.builder.vasp.potential_family is None
     assert upd.builder.vasp.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
     assert upd.builder.relax_settings.get_dict()['algo'] == 'cg'
 
 
-@pytest.mark.skip(reason='Not finalised he hybrid band structure workchain interface yet')
 @pytest.mark.parametrize('hybrid', [True, False])
-def test_vasp_band_updater(aiida_profile, vasp_code, hybrid):
+def test_vasp_band_updater(aiida_profile_clean, vasp_code, hybrid):
     structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
     vasp_code.store()
     if hybrid:
@@ -55,7 +55,7 @@ def test_vasp_band_updater(aiida_profile, vasp_code, hybrid):
     assert upd.builder.scf.code == vasp_code
     assert upd.builder.scf.settings.get_dict() == {}
     assert upd.builder.scf.kpoints_spacing.value == 0.05
-    assert upd.builder.scf.potential_family.value == 'PBE.54'
+    assert upd.builder.scf.potential_family is None
     assert upd.builder.scf.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
 
     if hybrid:
@@ -70,11 +70,11 @@ def test_vasp_band_updater(aiida_profile, vasp_code, hybrid):
     assert upd.builder.relax.vasp.code == vasp_code
     assert upd.builder.relax.vasp.settings.get_dict() == {}
     assert upd.builder.relax.vasp.kpoints_spacing.value == 0.05
-    assert upd.builder.relax.vasp.potential_family.value == 'PBE.54'
+    assert upd.builder.relax.vasp.potential_family is None
     assert upd.builder.relax.vasp.potential_mapping.get_dict() == {'Mg': 'Mg_pv', 'O': 'O'}
 
 
-def test_vasp_neb_updater(aiida_profile, vasp_code):
+def test_vasp_neb_updater(aiida_profile_clean, vasp_code):
     structure = orm.StructureData(ase=bulk('MgO', 'rocksalt', 5.0)).store()
     vasp_code.store()
     upd = bup.VaspNEBUpdater()


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:
#629
blocks:

is blocked by:

None of the above but is still related to the following:

## Description

This PR implements monitors for `VaspCalculation`. The monitors can be used to early terminate calculation to compute that are:

- Abnormal large stdout output - usually an indication of a crashed but stuck calculation. 
- Large LOOP time compared to the user defined wall-time limits - so the calculation is unlikely to finish even a single electronic loops
- No update of the stdout for a time that is many times of the LOOP time - so the calculation is likely stuck (for example, due to disk quota). 

The monitors are enabled by default for calculations launched via `VaspWorkChain`.  This can be turned off by settings '{'no_default_monitors': True}' in `inputs.settings`.

Some minor update to the documentations are also updated.
A validator for the `potential_faimly` input port is added for `VaspWorkChain`. 