### PR TITLE
fix(v2/vasp): Fix site_magnetization feature bugs

### DIFF
--- a/src/aiida_vasp/workchains/v2/vasp.py
+++ b/src/aiida_vasp/workchains/v2/vasp.py
@@ -229,6 +229,13 @@ A nested dictionary containing the following keys:
             help='Mapping for the initial magnetic moments.',
         )
         spec.input(
+            'site_magnetization',
+            valid_type=orm.Dict,
+            required=False,
+            serializer=to_aiida_type,
+            help='Site magnetization data from a previous calculation to initialize magnetic moments.',
+        )
+        spec.input(
             'kpoints_spacing',
             valid_type=orm.Float,
             required=False,
@@ -521,13 +528,13 @@ A nested dictionary containing the following keys:
         if node is None:
             node = self.ctx.children[-1]
 
-        if 'site_magnetization' in node.outputs:
-            try:
-                self.ctx.inputs.parameters['magmom'] = site_magnetization_to_magmom(
-                    node.outputs.site_magnetization.get_dict()
-                )
-            except ValueError:
-                pass
+        if 'misc' in node.outputs:
+            misc_dict = node.outputs.misc.get_dict()
+            if 'site_magnetization' in misc_dict:
+                try:
+                    self.ctx.inputs.parameters['magmom'] = site_magnetization_to_magmom(misc_dict['site_magnetization'])
+                except ValueError:
+                    pass
 
     def init_inputs(self) -> Optional[ExitCode]:
         """Make sure all the required inputs are there and valid, create input dictionary for calculation."""


### PR DESCRIPTION
## Fix site_magnetization feature bugs (#873)

### Summary

Fix two bugs in the `site_magnetization` feature of `VaspWorkChain` (v2):

### Changes

**1. Add missing `site_magnetization` input port**

- **File**: [vasp.py](file:///home/liguozhou/git/aiida-vasp/src/aiida_vasp/workchains/v2/vasp.py#L231-L237)
- **Issue**: The code at lines 599-602 checked for `site_magnetization` input, but the port was never declared in `define()`
- **Fix**: Added `spec.input('site_magnetization', ...)` with `valid_type=orm.Dict`, allowing users to pass site magnetization data via the builder

**2. Fix output node access in `update_magmom`**

- **File**: [vasp.py](file:///home/liguozhou/git/aiida-vasp/src/aiida_vasp/workchains/v2/vasp.py#L531-L537)
- **Issue**: Incorrectly accessed `node.outputs.site_magnetization` directly
- **Fix**: Changed to access via `node.outputs.misc.get_dict()['site_magnetization']`, as site magnetization data is parsed and stored inside the `misc` output node
