### PR TITLE
Pin pytest to >=9,<9.1 to avoid 9.1.0 duplicate parametrization regression

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           conda activate test
           conda install --yes -c conda-forge python=${{ matrix.python }}
-          conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml pytest pytest-cov seekpath PyCifRW
+          conda install --yes -c conda-forge pip "aiida-core>=2.6" ase lxml "pytest>=9,<9.1" pytest-cov seekpath PyCifRW
       - name: Setup parsevasp
         run: |
           conda activate test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install aiida-vasp
         run: |
           uv pip install -v -e .[tests]
+      - name: Pin pytest version (avoid 9.1+ duplicate parametrization regression)
+        run: |
+          uv pip install 'pytest>=9,<9.1'
       - name: Run tests with codecov
         run: |
           source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 Source = "https://github.com/aiida-vasp/aiida-vasp"
 
 [project.optional-dependencies]
-tests = ["aiida-core>=2.6", "pytest", "PyCifRW", "pymatgen"]
+tests = ["aiida-core>=2.6", "pytest>=9,<9.1", "PyCifRW", "pymatgen"]
 pre-commit = ["pre-commit"]
 docs = [
     "aiida-core[docs]~=2.4",


### PR DESCRIPTION
pytest 9.1.0 introduced a breaking change where `@pytest.mark.parametrize` with `indirect=True` on fixture parameters now errors with "duplicate parametrization" instead of being allowed.

This pins pytest to `>=9,<9.1` in:
- `cd.yml` (conda install)
- `ci.yml` (uv pip install)
- `pyproject.toml` (`[tests]` optional dependencies)

This is a temporary workaround until the test suite is updated to be compatible with pytest 9.1+.