### PR TITLE
Add ASE constraints to VASP selective dynamics converter

### DIFF
--- a/docs/source/howto/setup_calculations.md
+++ b/docs/source/howto/setup_calculations.md
@@ -359,6 +359,38 @@ The `T` and `F` applies to the **direct** (fractional) coordinates.
 To fix the **cartesian** coordinates, the $$lattice vectors needs to align with the x, y, z direction respectively.
 :::
 
+### Using ASE constraints for selective dynamics
+
+ASE constraint objects are automatically converted when assigned to `builder.dynamics`:
+
+```python
+from ase.constraints import FixAtoms, FixScaled
+
+# Fix atoms completely
+atoms.set_constraint(FixAtoms(indices=[0, 1, 2]))
+builder.dynamics = atoms
+
+# Or fix specific directions (e.g., z for slabs)
+atoms.set_constraint(FixScaled([0, 1, 2], mask=(False, False, True)))
+builder.dynamics = atoms
+```
+
+Supported: `FixAtoms` (fixes all directions), `FixScaled` (fixes fractional directions), `FixCartesian` (requires orthogonal cells). Multiple constraints are accumulated. ASE's mask convention (True=fixed) is automatically converted to VASP's convention (True=movable).
+
+Alternatively, manually specify the `positions_dof` array:
+
+```python
+# Manually define: True=movable, False=fixed
+builder.dynamics = {
+    'positions_dof': [
+        [False, False, False],  # atom 0: fixed
+        [False, False, False],  # atom 1: fixed
+        [True, True, False],    # atom 2: z fixed, x,y movable
+        [True, True, True],     # atom 3: free
+    ]
+}
+```
+
 
 ## How set initial magnetization for magnetic calculations
 

