### PR TITLE
Fix parser, workchain, and launch regressions

### DIFF
--- a/src/aiida_vasp/calcs/monitors.py
+++ b/src/aiida_vasp/calcs/monitors.py
@@ -26,6 +26,16 @@ from pathlib import Path
 from aiida.orm import CalcJobNode
 from aiida.transports import Transport
 
+try:
+    from asyncssh.sftp import SFTPNoSuchFile as _SFTPNoSuchFile
+except ImportError:
+    _SFTPNoSuchFile = None
+
+# Tuple of exceptions to catch when a remote file does not exist.
+# asyncssh raises SFTPNoSuchFile which does not inherit from FileNotFoundError,
+# so we need to catch it explicitly.
+_FILE_NOT_FOUND_ERRORS: tuple = tuple(filter(None, (FileNotFoundError, _SFTPNoSuchFile)))
+
 
 def monitor_stdout(node: CalcJobNode, transport: Transport, size_threshold_mb: float = 5) -> str | None:
     """
@@ -65,7 +75,7 @@ def monitor_stdout(node: CalcJobNode, transport: Transport, size_threshold_mb: f
     stdout_path = str(Path(node.get_remote_workdir()) / node.process_class._VASP_OUTPUT)
     try:
         file_stat = transport.get_attribute(stdout_path)
-    except FileNotFoundError:
+    except _FILE_NOT_FOUND_ERRORS:
         # No file yet - do nothing
         return
     if file_stat.st_size > 1024 * 1024 * size_threshold_mb:
@@ -164,7 +174,7 @@ def monitor_loop_time(
     # Monitor for stalled calculations by checking stdout file modification time
     try:
         file_stat = transport.get_attribute(stdout_path)
-    except FileNotFoundError:
+    except _FILE_NOT_FOUND_ERRORS:
         # Do nothing if the stdout is not there
         pass
     else:

--- a/src/aiida_vasp/calcs/neb.py
+++ b/src/aiida_vasp/calcs/neb.py
@@ -191,12 +191,12 @@ class VaspNEBCalculation(VaspCalculation):
 
                 # Link with singlefile WAVECAR/CHGCAR is needed
                 if self._need_wavecar():
-                    wavecar = self.inputs.wave_functions[img_key]
+                    wavecar = self.inputs.wavefunctions[img_key]
                     dst = folder_id + '/' + 'WAVECAR'
                     calcinfo.local_copy_list.append((wavecar.uuid, wavecar.filename, dst))
 
                 if self._need_chgcar():
-                    chgcar = self.inputs.charge_densities[img_key]
+                    chgcar = self.inputs.charge_density[img_key]
                     dst = folder_id + '/' + 'CHGCAR'
                     calcinfo.local_copy_list.append((chgcar.uuid, chgcar.filename, dst))
         try:
@@ -233,6 +233,14 @@ class VaspNEBCalculation(VaspCalculation):
         # self.logger.warning('Calcinfo: {}'.format(calcinfo))
 
         return calcinfo
+
+    def write_additional(self, folder: Folder, calcinfo: CalcInfo) -> None:
+        """Handle extra inputs that are not written by the per-image submission loop."""
+        _ = folder
+        if 'vdw_kernel' in self.inputs:
+            calcinfo.local_copy_list.append(
+                (self.inputs.vdw_kernel.uuid, self.inputs.vdw_kernel.filename, 'vdw_kernel.bindat')
+            )
 
     def _structure(self) -> orm.StructureData:
         """

