### PR TITLE
Fix OUTCAR path in loop time monitor

### DIFF
--- a/src/aiida_vasp/calcs/monitors.py
+++ b/src/aiida_vasp/calcs/monitors.py
@@ -128,7 +128,7 @@ def monitor_loop_time(
     :rtype: str or None
     """
 
-    outcar_path = str(Path(node.get_remote_workdir(), 'OURCAR'))
+    outcar_path = str(Path(node.get_remote_workdir(), 'OUTCAR'))
     stdout_path = str(Path(node.get_remote_workdir()) / node.process_class._VASP_OUTPUT)
     walltime_limit = node.get_option('max_wallclock_seconds')
     if walltime_limit is None:

--- a/tests/calcs/test_monitors.py
+++ b/tests/calcs/test_monitors.py
@@ -201,7 +201,7 @@ class TestMonitorLoopTime:
 
         # Assertions
         assert result is None
-        outcar_path = Path(os.getcwd()) / 'OURCAR'
+        outcar_path = Path(os.getcwd()) / 'OUTCAR'
         assert mock_transport.exec_command_wait_calls == [f"grep 'LOOP:' {outcar_path}"]
 
     def test_monitor_loop_time_fast_loops(self, mock_transport):


### PR DESCRIPTION
I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes: #876

## Description

Corrects the loop-time monitor to inspect `OUTCAR` rather than the misspelled `OURCAR` path. The existing transport-call assertion now serves as a regression test.

Validation: all 14 monitor tests pass; Ruff lint and format checks pass for the changed files.
