### PR TITLE
fix(parser): make stress optional in trajectory data

### DIFF
--- a/src/aiida_vasp/parsers/content_parsers/vasprun.py
+++ b/src/aiida_vasp/parsers/content_parsers/vasprun.py
@@ -339,49 +339,45 @@ class VasprunParser(BaseFileParser):
     @property
     def trajectory(self) -> dict[str, Any] | None:
         """
-        Fetch unitcells, positions, species, forces and stress.
+        Fetch unitcells, positions, species, forces and optionally stress.
 
-        For all calculation steps.
+        For all calculation steps. Stress is included only when present in the
+        ``vasprun.xml`` content so missing stress does not drop the whole trajectory.
 
         """
-
         unitcell = self._content_parser.get_unitcell('all')
         positions = self._content_parser.get_positions('all')
         species = self._content_parser.get_species()
         forces = self._content_parser.get_forces('all')
         stress = self._content_parser.get_stress('all')
+
+        if unitcell is None or positions is None or species is None or forces is None:
+            return None
+
         # make sure all are sorted, first to last calculation
         # (species is constant)
         unitcell = sorted(unitcell.items())
         positions = sorted(positions.items())
         forces = sorted(forces.items())
-        stress = sorted(stress.items())
         # convert to numpy
         unitcell = np.asarray([item[1] for item in unitcell])
         positions = np.asarray([item[1] for item in positions])
         forces = np.asarray([item[1] for item in forces])
-        stress = np.asarray([item[1] for item in stress])
         # Aiida wants the species as symbols, so invert
         elements = _invert_dict(parsevaspct.elements)
         symbols = np.asarray([elements[item].title() for item in species.tolist()])
 
-        if (
-            (unitcell is not None)
-            and (positions is not None)
-            and (species is not None)
-            and (forces is not None)
-            and (stress is not None)
-        ):
-            trajectory_data = {}
+        stepids = np.arange(unitcell.shape[0])
+        keys: tuple[str, ...] = ('cells', 'positions', 'symbols', 'forces', 'steps')
+        values: tuple[Any, ...] = (unitcell, positions, symbols, forces, stepids)
 
-            keys = ('cells', 'positions', 'symbols', 'forces', 'stress', 'steps')
-            stepids = np.arange(unitcell.shape[0])
+        if stress is not None:
+            stress = sorted(stress.items())
+            stress = np.asarray([item[1] for item in stress])
+            keys = keys + ('stress',)
+            values = values + (stress,)
 
-            for key, data in zip(keys, (unitcell, positions, symbols, forces, stress, stepids)):
-                trajectory_data[key] = data
-            return trajectory_data
-
-        return None
+        return dict(zip(keys, values))
 
     @property
     def total_energies(self) -> dict[str, float] | None:

--- a/tests/parsers/content_parsers/test_vasprun_parser.py
+++ b/tests/parsers/content_parsers/test_vasprun_parser.py
@@ -116,6 +116,33 @@ def test_parse_vasprun_final_stress(vasprun_parser):
     np.testing.assert_allclose(stress[2], stress_check[2], atol=0.0, rtol=1.0e-7)
 
 
+@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
+def test_parse_vasprun_trajectory(vasprun_parser):
+    """Trajectory includes stress when present in vasprun.xml."""
+    trajectory = vasprun_parser.get_quantity('trajectory')
+    assert trajectory is not None
+    assert set(trajectory) >= {'cells', 'positions', 'symbols', 'forces', 'steps', 'stress'}
+    assert trajectory['cells'].shape[0] == trajectory['positions'].shape[0]
+    assert trajectory['forces'].shape[0] == trajectory['steps'].shape[0]
+    assert trajectory['stress'].shape[0] == trajectory['steps'].shape[0]
+    assert trajectory['stress'].shape[-2:] == (3, 3)
+
+
+@pytest.mark.parametrize(['vasprun_parser'], [('basic',)], indirect=True)
+def test_parse_vasprun_trajectory_without_stress(vasprun_parser, monkeypatch):
+    """Missing stress must not abort trajectory parsing or drop other arrays."""
+    monkeypatch.setattr(vasprun_parser._content_parser, 'get_stress', lambda *args, **kwargs: None)
+    # Bypass cached full parse so the monkeypatched getter is used.
+    vasprun_parser._parsed_content = {}
+    trajectory = vasprun_parser.trajectory
+
+    assert trajectory is not None
+    assert 'stress' not in trajectory
+    assert set(trajectory) >= {'cells', 'positions', 'symbols', 'forces', 'steps'}
+    assert trajectory['cells'].shape[0] == trajectory['positions'].shape[0]
+    assert trajectory['forces'].shape[0] == trajectory['steps'].shape[0]
+
+
 @pytest.mark.parametrize(['vasprun_parser'], [('dielectric',)], indirect=True)
 def test_parse_vasprun_dielectrics(vasprun_parser):
     """Load a reference vasprun.xml and test that the dielectrics are returned correctly."""


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

## Description

`VasprunParser.trajectory` previously treated stress as a hard requirement:

1. It called `stress.items()` before checking for `None`, so a missing stress block could raise immediately.
2. Even with a later `stress is not None` guard, the whole trajectory quantity was dropped when stress was absent, despite cells/positions/forces being available.

This is a problem for calculations or incomplete `vasprun.xml` files without stress tensors. Downstream consumers such as `v2/relax` rely on trajectory data for structure history / convergence checks and should not lose the entire trajectory just because stress is missing.

### Changes
- Include `stress` in the trajectory dict only when present.
- Guard required fields (`unitcell`, `positions`, `species`, `forces`) before sorting/converting them.
- Add regression tests:
  - trajectory with stress present
  - trajectory with `get_stress('all') -> None` still returns cells/positions/forces/steps and omits `stress`

### Behavior change
Trajectory output may omit the `stress` array. Other trajectory arrays remain unchanged when available.