--- a/src/aiida_vasp/commands/launch.py
+++ b/src/aiida_vasp/commands/launch.py
@@ -145,16 +145,26 @@ def launch_workchain(
 
         # Try to link to existing structure node
         if match_existing:
-            structure_node.store()
+            if not structure_node.is_stored:
+                structure_node.store()
             existing = orm.QueryBuilder().append(
                 orm.StructureData,
                 filters={'extras._aiida_hash': structure_node.base.caching.get_hash()},
                 tag='structure',
             )
-            existing.order_by({'structure': [{'ctime': {'order': 'desc'}}]}).all()
-            if existing:
-                if yes or click.confirm(f'Using existing structure node with PK: {structure_node.pk} as input node'):
-                    structure_node = existing[0][0]
+            existing.order_by({'structure': [{'ctime': {'order': 'desc'}}]})
+            matches = existing.all()
+            if matches:
+                existing_node = matches[0][0]
+                if (
+                    dryrun
+                    or yes
+                    or click.confirm(
+                        f'Using existing structure node with PK: {existing_node.pk} as input node', default=True
+                    )
+                ):
+                    structure_node = existing_node
+                    click.echo(f'Using existing structure node with PK: {existing_node.pk}')
 
         # Initialize the builder updater
         click.echo(f'Initializing BuilderUpdater with preset: {preset}')
@@ -353,11 +363,33 @@ def pretty_print_builder(builder) -> None:
         stream: Output stream to write the pretty printed output.
     """
     import yaml
-    from aiida.engine.processes.builder import PrettyEncoder
+    from aiida import orm
+    from aiida.engine.processes.builder import ProcessBuilderNamespace
+
+    from aiida_vasp.common.builder_updater import builder_to_dict
+
+    def sanitize(value):
+        if isinstance(value, ProcessBuilderNamespace):
+            return sanitize(builder_to_dict(value))
+        if isinstance(value, orm.Dict):
+            return sanitize(value.get_dict())
+        if isinstance(value, orm.List):
+            return [sanitize(item) for item in value.get_list()]
+        if isinstance(value, (orm.Bool, orm.Float, orm.Int, orm.Str)):
+            return value.value
+        if isinstance(value, dict):
+            return {key: sanitize(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [sanitize(item) for item in value]
+        if isinstance(value, orm.Data):
+            if value.pk is not None:
+                return f'{value.__class__.__name__}<{value.pk}>'
+            return f'{value.__class__.__name__}<unstored>'
+        return value
 
     return (
         f'Process class: {builder._process_class.__name__}\n'
-        f'Inputs:\n{yaml.safe_dump(json.JSONDecoder().decode(PrettyEncoder().encode(builder)))}'
+        f'Inputs:\n{yaml.safe_dump(sanitize(builder_to_dict(builder)), sort_keys=False)}'
     )
 
 

--- a/src/aiida_vasp/commands/launch.py
+++ b/src/aiida_vasp/commands/launch.py
@@ -2,8 +2,6 @@
 Provides aiida-vasp related tools as standalone commands.
 """
 
-import json
-
 import click
 
 from . import cmd_aiida_vasp
@@ -353,14 +351,40 @@ def status(process_pk):
                 click.echo('-' * 40)
 
 
-def pretty_print_builder(builder) -> None:
+def _builder_to_dict(obj):
+    """Recursively convert a ProcessBuilderNamespace or AiiDA node to a plain dict for pretty-printing."""
+    from aiida import orm
+    from aiida.engine.processes.builder import ProcessBuilderNamespace
+
+    if isinstance(obj, ProcessBuilderNamespace):
+        result = {}
+        for key, value in obj.items():
+            converted = _builder_to_dict(value)
+            if converted is not None:
+                result[key] = converted
+        return result or None
+    if isinstance(obj, orm.Dict):
+        return obj.get_dict()
+    if isinstance(obj, orm.BaseType):
+        return obj.value
+    if isinstance(obj, orm.Node):
+        return repr(obj)
+    if isinstance(obj, dict):
+        result = {}
+        for key, value in obj.items():
+            converted = _builder_to_dict(value)
+            if converted is not None:
+                result[key] = converted
+        return result or None
+    return obj
+
+
+def pretty_print_builder(builder) -> str:
     """
     Pretty print the builder object.
 
     Args:
         builder: The builder object to print.
-        indent: Indentation level for pretty printing.
-        stream: Output stream to write the pretty printed output.
     """
     import yaml
     from aiida import orm
@@ -391,13 +415,6 @@ def pretty_print_builder(builder) -> None:
         f'Process class: {builder._process_class.__name__}\n'
         f'Inputs:\n{yaml.safe_dump(sanitize(builder_to_dict(builder)), sort_keys=False)}'
     )
-
-
-class PrettyEncoder(json.JSONEncoder):
-    """JSON encoder for returning a pretty representation of an AiiDA ``ProcessBuilder``."""
-
-    def default(self, o):
-        return dict(o)
 
 
 def load_inputs_from_vasp_folder(folder_path):
@@ -458,19 +475,29 @@ def load_inputs_from_vasp_folder(folder_path):
 
     # Compose overrides for each workchain type
     # VaspWorkChain
-    vasp_override = {'parameters': {'incar': incar_dict}, 'kpoints': kpoints_node, 'potential': potcars}
+    vasp_override = {'parameters': {'incar': incar_dict}, 'potential': potcars}
+    if kpoints_node is not None:
+        vasp_override['kpoints'] = kpoints_node
     overrides_map['vasp'] = vasp_override
 
     # VaspRelaxWorkChain
-    relax_override = {'vasp': {'parameters': {'incar': incar_dict}, 'kpoints': kpoints_node, 'potential': potcars}}
+    vasp_sub = {'parameters': {'incar': incar_dict}, 'potential': potcars}
+    if kpoints_node is not None:
+        vasp_sub['kpoints'] = kpoints_node
+    relax_override = {'vasp': vasp_sub}
     overrides_map['relax'] = relax_override
 
     # VaspBandsWorkChain
