### PR TITLE
Fix E501 line too long in commands/tools.py

### DIFF
--- a/src/aiida_vasp/commands/tools.py
+++ b/src/aiida_vasp/commands/tools.py
@@ -223,7 +223,8 @@ def tailf_command(transport, remotedir: str, fname: str) -> str:
 
     connect_string = (
         """ "if [ -d {escaped_remotedir} ] ;"""
-        """ then cd {escaped_remotedir} ; {bash_command} -c 'tail -f {escaped_fname}' ; else echo '  ** The directory' ; """
+        """ then cd {escaped_remotedir} ; {bash_command} -c 'tail -f {escaped_fname}' ;"""
+        """ else echo '  ** The directory' ; """
         """echo '  ** {remotedir}' ; echo '  ** seems to have been deleted, I logout...' ; fi" """.format(
             bash_command=transport._bash_command_str,
             escaped_remotedir=f"'{remotedir}'",


### PR DESCRIPTION
Fixes a pre-commit.ci ruff failure on `src/aiida_vasp/commands/tools.py:226` where a concatenated string was 124 characters, exceeding the 120-character line length limit.

The string has been split into two concatenated string literals to comply with the line length limit.

Closes pre-commit.ci failures seen on recent PRs (#861, #856, #855).