### PR TITLE
Added option to bypass residual force check

### DIFF
--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -172,7 +172,7 @@ class RelaxOptions(OptionContainer):
         'due to change of basis set with variable cell and high-throughput studies.',
         default=False,
     )
-    residual_check: bool = Field(
+    residual_forces_check: bool = Field(
         description='Whether to perform residual force check after relaxation to ensure the forces are below threshold',
         default=True,
     )

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -172,6 +172,10 @@ class RelaxOptions(OptionContainer):
         'due to change of basis set with variable cell and high-throughput studies.',
         default=False,
     )
+    residual_check: bool = Field(
+        description='Whether to perform residual force check after relaxation to ensure the forces are below threshold',
+        default=True,
+    )
 
     # TODO: implement pyandtic checks
 

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -224,7 +224,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         )  # relax_settings controls the logic of the workchain
         self.ctx.current_magmom = None
         self.ctx.is_double_relax = self.ctx.relax_settings.get('double_relax_mode', False)
-        self.ctx.do_residual_check = self.ctx.relax_settings.get('residual_check', True)
+        self.ctx.do_residual_forces_check = self.ctx.relax_settings.get('residual_forces_check', True)
 
         # Check potential issues in the the input parameters
         self._check_input_parameters()
@@ -798,7 +798,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
                 # TODO: Make this check part of the convergence cycle?
                 actual_max_force > max(max_force_threshold * 1.5, max_force_threshold + 0.001)
                 and self.perform_relaxation()
-                and self.ctx.do_residual_check
+                and self.ctx.do_residual_forces_check
             ):
                 if self.is_verbose():
                     self.report(

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -223,7 +223,8 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
             self.inputs.relax_settings.get_dict()
         )  # relax_settings controls the logic of the workchain
         self.ctx.current_magmom = None
-        self.ctx.is_double_relax = self.inputs.relax_settings.get('double_relax_mode', False)
+        self.ctx.is_double_relax = self.ctx.relax_settings.get('double_relax_mode', False)
+        self.ctx.do_residual_check = self.ctx.relax_settings.get('residual_check', True)
 
         # Check potential issues in the the input parameters
         self._check_input_parameters()
@@ -794,8 +795,10 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
             max_force_threshold = self.ctx.relax_settings.get('force_cutoff', 0.03)
             actual_max_force = get_maximum_force(workchain.outputs.misc['forces'], dof=dof)
             if (
+                # TODO: Make this check part of the convergence cycle?
                 actual_max_force > max(max_force_threshold * 1.5, max_force_threshold + 0.001)
                 and self.perform_relaxation()
+                and self.ctx.do_residual_check
             ):
                 if self.is_verbose():
                     self.report(


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Add this option to bypass residual force check in the final singlepoint calculation of the relaxation workchain. 
Normally, large residual forces in the final singlepoint calcualtion means there was a problem when the electronic convergence, e.g. converging to a different local minimum with the electronic degrees of freedom. However, this can also happen when relaxing a structure to very high precision. 