-    band_override = {'scf': {'parameters': {'incar': incar_dict}, 'kpoints': kpoints_node, 'potential': potcars}}
+    scf_sub = {'parameters': {'incar': incar_dict}, 'potential': potcars}
+    if kpoints_node is not None:
+        scf_sub['kpoints'] = kpoints_node
+    band_override = {'scf': scf_sub}
     overrides_map['band'] = band_override
 
     # VaspConvergeWorkChain
-    conv_override = {'parameters': {'incar': incar_dict, 'kpoints': kpoints_node, 'potential': potcars}}
+    conv_override = {'parameters': {'incar': incar_dict, 'potential': potcars}}
+    if kpoints_node is not None:
+        conv_override['kpoints'] = kpoints_node
     overrides_map['conv'] = conv_override
 
     return structure_node, overrides_map

--- a/src/aiida_vasp/common/builder_updater.py
+++ b/src/aiida_vasp/common/builder_updater.py
@@ -836,7 +836,7 @@ class VaspNEBUpdater(VaspBuilderUpdater):
             self.set_interpolated_images(nimages)
         else:
             logging.info('Not interpolating images, please set with .set_neb_image(images)')
-        self.update_incar(images=nimages)
+        self.set_incar(images=nimages)
 
         return self
 

--- a/src/aiida_vasp/data/potcar.py
+++ b/src/aiida_vasp/data/potcar.py
@@ -105,6 +105,7 @@ The mechanism for writing one or more PotcarData to file (from a calculation)::
 from __future__ import annotations, print_function
 
 import hashlib
+import inspect
 import os
 import re
 import shutil
@@ -275,7 +276,10 @@ def extract_tarfile(file_path: Path) -> Path:
         new_dir = file_path.name.split('.tar')[0]
         new_path = file_path.parent / new_dir
         if not new_path.exists():
-            archive.extractall(str(new_path))
+            extract_kwargs = {}
+            if 'filter' in inspect.signature(archive.extractall).parameters:
+                extract_kwargs['filter'] = 'data'
+            archive.extractall(str(new_path), **extract_kwargs)
 
     return new_path
 

--- a/src/aiida_vasp/parsers/neb.py
+++ b/src/aiida_vasp/parsers/neb.py
@@ -205,7 +205,7 @@ class NebParser(VaspParser):
                     return None
                 for key, value in traj_data.items():
                     if key == 'symbols':
-                        node.base.attributes.set(key, value)
+                        node.base.attributes.set(key, list(value))
                     else:
                         node.set_array(key, value)
                 output['image_' + index] = node
@@ -260,19 +260,20 @@ class NebParser(VaspParser):
 
         # Check for the existence of critical warnings
         if 'notifications' in quantities:
-            notifications = quantities['notifications']['01']
             ignore_all = self.user_config.ignore_notification_errors
             if not ignore_all:
-                composer = NotificationComposer(
-                    notifications,
-                    quantities['run_status']['01'],
-                    self.node.inputs,
-                    self.exit_codes,
-                    critical_notifications=self.user_config.critical_notification_errors,
-                )
-                exit_code = composer.compose()
-                if exit_code is not None:
-                    return exit_code
+                for index in self.neb_indices:
+                    notifications = quantities['notifications'].get(index, [])
+                    composer = NotificationComposer(
+                        notifications,
+                        quantities['run_status'][index],
+                        self.node.inputs,
+                        self.exit_codes,
+                        critical_notifications=self.user_config.critical_notification_errors,
+                    )
+                    exit_code = composer.compose()
+                    if exit_code is not None:
+                        return exit_code
         else:
             self.logger.warning('WARNING: missing notification output for VASP warnings and errors.')
 

--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -446,7 +446,7 @@ class VaspParser(Parser):
                 return None
             for key, value in traj_data.items():
                 if key == 'symbols':
-                    node.base.attributes.set(key, value)
+                    node.base.attributes.set(key, list(value))
                 elif value.dtype.hasobject:
                     self.logger.warning(f'Cannot set array {key}: {value} in TrajectoryData as it is not numerical.')
                 else:

