### PR TITLE
👌 Use `parameters_validator` to convert to lowercase

### DIFF
--- a/src/aiida_vasp/workchains/v2/common/__init__.py
+++ b/src/aiida_vasp/workchains/v2/common/__init__.py
@@ -56,12 +56,16 @@ def parameters_validator(node: orm.Dict | None, port: Any = None) -> None:
         return
 
     pdict = node.get_dict()
+
     try:
-        convert_dict_case(pdict, lower=True, raise_convert=True)
+        convert_dict_case(pdict, lower=True, raise_convert=node.is_stored)
     except ValueError as error:
         raise InputValidationError(
             f'Case inconsistency found in the parameters dictionary please use lower case keys: {error}'
         )
+
+    if not node.is_stored:
+        node.set_dict(convert_dict_case(pdict, lower=True, warn=True))
 
     if OVERRIDE_NAMESPACE not in pdict:
         raise InputValidationError(f'Would expect some incar tags supplied under {OVERRIDE_NAMESPACE} key!')

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -131,8 +131,15 @@ def test_vasp_incar_case(aiida_profile):
     """Test catching inconsistent incar key cases"""
     workchain = WorkflowFactory('vasp.vasp')
     builder = workchain.get_builder()
-    with pytest.raises(InputValidationError):
-        builder.parameters = orm.Dict(dict={'incar': {'ALGO': 21}})
+
+    with pytest.warns(UserWarning, match="Key 'ALGO' converted to 'algo'"):
+        builder.parameters = orm.Dict({'incar': {'ALGO': 21}})
+
+    parameters = orm.Dict({'incar': {'ALGO': 21}})
+    parameters.store()
+
+    with pytest.raises(InputValidationError, match='Case inconsistency found in'):
+        builder.parameters = parameters
 
 
 def test_vasp_wc_nelm(aiida_profile, upload_potcar, potcar_family_name, potcar_mapping, mock_vasp_strict):


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [ ] ready to be reviewed and merged (as soon as tests have passed)
 - [x] work in progress (early feedback welcome)

## Interactions with issues / other PRs

Fixes #799 

## Description

The `parameters` input of the `VaspWorkChain` has a validator (`parameters_validator`) that among other things checks if all the keys of the provided dictionary are lowercase. If they are not, an `InputValidationError` is raised.

Since it is possible to update the contents of the validated `node` in the validator, here we adapt the validator to instead change the case of the provided keys to lowercase on the fly, and warn the user of any keys that were updated.