### PR TITLE
Enhance bands workchain by excluding additional inputs from base workchain

### DIFF
--- a/src/aiida_vasp/commands/tools.py
+++ b/src/aiida_vasp/commands/tools.py
@@ -223,8 +223,11 @@ def tailf_command(transport, remotedir: str, fname: str) -> str:
 
     connect_string = (
         """ "if [ -d {escaped_remotedir} ] ;"""
-        """ then cd {escaped_remotedir} ; {bash_command} -c 'tail -f {escaped_fname}' ; else echo '  ** The directory' ; """
-        """echo '  ** {remotedir}' ; echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
+        """ then cd {escaped_remotedir} ; """
+        """{bash_command} -c 'tail -f {escaped_fname}' ; """
+        """else echo '  ** The directory' ; """
+        """echo '  ** {remotedir}' ; """
+        """echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
             bash_command=transport._bash_command_str,
             escaped_remotedir=f"'{remotedir}'",
             remotedir=remotedir,

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -577,6 +577,10 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
             inputs.update(dos_input)
             inputs.parameters = orm.Dict(dict=parameters)
 
+            # Ensure DOS uses 3D mesh kpoints, not the band's 1D path
+            if 'kpoints' in dos_input:
+                inputs.kpoints = dos_input.kpoints
+
             if 'dos' not in self.inputs:
                 # kindly add `add_dos` if the `dos` input namespace is not
                 # explicitly defined.

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -128,9 +128,6 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
                 'kpoints',
                 'potential_family',
                 'potential_mapping',
-                'code',
-                'calc',
-                'kpoints_spacing',
             ),
             namespace_options={
                 'required': False,
@@ -145,10 +142,6 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
                 'structure',
                 'potential_family',
                 'potential_mapping',
-                'code',
-                'calc',
-                'kpoints',
-                'kpoints_spacing',
             ),
             namespace_options={
                 'required': False,

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -133,7 +133,7 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         spec.expose_inputs(
             base_work,
             namespace='dos',
-            exclude=('structure','potential_family', 'potential_mapping', 'code', 'calc'),
+            exclude=('structure', 'potential_family', 'potential_mapping', 'code', 'calc'),
             namespace_options={
                 'required': False,
                 'populate_defaults': False,

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -123,7 +123,7 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         spec.expose_inputs(
             base_work,
             namespace='bands',
-            exclude=('structure', 'kpoints'),
+            exclude=('structure', 'kpoints', 'potential_family', 'potential_mapping', 'code', 'calc'),
             namespace_options={
                 'required': False,
                 'populate_defaults': False,
@@ -133,7 +133,7 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         spec.expose_inputs(
             base_work,
             namespace='dos',
-            exclude=('structure',),
+            exclude=('structure','potential_family', 'potential_mapping', 'code', 'calc'),
             namespace_options={
                 'required': False,
                 'populate_defaults': False,

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -543,23 +543,18 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         if (self.inputs.band_settings['run_dos']) or ('dos' in self.inputs):
             if 'dos' in self.inputs:
                 dos_input = AttributeDict(self.exposed_inputs(base_work, namespace='dos'))
-                if 'kpoints' not in dos_input:
-                    dos_kpoints_distance = self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi
-                    dos_kpoints = orm.KpointsData()
-                    dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
-                    dos_kpoints.set_kpoints_mesh_from_density(dos_kpoints_distance)
-                    dos_input.kpoints = dos_kpoints
             else:
                 dos_input = AttributeDict(
                     {
                         'parameters': orm.Dict(dict={'charge': {'constant_charge': True}}),
+                        'settings': {'parser_settings': {'include_node': ['dos']}},
                     }
                 )
+            if 'kpoints' not in dos_input and 'kpoints_spacing' not in dos_input:
                 # Use the supplied kpoints density for DOS
-                dos_kpoints_distance = self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi
                 dos_kpoints = orm.KpointsData()
                 dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
-                dos_kpoints.set_kpoints_mesh_from_density(dos_kpoints_distance)
+                dos_kpoints.set_kpoints_mesh_from_density(self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi)
                 dos_input.kpoints = dos_kpoints
 
             # Special treatment - combine the parameters

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -577,10 +577,6 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
             inputs.update(dos_input)
             inputs.parameters = orm.Dict(dict=parameters)
 
-            # Ensure DOS uses 3D mesh kpoints, not the band's 1D path
-            if 'kpoints' in dos_input:
-                inputs.kpoints = dos_input.kpoints
-
             if 'dos' not in self.inputs:
                 # kindly add `add_dos` if the `dos` input namespace is not
                 # explicitly defined.

--- a/src/aiida_vasp/workchains/v2/bands.py
+++ b/src/aiida_vasp/workchains/v2/bands.py
@@ -123,7 +123,15 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         spec.expose_inputs(
             base_work,
             namespace='bands',
-            exclude=('structure', 'kpoints', 'potential_family', 'potential_mapping', 'code', 'calc'),
+            exclude=(
+                'structure',
+                'kpoints',
+                'potential_family',
+                'potential_mapping',
+                'code',
+                'calc',
+                'kpoints_spacing',
+            ),
             namespace_options={
                 'required': False,
                 'populate_defaults': False,
@@ -133,7 +141,15 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         spec.expose_inputs(
             base_work,
             namespace='dos',
-            exclude=('structure', 'potential_family', 'potential_mapping', 'code', 'calc'),
+            exclude=(
+                'structure',
+                'potential_family',
+                'potential_mapping',
+                'code',
+                'calc',
+                'kpoints',
+                'kpoints_spacing',
+            ),
             namespace_options={
                 'required': False,
                 'populate_defaults': False,
@@ -527,6 +543,12 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
         if (self.inputs.band_settings['run_dos']) or ('dos' in self.inputs):
             if 'dos' in self.inputs:
                 dos_input = AttributeDict(self.exposed_inputs(base_work, namespace='dos'))
+                if 'kpoints' not in dos_input:
+                    dos_kpoints_distance = self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi
+                    dos_kpoints = orm.KpointsData()
+                    dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
+                    dos_kpoints.set_kpoints_mesh_from_density(dos_kpoints_distance)
+                    dos_input.kpoints = dos_kpoints
             else:
                 dos_input = AttributeDict(
                     {
@@ -534,9 +556,10 @@ class VaspBandsWorkChain(WorkChain, WithBuilderUpdater, ProtocolMixin):
                     }
                 )
                 # Use the supplied kpoints density for DOS
+                dos_kpoints_distance = self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi
                 dos_kpoints = orm.KpointsData()
                 dos_kpoints.set_cell_from_structure(self.ctx.current_structure)
-                dos_kpoints.set_kpoints_mesh_from_density(self.inputs.band_settings['dos_kpoints_distance'] * 2 * np.pi)
+                dos_kpoints.set_kpoints_mesh_from_density(dos_kpoints_distance)
                 dos_input.kpoints = dos_kpoints
 
             # Special treatment - combine the parameters


### PR DESCRIPTION
## Purpose

Extend the `exclude` parameter of the `bands` and `dos` namespaces in `VaspBandsWorkChain` to exclude parameters such as `potential_family`, `potential_mapping`, `code`, and `calc`, so that the bands and DOS calculations can automatically inherit the configuration of the parent work chain.

## Advantages

1. **Reduces repetitive configuration**: Users only need to set the parameters once in the parent work chain (e.g., the SCF calculation), without having to specify them again for the bands and DOS calculations.
2. **Ensures consistency**: Guarantees that all calculations use the same pseudopotentials, code, and calculation settings.

## Changes Made

- `bands` namespace: Add `potential_family`, `potential_mapping`, `code`, `calc` to the exclude list.
- `dos` namespace: Add `potential_family`, `potential_mapping`, `code`, `calc` to the exclude list.
#857 