--- a/src/aiida_vasp/utils/opthold.py
+++ b/src/aiida_vasp/utils/opthold.py
@@ -53,10 +53,9 @@ class OptionContainer(BaseModel):
         Return a string for the options of a OptionContains in a human-readable format.
         """
 
-        obj = cls()
         template = '{:>{width_name}s}:  {:10s} \n{default:>{width_name2}}: {}'
         entries = []
-        for name, field in obj.model_fields.items():
+        for name, field in cls.model_fields.items():
             # Each entry is name, type, doc, default value
             entries.append([name, str(field.annotation.__name__), field.description, field.default])
         max_width_name = max(len(entry[0]) for entry in entries) + 2

--- a/src/aiida_vasp/utils/workchains.py
+++ b/src/aiida_vasp/utils/workchains.py
@@ -87,7 +87,12 @@ def compare_structures(structure_a: Any, structure_b: Any) -> AttributeDict:
     site_vectors = [delta.absolute.pos[i, :] for i in range(delta.absolute.pos.shape[0])]
     a_lengths = np.linalg.norm(pos_a, axis=1)
     delta.absolute.pos_lengths = np.array([np.linalg.norm(vector) for vector in site_vectors])
-    delta.relative.pos_lengths = np.array([np.linalg.norm(vector) for vector in site_vectors]) / a_lengths
+    delta.relative.pos_lengths = np.divide(
+        delta.absolute.pos_lengths,
+        a_lengths,
+        out=np.zeros_like(delta.absolute.pos_lengths),
+        where=a_lengths != 0,
+    )
 
     cell_lengths_a = np.array(structure_a.cell_lengths)
     delta.absolute.cell_lengths = np.absolute(cell_lengths_a - np.array(structure_b.cell_lengths))

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -689,7 +689,7 @@ class VaspRelaxWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
             self.report('Cell angles check bypassed.')
             angles_converged = True
         else:
-            angles_converged = bool(delta.cell_lengths.max() <= threshold_lengths)
+            angles_converged = bool(delta.cell_angles.max() <= threshold_angles)
 
         if not angles_converged:
             self.report(
@@ -1015,6 +1015,12 @@ class VaspMultiStageRelaxWorkChain(WorkChain, WithBuilderUpdater):
             default=lambda: orm.Bool(True),
             help='Use nested update for parameters, options, relax_settings, and settings. '
             'Otherwise full dictionary should be provided',
+        )
+        spec.input(
+            'ignored_failed',
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            help='If True, continue to the next stage even when a stage fails, provided a relaxed structure exists.',
         )
         spec.expose_inputs(cls._base_workchain, 'relax', exclude=('structure',))
         spec.input('structure', valid_type=(orm.StructureData, orm.CifData))

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -1111,7 +1111,7 @@ class VaspMultiStageRelaxWorkChain(WorkChain, WithBuilderUpdater):
         self.report(f'Inspecting stage {self.ctx.current_stage} - {workchain}')
         if not workchain.is_finished_ok:
             self.report(f'Stage {self.ctx.current_stage} failed with exit status {workchain.exit_status} - aborting.')
-            if not self.inputs.ignored_failed:
+            if not self.inputs.ignored_failed.value:
                 self.out_many(self.exposed_outputs(workchain, self._base_workchain))
                 return self.exit_codes.ERROR_SUB_PROCESS_FAILED
             else:

--- a/src/aiida_vasp/workchains/v2/relax.py
+++ b/src/aiida_vasp/workchains/v2/relax.py
@@ -923,7 +923,12 @@ def compare_structures(structure_a: orm.StructureData, structure_b: orm.Structur
     site_vectors = [delta.absolute.pos[i, :] for i in range(delta.absolute.pos.shape[0])]
     a_lengths = np.linalg.norm(pos_a, axis=1)
     delta.absolute.pos_lengths = np.array([np.linalg.norm(vector) for vector in site_vectors])
-    delta.relative.pos_lengths = np.array([np.linalg.norm(vector) for vector in site_vectors]) / a_lengths
+    delta.relative.pos_lengths = np.divide(
+        delta.absolute.pos_lengths,
+        a_lengths,
+        out=np.zeros_like(delta.absolute.pos_lengths),
+        where=a_lengths != 0,
+    )
 
     cell_lengths_a = np.array(structure_a.cell_lengths)
     delta.absolute.cell_lengths = np.absolute(cell_lengths_a - np.array(structure_b.cell_lengths))

--- a/src/aiida_vasp/workchains/v2/vasp.py
+++ b/src/aiida_vasp/workchains/v2/vasp.py
@@ -1201,7 +1201,7 @@ A nested dictionary containing the following keys:
             self.report(msg)
             return ProcessHandlerReport(
                 do_break=True,
-                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(msg),
+                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(message=msg),
             )
 
         # Check if there are very few step performed per launch. Because VASP does not carry over
@@ -1214,7 +1214,7 @@ A nested dictionary containing the following keys:
             self.report(msg)
             return ProcessHandlerReport(
                 do_break=True,
-                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(msg),
+                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(message=msg),
             )
 
         # Warn about very unusually large number of steps and switch IBRION if needed.
@@ -1255,7 +1255,7 @@ A nested dictionary containing the following keys:
             self.report(msg)
             return ProcessHandlerReport(
                 do_break=True,
-                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(msg),
+                exit_code=self.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.format(message=msg),
             )
 
         self.report('No fixes can be applied for ionic convergence.')

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -10,6 +10,12 @@ from aiida.common.extendeddicts import AttributeDict
 from aiida_vasp.calcs.monitors import monitor_loop_time, monitor_stdout
 from aiida_vasp.calcs.vasp import VaspCalculation
 
+try:
+    from asyncssh.sftp import SFTPNoSuchFile
+    HAS_ASYNCSSH = True
+except ImportError:
+    HAS_ASYNCSSH = False
+
 
 class MockFileStatResult:
     """Mock object for file stat results."""
@@ -30,6 +36,7 @@ class MockTransport:
     def __init__(self):
         """Initialize mock transport."""
         self.get_attribute_return = None
+        self.get_attribute_raise = None
         self.exec_command_wait_return = None
         self.get_attribute_calls = []
         self.exec_command_wait_calls = []
@@ -37,6 +44,7 @@ class MockTransport:
     def reset(self):
         """Reset the status"""
         self.get_attribute_return = None
+        self.get_attribute_raise = None
         self.exec_command_wait_return = None
         self.get_attribute_calls = []
         self.exec_command_wait_calls = []
@@ -44,6 +52,8 @@ class MockTransport:
     def get_attribute(self, filename):
         """Mock get_attribute method."""
         self.get_attribute_calls.append(filename)
+        if self.get_attribute_raise is not None:
+            raise self.get_attribute_raise
         return self.get_attribute_return
 
     def exec_command_wait(self, command):
@@ -143,6 +153,25 @@ class TestMonitorStdout:
         result = monitor_stdout(mock_node, mock_transport, size_threshold_mb=10)
         assert result is None
         assert not mock_transport.exec_command_wait_calls
+
+    def test_monitor_stdout_file_not_found(self, mock_node, mock_transport):
+        """Test monitor_stdout when FileNotFoundError is raised (file not yet created)."""
+        mock_transport.get_attribute_raise = FileNotFoundError('No such file')
+
+        result = monitor_stdout(mock_node, mock_transport)
+
+        assert result is None
+        assert mock_transport.exec_command_wait_calls == []
+
+    @pytest.mark.skipif(not HAS_ASYNCSSH, reason='asyncssh is not installed')
+    def test_monitor_stdout_sftp_no_such_file(self, mock_node, mock_transport):
+        """Test monitor_stdout when SFTPNoSuchFile is raised (asyncssh transport, pending job)."""
+        mock_transport.get_attribute_raise = SFTPNoSuchFile('No such file')
+
+        result = monitor_stdout(mock_node, mock_transport)
+
+        assert result is None
+        assert mock_transport.exec_command_wait_calls == []
 
 
 class TestMonitorLoopTime:
@@ -286,6 +315,31 @@ class TestMonitorLoopTime:
         mock_transport.get_attribute_return = MockFileStatResult(mtime=file_mtime)
 
         # Call function
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        assert result is None
+
+    def test_monitor_loop_time_file_not_found(self, mock_transport):
+        """Test monitor_loop_time when FileNotFoundError is raised for stdout (file not yet created)."""
+        mock_node = MockNode(walltime_limit=3600)
+
+        grep_output = 'LOOP:  cpu time    50.5: real time    50.5\nLOOP:  cpu time    50.5: real time    50.5'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_raise = FileNotFoundError('No such file')
+
+        result = monitor_loop_time(mock_node, mock_transport)
+
+        assert result is None
+
+    @pytest.mark.skipif(not HAS_ASYNCSSH, reason='asyncssh is not installed')
+    def test_monitor_loop_time_sftp_no_such_file(self, mock_transport):
+        """Test monitor_loop_time when SFTPNoSuchFile is raised (asyncssh transport, pending job)."""
+        mock_node = MockNode(walltime_limit=3600)
+
+        grep_output = 'LOOP:  cpu time    50.5: real time    50.5\nLOOP:  cpu time    50.5: real time    50.5'
+        mock_transport.exec_command_wait_return = (0, grep_output, '')
+        mock_transport.get_attribute_raise = SFTPNoSuchFile('No such file')
+
         result = monitor_loop_time(mock_node, mock_transport)
 
         assert result is None

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -12,6 +12,7 @@ from aiida_vasp.calcs.vasp import VaspCalculation
 
 try:
     from asyncssh.sftp import SFTPNoSuchFile
+
     HAS_ASYNCSSH = True
 except ImportError:
     HAS_ASYNCSSH = False

--- a/tests/calcs/test_neb.py
+++ b/tests/calcs/test_neb.py
@@ -54,3 +54,39 @@ def test_prepare(
     calcinfo = calc.prepare_for_submission(temp_folder)
 
     assert ['01/IBZKPT', '.', 2] in calcinfo.retrieve_list
+
+
+@pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('cif', 'mesh')], indirect=True)
+def test_prepare_restart_files(
+    aiida_profile,
+    vasp_neb_calc,
+    vasp_neb_inputs,
+    sandbox_folder,
+    vasp_chgcar,
+    vasp_wavecar,
+):
+    """Check that per-image restart files are copied from the declared namespaces."""
+    chgcar, _ = vasp_chgcar
+    wavecar, _ = vasp_wavecar
+    inputs = vasp_neb_inputs(
+        parameters={
+            'gga': 'PE',
+            'gga_compat': False,
+            'lorbit': 11,
+            'sigma': 0.5,
+            'magmom': '30 * 2*0.',
+            'images': 3,
+            'istart': 1,
+            'icharg': 1,
+        }
+    )
+    inputs.wavefunctions = {key: wavecar for key in inputs.neb_images}
+    inputs.charge_density = {key: chgcar for key in inputs.neb_images}
+
+    calc = vasp_neb_calc(inputs=inputs)
+    calcinfo = calc.prepare_for_submission(sandbox_folder)
+
+    assert (wavecar.uuid, wavecar.filename, '01/WAVECAR') in calcinfo.local_copy_list
+    assert (wavecar.uuid, wavecar.filename, '03/WAVECAR') in calcinfo.local_copy_list
+    assert (chgcar.uuid, chgcar.filename, '01/CHGCAR') in calcinfo.local_copy_list
+    assert (chgcar.uuid, chgcar.filename, '03/CHGCAR') in calcinfo.local_copy_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib
 import os
 import pathlib
 import subprocess as sp
+import warnings
 
 import numpy as np
 import pytest
@@ -16,7 +18,6 @@ from aiida.orm import CalculationNode, Code, Computer, Dict, InstalledCode, Quer
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.tools.archive import create_archive
 
-from aiida_vasp.common.builder_updater import VaspBuilderUpdater
 from aiida_vasp.data.potcar import OLD_POTCAR_FAMILY_TYPE, Group, PotcarData, PotcarGroup
 from aiida_vasp.utils.general import copytree
 
@@ -383,7 +384,14 @@ def builder_updater(
     """
     Return a Builder Updater object for mock-vasp
     """
-    return VaspBuilderUpdater(code='mock-vasp@localhost')
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='The builder_updater module is deprecated.*|The Vasp.*Updater class is deprecated.*',
+            category=DeprecationWarning,
+        )
+        vasp_builder_updater = importlib.import_module('aiida_vasp.common.builder_updater').VaspBuilderUpdater
+        return vasp_builder_updater(code='mock-vasp@localhost')
 
 
 def print_and_export_failed_mock():

--- a/tests/parsers/test_neb_parser.py
+++ b/tests/parsers/test_neb_parser.py
@@ -57,3 +57,32 @@ def test_neb_parser(neb_parser_with_test):
     assert np.all(forces[0] == np.array([0.008815, 0.005492, -0.000661]))
 
     assert np.array(forces).shape == (4, 3)
+
+
+def test_neb_parser_checks_notifications_for_all_images(neb_calc_with_retrieved):
+    """Critical notifications in later images should still fail the parse."""
+    settings_dict = {'parser_settings': {}}
+    file_path = cwd / '..' / 'test_data/neb'
+    node = neb_calc_with_retrieved(file_path, settings_dict, 3)
+    parser = ParserFactory('vasp.neb')(node)
+    parser._init_user_settings()
+    parser.neb_indices = ['01', '02']
+    parser.quantities_each = {
+        'vasp_output': {
+            'notifications': {
+                '01': [],
+                '02': [{'name': 'brmix', 'message': 'error in second image'}],
+            }
+        },
+        'OUTCAR': {
+            'run_status': {
+                '01': {'finished': True, 'electronic_converged': True, 'ionic_converged': True},
+                '02': {'finished': True, 'electronic_converged': True, 'ionic_converged': True},
+            }
+        },
+    }
+
+    exit_code = parser._check_vasp_errors({})
+
+    assert exit_code.status == parser.exit_codes.ERROR_VASP_CRITICAL_ERROR.status
+    assert 'second image' in exit_code.message

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -17,6 +17,8 @@ from aiida.engine import run
 from aiida.plugins import WorkflowFactory
 from aiida.plugins.factories import DataFactory
 
+from aiida_vasp.workchains.v2.vasp import VaspWorkChain
+
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 @pytest.mark.parametrize('standalone_options', [True, False])
@@ -230,6 +232,40 @@ def test_vasp_wc_ionic_continue(
     # Check the child status - here the first calculation is not finished but the second one is
     for idx, code in enumerate(exit_codes):
         assert called_nodes[idx].exit_status == code
+
+
+def test_handler_ionic_conv_enhanced_formats_exit_code_message():
+    """The enhanced ionic handler should return an exit code instead of raising TypeError."""
+
+    class FakeStructure:
+        sites = [object()]
+
+    def make_child(energy):
+        return AttributeDict(
+            {
+                'outputs': AttributeDict(
+                    {
+                        'structure': object(),
+                        'misc': {
+                            'run_status': {'last_iteration_index': [6, 1]},
+                            'total_energies': {'energy_extrapolated': energy},
+                        },
+                    }
+                )
+            }
+        )
+
+    workchain = object.__new__(VaspWorkChain)
+    object.__setattr__(workchain, '_context', AttributeDict())
+    workchain.ctx.inputs = AttributeDict({'structure': FakeStructure(), 'parameters': {'isif': 2}})
+    workchain.ctx.children = [make_child(-1.0), make_child(-1.0), make_child(-1.0)]
+    workchain.update_magmom = lambda node=None: None
+    workchain.report = lambda *args, **kwargs: None
+
+    report = VaspWorkChain.handler_ionic_conv_enhanced.__wrapped__(workchain, workchain.ctx.children[-1])
+
+    assert report.exit_code.status == VaspWorkChain.exit_codes.ERROR_OTHER_INTERVENTION_NEEDED.status
+    assert '1e-5 /atom' in report.exit_code.message
 
 
 @pytest.mark.skip(reason='This test is not working yet')

--- a/tests/workchains/test_vasp_wc.py
+++ b/tests/workchains/test_vasp_wc.py
@@ -22,6 +22,7 @@ from aiida_vasp.workchains.v2.vasp import VaspWorkChain
 
 @pytest.mark.parametrize(['vasp_structure', 'vasp_kpoints'], [('str', 'mesh')], indirect=True)
 @pytest.mark.parametrize('standalone_options', [True, False])
+@pytest.mark.filterwarnings('ignore:The use of `options` port is deprecated.*:UserWarning')
 def test_vasp_wc(run_vasp_process, standalone_options):
     """Test submitting only, not correctness, with mocked vasp code."""
     results, node = run_vasp_process(process_type='workchain', standalone_options=standalone_options)
@@ -215,7 +216,7 @@ def test_vasp_wc_ionic_continue(
     inputs = setup_vasp_workchain(si_structure(), incar, nkpts, potcar_family_name, potcar_mapping)
     inputs.verbose = orm.Bool(True)
     # The test calculation contain NELM breaches during the relaxation - set to ignore it.
-    inputs.handler_overrides = orm.Dict(dict={'ignore_nelm_breach_relax': True})
+    inputs.handler_overrides = orm.Dict(dict={'ignore_nelm_breach_relax': {'enabled': True}})
     results, node = run.get_node(workchain, **inputs)
 
     assert node.exit_status == 0
@@ -285,7 +286,7 @@ def test_vasp_wc_ionic_magmom_carry(aiida_profile, upload_potcar, potcar_family_
     inputs.verbose = orm.Bool(True)
 
     # The test calculation contain NELM breaches during the relaxation - set to ignore it.
-    inputs.handler_overrides = orm.Dict(dict={'ignore_nelm_breach_relax': True})
+    inputs.handler_overrides = orm.Dict(dict={'ignore_nelm_breach_relax': {'enabled': True}})
     inputs.settings = orm.Dict(
         dict={
             'parser_settings': {

--- a/tests/workchains/test_vasp_wc_mock.py
+++ b/tests/workchains/test_vasp_wc_mock.py
@@ -111,7 +111,10 @@ def test_silicon_band_hybrid_no_relax(fresh_aiida_env, mock_potcars, mock_vasp_s
     assert results.node.is_finished_ok
 
 
-def test_silicon_relax_staged(fresh_aiida_env, mock_potcars, mock_vasp_strict, builder_updater):
+@pytest.mark.filterwarnings('ignore:The BuilderUpdater functionality is deprecated.*:DeprecationWarning')
+@pytest.mark.filterwarnings('ignore:The builder_updater module is deprecated.*:DeprecationWarning')
+@pytest.mark.filterwarnings('ignore:The Vasp.*Updater class is deprecated.*:DeprecationWarning')
+def test_silicon_relax_staged(fresh_aiida_env, mock_potcars, mock_vasp_strict):
     """Test running a VASP workchain on silicon using the mock code."""
 
     si = bulk('Si', 'diamond', 5.4)

--- a/tests/workchains/v2/test_builder_updater.py
+++ b/tests/workchains/v2/test_builder_updater.py
@@ -1,8 +1,26 @@
+import importlib
+import warnings
+
 import pytest
 from aiida import orm
 from ase.build import bulk
 
-from aiida_vasp.common import builder_updater as bup
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        'ignore',
+        message='The builder_updater module is deprecated.*|The Vasp.*Updater class is deprecated.*',
+        category=DeprecationWarning,
+    )
+    bup = importlib.import_module('aiida_vasp.common.builder_updater')
+
+pytestmark = [
+    pytest.mark.filterwarnings('ignore:The builder_updater module is deprecated.*:DeprecationWarning'),
+    pytest.mark.filterwarnings('ignore:The Vasp.*Updater class is deprecated.*:DeprecationWarning'),
+    pytest.mark.filterwarnings('ignore:Error validating potential family .*:UserWarning'),
+    pytest.mark.filterwarnings(
+        "ignore:The default method has changed from 'aseneb' to 'improvedtangent'.*:UserWarning"
+    ),
+]
 
 
 def test_vasp_builder_updater(aiida_profile_clean, vasp_code, upload_potcar, potcar_family_name):

--- a/tests/workchains/v2/test_wc_utils.py
+++ b/tests/workchains/v2/test_wc_utils.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
+from aiida.common.extendeddicts import AttributeDict
 
-from aiida_vasp.workchains.v2.relax import get_maximum_force
+from aiida_vasp.workchains.v2.relax import VaspRelaxWorkChain, get_maximum_force
 
 
 def test_get_maximum_forces():
@@ -21,3 +22,28 @@ def test_get_maximum_forces():
         ]
     )
     assert get_maximum_force(forces, mask) == pytest.approx(np.sqrt(0.4**2 + 0.5**2 + 0.6**2), rel=1e-6, abs=1e-8)
+
+
+def test_check_shape_convergence_uses_angle_threshold():
+    """A pure angle change above the angle threshold should not be marked converged."""
+    workchain = object.__new__(VaspRelaxWorkChain)
+    object.__setattr__(
+        workchain,
+        '_context',
+        AttributeDict(
+            {
+                'relax_settings': AttributeDict(
+                    {
+                        'convergence_shape_angles': 0.1,
+                        'convergence_shape_lengths': 0.01,
+                    }
+                )
+            }
+        ),
+    )
+    workchain.report = lambda *args, **kwargs: None
+    workchain.is_verbose = lambda: False
+
+    delta = AttributeDict({'cell_lengths': np.array([0.0, 0.0, 0.0]), 'cell_angles': np.array([0.2, 0.0, 0.0])})
+
+    assert workchain.check_shape_convergence(delta) is False


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

*type "#" followed by search words to find issues / PRs*

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

 ## Summary

  This PR fixes a set of regressions across the CLI, parsers,
  calculations, and workchains, and adds regression coverage for the
  affected paths.

  It also incorporates the monitor and launch-command fixes from PR #851
  (https://github.com/aiida-vasp/aiida-vasp/pull/851), and reduces warning
  noise in the affected test suites without weakening result assertions.

  ## Main changes

  ### CLI / launch command

  - Fix pretty_print_builder so dry-run output shows the actual builder
    contents.
  - Fix --match-existing handling so existing structures are reused
    correctly.
  - Avoid interactive reuse prompts during --dryrun.
  - Improve loading of inputs from existing VASP folders.

  ### NEB

  - Fix per-image restart file handling to use the declared wavefunctions
    and charge_density namespaces.
  - Ensure NEB-specific restart file copying does not fall through the
    base single-file path.
  - Check parser notifications for all images, not only image 01.

  ### Parsers / trajectory outputs

  - Store TrajectoryData.symbols as a plain Python list instead of a NumPy
    array.

  ### Workchains

  - Fix ERROR_OTHER_INTERVENTION_NEEDED.format(...) usage so the ionic
    handler returns an exit code instead of raising TypeError.
  - Add the missing ignored_failed input to VaspMultiStageRelaxWorkChain.
  - Fix shape-convergence logic so angle convergence is checked against
    the angle threshold, not the length threshold.

  ### Monitors

  - Catch SFTPNoSuchFile in monitor logic, matching asyncssh transport
    behavior.
  - Add regression tests for missing stdout files in both
    FileNotFoundError and asyncssh cases.

  ### Warning cleanup

  - Remove repo-owned runtime/deprecation warnings in the touched paths:
      - safe tarfile.extractall(...) usage for Python 3.14 compatibility,
      - class-based model_fields access for Pydantic,
      - updated non-deprecated handler_overrides test input format,
      - targeted warning filtering only for tests that intentionally
        exercise deprecated builder-updater APIs.

  ## Tests

  Validated with:

  uv run pytest -q tests/commands/test_launch_cmd.py \
    tests/calcs/test_monitors.py \
    tests/workchains/test_vasp_wc_mock.py \
    tests/workchains/test_vasp_wc.py \
    tests/workchains/v2/test_builder_updater.py \
    tests/workchains/v2/test_wc_utils.py
