### PR TITLE
Fix _compose_dos: wrong namespace and flatten_dict=True

### DIFF
--- a/src/aiida_vasp/parsers/vasp.py
+++ b/src/aiida_vasp/parsers/vasp.py
@@ -482,9 +482,13 @@ class VaspParser(Parser):
         """Compose the `dos` node"""
         arrays_dict = {}
         if 'vasprun.xml' in quantities_each:
-            gather_quantities(quantities_each, 'dos', arrays_dict, ['dos'], flatten_dict=True)
+            gather_quantities(quantities_each, 'vasprun.xml', arrays_dict, ['dos'], flatten_dict=False)
         if arrays_dict:
-            node = orm.ArrayData(arrays_dict['dos'])
+            dos_data = arrays_dict['dos']
+            node = orm.ArrayData()
+            for key, value in dos_data.items():
+                if value is not None:
+                    node.set_array(key, value)
             return node
 
     def _check_vasp_errors(self, parser_notifications: dict[str, Any]) -> ExitCode | None:


### PR DESCRIPTION
### Bug

`_compose_dos` fails to compose the `dos` output node when parsing `vasprun.xml`. #859

### Root Cause

Two bugs in `_compose_dos`:

1. **Wrong namespace** — `gather_quantities` looked up `quantities_each['dos']`, but DOS data is stored under `quantities_each['vasprun.xml']['dos']`.
2. **`flatten_dict=True` breaks `arrays_dict['dos']` lookup** — With `flatten_dict=True`, DOS arrays get prefixed keys (e.g. `dos_energy`), so `arrays_dict['dos']` raises a `KeyError`.

### Fix

- Changed the namespace from `'dos'` to `'vasprun.xml'`
- Set `flatten_dict=False`
- Iterate over `dos_data` and set arrays individually with `set_array`