--- a/docs/source/howto/setup_calculations.md
+++ b/docs/source/howto/setup_calculations.md
@@ -375,7 +375,7 @@ atoms.set_constraint(FixScaled([0, 1, 2], mask=(False, False, True)))
 builder.dynamics = atoms
 ```
 
-Supported: `FixAtoms` (fixes all directions), `FixScaled` (fixes fractional directions), `FixCartesian` (requires orthogonal cells). Multiple constraints are accumulated. ASE's mask convention (True=fixed) is automatically converted to VASP's convention (True=movable).
+Supported: `FixAtoms` (fixes all directions), `FixScaled` (fixes fractional directions), `FixCartesian` (requires an axis-aligned/diagonal cell matrix). Multiple constraints are accumulated. ASE's mask convention (True=fixed) is automatically converted to VASP's convention (True=movable).
 
 Alternatively, manually specify the `positions_dof` array:
 

--- a/src/aiida_vasp/calcs/vasp.py
+++ b/src/aiida_vasp/calcs/vasp.py
@@ -22,6 +22,7 @@ from aiida_vasp.parsers.content_parsers.incar import IncarParser
 from aiida_vasp.parsers.content_parsers.kpoints import KpointsParser
 from aiida_vasp.parsers.content_parsers.poscar import PoscarParser
 from aiida_vasp.parsers.content_parsers.potcar import MultiPotcarIo
+from aiida_vasp.utils.constraints import serialize_dynamics
 
 if TYPE_CHECKING:
     from aiida.common import CalcInfo
@@ -88,7 +89,7 @@ class VaspCalculation(VaspCalcBase):
         spec.input(
             'dynamics',
             valid_type=orm.Dict,
-            serializer=to_aiida_type,
+            serializer=serialize_dynamics,
             help='The VASP parameters related to ionic dynamics, e.g. flags to set the selective dynamics',
             required=False,
         )

--- a/src/aiida_vasp/utils/constraints.py
+++ b/src/aiida_vasp/utils/constraints.py
@@ -118,10 +118,10 @@ def atoms_to_positions_dof(atoms: Atoms) -> np.ndarray | None:
             cell = atoms.get_cell()
             if not _is_cell_orthogonal(cell):
                 raise InputValidationError(
-                    'FixCartesian constraint cannot be used with non-orthogonal cells. '
+                    'FixCartesian constraint requires a cell with vectors aligned with the Cartesian x, y, z axes '
+                    '(i.e. a diagonal cell matrix). '
                     'VASP selective dynamics operates in fractional coordinates. '
-                    'For non-orthogonal cells, use FixScaled instead or ensure your '
-                    'cell vectors are aligned with x, y, z axes.'
+                    'For rotated or non-orthogonal cells, use FixScaled instead.'
                 )
 
             # Issue warning about fractional vs Cartesian

--- a/src/aiida_vasp/utils/constraints.py
+++ b/src/aiida_vasp/utils/constraints.py
@@ -18,7 +18,7 @@ from ase import Atoms
 from ase.constraints import FixAtoms, FixCartesian, FixScaled
 
 
-def _is_cell_orthogonal(cell: np.ndarray, tol: float = 1e-6) -> bool:
+def _is_cell_axis_aligned(cell: np.ndarray, tol: float = 1e-6) -> bool:
     """
     Check if cell vectors are aligned with Cartesian x, y, z axes.
 
@@ -116,7 +116,7 @@ def atoms_to_positions_dof(atoms: Atoms) -> np.ndarray | None:
 
             # Check if cell is orthogonal
             cell = atoms.get_cell()
-            if not _is_cell_orthogonal(cell):
+            if not _is_cell_axis_aligned(cell):
                 raise InputValidationError(
                     'FixCartesian constraint requires a cell with vectors aligned with the Cartesian x, y, z axes '
                     '(i.e. a diagonal cell matrix). '

--- a/src/aiida_vasp/utils/constraints.py
+++ b/src/aiida_vasp/utils/constraints.py
@@ -1,0 +1,193 @@
+"""
+Utilities for converting ASE constraints to VASP selective dynamics.
+
+This module provides functions to convert ASE constraint objects (FixAtoms, FixScaled, FixCartesian)
+into VASP's selective dynamics format (positions_dof).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Union
+
+import numpy as np
+from aiida import orm
+from aiida.common.exceptions import InputValidationError
+from aiida.orm.nodes.data.base import to_aiida_type
+from ase import Atoms
+from ase.constraints import FixAtoms, FixCartesian, FixScaled
+
+
+def _is_cell_orthogonal(cell: np.ndarray, tol: float = 1e-6) -> bool:
+    """
+    Check if cell vectors are aligned with Cartesian x, y, z axes.
+
+    :param cell: Cell vectors as (3, 3) array
+    :type cell: np.ndarray
+    :param tol: Tolerance for considering off-diagonal elements as zero
+    :type tol: float
+    :returns: True if cell is orthogonal (aligned with Cartesian axes)
+    :rtype: bool
+    """
+    # Check if cell is diagonal (off-diagonal elements should be ~0)
+    # Cell format: [[a_x, a_y, a_z], [b_x, b_y, b_z], [c_x, c_y, c_z]]
+    # For orthogonal: a_y, a_z, b_x, b_z, c_x, c_y should be ~0
+    off_diagonal = [
+        cell[0, 1],
+        cell[0, 2],  # a_y, a_z
+        cell[1, 0],
+        cell[1, 2],  # b_x, b_z
+        cell[2, 0],
+        cell[2, 1],  # c_x, c_y
+    ]
+    return all(abs(val) < tol for val in off_diagonal)
+
+
+def atoms_to_positions_dof(atoms: Atoms) -> np.ndarray | None:
+    """
+    Convert ASE constraints to VASP positions_dof format.
+
+    This function extracts FixAtoms, FixScaled, and FixCartesian constraints from an ASE Atoms object
+    and converts them to VASP's selective dynamics format. Multiple constraints are
+    properly accumulated using a union of restrictions.
+
+    :param atoms: ASE Atoms object with optional constraints
+    :type atoms: Atoms
+    :returns: Numpy array of shape (N, 3) with dtype=bool, where True means the atom
+        can move in that direction (VASP convention), False means fixed.
+        Returns None if no constraints are present.
+    :rtype: np.ndarray | None
+    :raises InputValidationError: If an unsupported constraint type is encountered or if
+        FixCartesian is used with non-orthogonal cells
+
+    .. note::
+        - Supports FixAtoms (fixes all 3 directions), FixScaled (fixes specific
+          fractional directions), and FixCartesian (fixes Cartesian directions).
+        - ASE mask convention (True=fixed) is automatically inverted to VASP
+          convention (True=movable).
+        - VASP selective dynamics operates in fractional (direct) coordinates.
+        - FixCartesian only works correctly when cell vectors are aligned with
+          Cartesian axes. A warning is issued if used, and an error is raised if
+          the cell is not orthogonal.
+        - Multiple constraints on the same atom are accumulated (union of restrictions).
+
+    Example::
+
+        >>> from ase import Atoms
+        >>> from ase.constraints import FixAtoms
+        >>> atoms = Atoms('H2O', positions=[[0,0,0], [1,0,0], [0,1,0]])
+        >>> atoms.set_constraint(FixAtoms(indices=[0]))
+        >>> dof = atoms_to_positions_dof(atoms)
+        >>> dof[0]  # First atom fixed
+        array([False, False, False])
+        >>> dof[1]  # Second atom free
+        array([True, True, True])
+    """
+    # Return None if no constraints
+    if not atoms.constraints:
+        return None
+
+    # Initialize all atoms as movable (True = movable in VASP)
+    natoms = len(atoms)
+    positions_dof = np.ones((natoms, 3), dtype=bool)
+
+    # Process each constraint
+    for constraint in atoms.constraints:
+        if isinstance(constraint, FixAtoms):
+            # FixAtoms: fix all 3 directions for specified atoms
+            indices = constraint.get_indices()
+            positions_dof[indices, :] = False
+
+        elif isinstance(constraint, FixScaled):
+            # FixScaled: fix specific fractional directions
+            # CRITICAL: ASE mask convention is opposite to VASP
+            # ASE: True = fixed, False = movable
+            # VASP: True = movable, False = fixed
+            indices = constraint.get_indices()
+            mask = constraint.mask  # ASE convention: True = fixed
+
+            # Invert mask: where ASE mask is True (fixed), set VASP dof to False (fixed)
+            positions_dof[indices, mask] = False
+
+        elif isinstance(constraint, FixCartesian):
+            # FixCartesian: fix specific Cartesian directions
+            # WARNING: VASP selective dynamics works in fractional coordinates!
+            # This only works correctly if cell vectors are aligned with Cartesian axes
+
+            # Check if cell is orthogonal
+            cell = atoms.get_cell()
+            if not _is_cell_orthogonal(cell):
+                raise InputValidationError(
+                    'FixCartesian constraint cannot be used with non-orthogonal cells. '
+                    'VASP selective dynamics operates in fractional coordinates. '
+                    'For non-orthogonal cells, use FixScaled instead or ensure your '
+                    'cell vectors are aligned with x, y, z axes.'
+                )
+
+            # Issue warning about fractional vs Cartesian
+            warnings.warn(
+                'FixCartesian constraint is being converted to VASP selective dynamics. '
+                'Note that VASP selective dynamics operates in fractional (direct) coordinates. '
+                'This conversion assumes your cell vectors are aligned with Cartesian x, y, z axes. '
+                'Consider using FixScaled for explicit fractional coordinate control.',
+                UserWarning,
+                stacklevel=2,
+            )
+
+            # Treat like FixScaled with same logic
+            indices = constraint.get_indices()
+            mask = constraint.mask  # ASE convention: True = fixed
+            positions_dof[indices, mask] = False
+
+        else:
+            # Unsupported constraint type
+            constraint_type = type(constraint).__name__
+            raise InputValidationError(
+                f"Unsupported constraint type '{constraint_type}'. "
+                f'Only FixAtoms, FixScaled, and FixCartesian are supported for VASP selective dynamics. '
+                f"For complex constraints, manually specify the 'dynamics' port with 'positions_dof'."
+            )
+
+    return positions_dof
+
+
+def serialize_dynamics(atoms: Union[Atoms, dict]) -> orm.Dict | None:
+    """
+    Serialize ASE Atoms with constraints to dynamics Dict for builder.dynamics port.
+
+    This is a convenience function that converts ASE constraints to an AiiDA Dict
+    node ready for direct use with the builder.dynamics port.
+
+    :param atoms: ASE Atoms object with optional constraints
+    :type atoms: Atoms
+    :returns: orm.Dict with 'positions_dof' key, or None if no constraints present.
+        The Dict is ready for direct assignment: ``builder.dynamics = serialize_dynamics(atoms)``
+    :rtype: orm.Dict | None
+
+    .. note::
+        Handles FixAtoms, FixScaled, and FixCartesian constraints. Multiple constraints are
+        properly accumulated (union of restrictions). FixCartesian requires orthogonal cells.
+
+    Example::
+
+        >>> from ase.build import bulk
+        >>> from ase.constraints import FixAtoms
+        >>> from aiida_vasp.utils import serialize_dynamics
+        >>>
+        >>> atoms = bulk('Si', 'diamond', a=5.43).repeat((2, 2, 2))
+        >>> atoms.set_constraint(FixAtoms(indices=[0, 1, 2, 3]))
+        >>>
+        >>> # Direct usage with builder
+        >>> builder.dynamics = serialize_dynamics(atoms)
+    """
+    if not isinstance(atoms, Atoms):
+        return to_aiida_type(atoms)
+    # Get positions_dof array
+    dof = atoms_to_positions_dof(atoms)
+
+    # Return None if no constraints
+    if dof is None:
+        return None
+
+    # Convert to Dict node (tolist() converts numpy array to JSON-serializable list)
+    return orm.Dict(dict={'positions_dof': dof.tolist()})

--- a/tests/utils/test_constraints.py
+++ b/tests/utils/test_constraints.py
@@ -278,7 +278,7 @@ def test_fixcartesian_non_orthogonal():
 
     atoms.set_constraint(FixCartesian([0], mask=(True, False, False)))
 
-    with pytest.raises(InputValidationError, match='FixCartesian constraint cannot be used with non-orthogonal cells'):
+    with pytest.raises(InputValidationError, match='FixCartesian constraint requires a cell with vectors aligned'):
         atoms_to_positions_dof(atoms)
 
 

--- a/tests/utils/test_constraints.py
+++ b/tests/utils/test_constraints.py
@@ -1,0 +1,380 @@
+"""Tests for constraints module."""
+
+import numpy as np
+import pytest
+from aiida import orm
+from aiida.common.exceptions import InputValidationError
+from ase import Atoms
+from ase.constraints import FixAtoms, FixBondLength, FixCartesian, FixScaled
+
+from aiida_vasp.utils.constraints import atoms_to_positions_dof, serialize_dynamics
+from aiida_vasp.workchains.v2.relax import get_maximum_force
+
+
+def test_fixatoms_basic():
+    """Test FixAtoms constraint fixes all 3 directions for specified atoms."""
+    atoms = Atoms('H5', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0]])
+    atoms.set_constraint(FixAtoms(indices=[0, 2, 4]))
+
+    dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [False, False, False],  # atom 0: fixed
+            [True, True, True],  # atom 1: free
+            [False, False, False],  # atom 2: fixed
+            [True, True, True],  # atom 3: free
+            [False, False, False],  # atom 4: fixed
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_fixscaled_basic():
+    """Test FixScaled with partial constraints."""
+    atoms = Atoms('H3', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0]], cell=[5, 5, 5])
+    # Fix x and z directions for atom 1 (ASE: True=fixed)
+    atoms.set_constraint(FixScaled([1], mask=(True, False, True)))
+
+    dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [True, True, True],  # atom 0: free
+            [False, True, False],  # atom 1: x and z fixed, y movable
+            [True, True, True],  # atom 2: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_fixscaled_mask_inversion():
+    """Test that ASE mask convention (True=fixed) is inverted to VASP (True=movable).
+
+    This is the CRITICAL test for mask inversion.
+    """
+    atoms = Atoms('H2', positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+
+    # ASE convention: mask=(True, True, False) means fix x and y, allow z
+    atoms.set_constraint(FixScaled([1], mask=(True, True, False)))
+
+    dof = atoms_to_positions_dof(atoms)
+
+    # VASP convention: (False, False, True) means x and y fixed, z movable
+    expected = np.array(
+        [
+            [True, True, True],  # atom 0: all movable
+            [False, False, True],  # atom 1: x,y fixed (inverted from ASE), z movable
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_multiple_fixatoms():
+    """Test multiple FixAtoms constraints are properly accumulated."""
+    atoms = Atoms('H4', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]])
+
+    # Multiple FixAtoms constraints
+    constraint1 = FixAtoms(indices=[0])
+    constraint2 = FixAtoms(indices=[2, 3])
+    atoms.set_constraint([constraint1, constraint2])
+
+    dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [False, False, False],  # atom 0: fixed
+            [True, True, True],  # atom 1: free
+            [False, False, False],  # atom 2: fixed
+            [False, False, False],  # atom 3: fixed
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_multiple_mixed():
+    """Test FixAtoms + FixScaled constraints together."""
+    atoms = Atoms('H4', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0]], cell=[5, 5, 5])
+
+    # Fix atom 0 completely, fix z-direction for atoms 2 and 3
+    constraint1 = FixAtoms(indices=[0])
+    constraint2 = FixScaled([2, 3], mask=(False, False, True))
+    atoms.set_constraint([constraint1, constraint2])
+
+    dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [False, False, False],  # atom 0: fully fixed (FixAtoms)
+            [True, True, True],  # atom 1: free
+            [True, True, False],  # atom 2: z fixed (FixScaled)
+            [True, True, False],  # atom 3: z fixed (FixScaled)
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_overlapping_constraints():
+    """Test overlapping constraints on same atom (union of restrictions)."""
+    atoms = Atoms('H2', positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+
+    # Fix x direction
+    constraint1 = FixScaled([0], mask=(True, False, False))
+    # Fix y direction on same atom
+    constraint2 = FixScaled([0], mask=(False, True, False))
+    atoms.set_constraint([constraint1, constraint2])
+
+    dof = atoms_to_positions_dof(atoms)
+
+    # Union: both x and y should be fixed
+    expected = np.array(
+        [
+            [False, False, True],  # atom 0: x and y fixed, z movable
+            [True, True, True],  # atom 1: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_no_constraints():
+    """Test that None is returned when no constraints are present."""
+    atoms = Atoms('H3', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+
+    dof = atoms_to_positions_dof(atoms)
+
+    assert dof is None
+
+
+def test_unsupported_constraint():
+    """Test that unsupported constraint types raise InputValidationError."""
+    atoms = Atoms('H2', positions=[[0, 0, 0], [1, 0, 0]])
+    atoms.set_constraint(FixBondLength(0, 1))
+
+    with pytest.raises(InputValidationError, match='Unsupported constraint type'):
+        atoms_to_positions_dof(atoms)
+
+
+def test_serialize_dynamics(aiida_profile):
+    """Test serialize_dynamics returns correct orm.Dict."""
+    atoms = Atoms('H3', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+    atoms.set_constraint(FixAtoms(indices=[0, 2]))
+
+    result = serialize_dynamics(atoms)
+
+    # Check return type
+    assert isinstance(result, orm.Dict)
+
+    # Check content
+    dof_dict = result.get_dict()
+    assert 'positions_dof' in dof_dict
+
+    dof = dof_dict['positions_dof']
+    expected = [
+        [False, False, False],  # atom 0: fixed
+        [True, True, True],  # atom 1: free
+        [False, False, False],  # atom 2: fixed
+    ]
+
+    assert dof == expected
+
+
+def test_serialize_no_constraints(aiida_profile):
+    """Test serialize_dynamics returns None for no constraints."""
+    atoms = Atoms('H3', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+
+    result = serialize_dynamics(atoms)
+
+    assert result is None
+
+
+def test_serialize_function(aiida_profile):
+    """Test serialize_dynamics returns input dicts unchanged."""
+
+    assert serialize_dynamics({'x': 1}).get_dict() == {'x': 1}
+
+
+def test_empty_atoms():
+    """Test graceful handling of empty atoms object."""
+    atoms = Atoms()
+
+    dof = atoms_to_positions_dof(atoms)
+
+    assert dof is None
+
+
+def test_fixscaled_single_direction():
+    """Test FixScaled fixing only single direction."""
+    atoms = Atoms('H2', positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5])
+
+    # Fix only z-direction (most common for slabs)
+    atoms.set_constraint(FixScaled([0], mask=(False, False, True)))
+
+    dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [True, True, False],  # atom 0: only z fixed
+            [True, True, True],  # atom 1: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_fixatoms_with_multiple_atoms():
+    """Test FixAtoms with many atoms (realistic case)."""
+    # Create a larger structure
+    atoms = Atoms('H10', positions=[[i, 0, 0] for i in range(10)])
+
+    # Fix bottom 3 atoms (like a slab)
+    atoms.set_constraint(FixAtoms(indices=[0, 1, 2]))
+
+    dof = atoms_to_positions_dof(atoms)
+
+    # First 3 should be fixed
+    assert np.all(~dof[:3])
+    # Rest should be free
+    assert np.all(dof[3:])
+
+
+def test_fixcartesian_orthogonal():
+    """Test FixCartesian with orthogonal cell (should work with warning)."""
+    # Create orthogonal cell (aligned with x, y, z)
+    atoms = Atoms('H3', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0]], cell=[5, 5, 5], pbc=True)
+
+    # Fix z-direction in Cartesian coordinates
+    atoms.set_constraint(FixCartesian([1], mask=(False, False, True)))
+
+    # Should work but issue a warning
+    with pytest.warns(UserWarning, match='FixCartesian constraint is being converted'):
+        dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [True, True, True],  # atom 0: free
+            [True, True, False],  # atom 1: z fixed
+            [True, True, True],  # atom 2: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_fixcartesian_non_orthogonal():
+    """Test FixCartesian with non-orthogonal cell (should raise error)."""
+    # Create non-orthogonal cell
+    atoms = Atoms(
+        'H2',
+        positions=[[0, 0, 0], [1, 0, 0]],
+        cell=[[5, 0, 0], [2, 5, 0], [0, 0, 5]],  # Non-orthogonal: b_x != 0
+        pbc=True,
+    )
+
+    atoms.set_constraint(FixCartesian([0], mask=(True, False, False)))
+
+    with pytest.raises(InputValidationError, match='FixCartesian constraint cannot be used with non-orthogonal cells'):
+        atoms_to_positions_dof(atoms)
+
+
+def test_fixcartesian_multiple_directions():
+    """Test FixCartesian fixing multiple directions."""
+    atoms = Atoms('H2', positions=[[0, 0, 0], [1, 0, 0]], cell=[5, 5, 5], pbc=True)
+
+    # Fix x and y directions
+    atoms.set_constraint(FixCartesian([0], mask=(True, True, False)))
+
+    with pytest.warns(UserWarning):
+        dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [False, False, True],  # atom 0: x,y fixed, z free
+            [True, True, True],  # atom 1: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_mixed_constraints_with_fixcartesian():
+    """Test mixing FixAtoms, FixScaled, and FixCartesian."""
+    atoms = Atoms('H5', positions=[[i, 0, 0] for i in range(5)], cell=[10, 10, 10], pbc=True)
+
+    constraint1 = FixAtoms(indices=[0])  # Fully fix atom 0
+    constraint2 = FixScaled([1], mask=(False, False, True))  # Fix z for atom 1
+    constraint3 = FixCartesian([2], mask=(True, False, False))  # Fix x for atom 2
+
+    atoms.set_constraint([constraint1, constraint2, constraint3])
+
+    with pytest.warns(UserWarning):
+        dof = atoms_to_positions_dof(atoms)
+
+    expected = np.array(
+        [
+            [False, False, False],  # atom 0: fully fixed (FixAtoms)
+            [True, True, False],  # atom 1: z fixed (FixScaled)
+            [False, True, True],  # atom 2: x fixed (FixCartesian)
+            [True, True, True],  # atom 3: free
+            [True, True, True],  # atom 4: free
+        ]
+    )
+
+    np.testing.assert_array_equal(dof, expected)
+
+
+def test_integration_with_get_maximum_force():
+    """Test integration with get_maximum_force from relax workchain.
+
+    This verifies the complete workflow: ASE constraints → positions_dof → force calculation.
+    Forces on fixed atoms should be ignored when calculating maximum force.
+    """
+    # Create atoms with mixed constraints
+    atoms = Atoms('H5', positions=[[0, 0, 0], [1, 0, 0], [2, 0, 0], [3, 0, 0], [4, 0, 0]])
+    # Fix atoms 0 and 2 completely, fix z-direction for atom 4
+    constraint1 = FixAtoms(indices=[0, 2])
+    constraint2 = FixScaled([4], mask=(False, False, True))
+    atoms.set_constraint([constraint1, constraint2])
+
+    # Convert constraints to positions_dof
+    dof = atoms_to_positions_dof(atoms)
+
+    # Expected dof array
+    expected_dof = np.array(
+        [
+            [False, False, False],  # atom 0: fully fixed
+            [True, True, True],  # atom 1: free
+            [False, False, False],  # atom 2: fully fixed
+            [True, True, True],  # atom 3: free
+            [True, True, False],  # atom 4: z fixed
+        ]
+    )
+    np.testing.assert_array_equal(dof, expected_dof)
+
+    # Create force array where fixed atoms have large forces
+    forces = np.array(
+        [
+            [10.0, 10.0, 10.0],  # atom 0: large force but FIXED → should be ignored
+            [0.1, 0.2, 0.3],  # atom 1: small force, free
+            [5.0, 5.0, 5.0],  # atom 2: large force but FIXED → should be ignored
+            [0.4, 0.5, 0.6],  # atom 3: medium force, free
+            [1.0, 1.0, 1.0],  # atom 4: medium force but z is FIXED → should be ignored
+        ]
+    )
+
+    # Without dof: maximum force would be from atom 0 (norm = 10*sqrt(3) ≈ 17.32)
+    max_force_no_dof = get_maximum_force(forces)
+    assert max_force_no_dof == pytest.approx(10.0 * np.sqrt(3), rel=1e-6)
+
+    # With dof: atoms 0, 2, and 4 are ignored, maximum is from atom 3
+    max_force_with_dof = get_maximum_force(forces, dof=dof)
+    expected_max = np.sqrt(0.4**2 + 0.5**2 + 0.6**2)
+    assert max_force_with_dof == pytest.approx(expected_max, rel=1e-6)
+
+    # Verify forces on fixed atoms are properly ignored
+    assert max_force_with_dof < 1.0  # Much smaller than forces on fixed atoms


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes: #834

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

Add utilities to automatically convert ASE constraints (FixAtoms, FixScaled, FixCartesian) to VASP selective dynamics format. Users can now directly assign atoms with constraints to `builder.dynamics` and the conversion happens automatically.

### Changes:
- New module `src/aiida_vasp/utils/constraints.py` with converter functions
- Modified `src/aiida_vasp/calcs/vasp.py` to enable automatic conversion via serializer
- Added 19 comprehensive tests in `tests/utils/test_constraints.py`
- Updated documentation with usage examples

The existing `get_maximum_force` function in the relax workchain already correctly handles selective dynamics by ignoring forces on fixed atoms during convergence checks.