### PR TITLE
fix(parameters): recognize ISEARCH INCAR tag

### DIFF
--- a/src/aiida_vasp/assistant/parameters.yml
+++ b/src/aiida_vasp/assistant/parameters.yml
@@ -965,6 +965,14 @@ irestart:
   description: Undocumented
   type: null
   values: null
+isearch:
+  default: '0'
+  description: ISEARCH controls the line-search algorithm used during direct electronic
+    minimization.
+  type: null
+  values:
+  - '0'
+  - '1'
 isif:
   default: null
   description: ISIF determines whether the stress tensor is calculated and which principal

--- a/tests/assistant/test_parameters.py
+++ b/tests/assistant/test_parameters.py
@@ -297,6 +297,14 @@ def test_vasp_parameter_override(init_relax_parameters):
     assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].isif == 0
 
 
+def test_isearch_parameter_override(init_relax_parameters):
+    """Test that the official ISEARCH INCAR tag is accepted."""
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE] = AttributeDict()
+    init_relax_parameters[_DEFAULT_OVERRIDE_NAMESPACE].isearch = 1
+    massager = ParametersMassage(init_relax_parameters)
+    assert massager.parameters[_DEFAULT_OVERRIDE_NAMESPACE].isearch == 1
+
+
 def test_inherit_and_merge():
     """Test the inherit and merge functionality for the parameters and inputs."""
 


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

fixes:

blocks:

is blocked by:

None of the above but is still related to the following:

Independent of #881.

## Description

`ISEARCH` is an official VASP INCAR tag that selects the line-search algorithm during direct electronic minimization. The parameter massager rejected it before submission because it was missing from the supported tag registry.

### Changes
- Register `isearch` in `parameters.yml` with the documented values `0` / `1`.
- Add a regression test that the override namespace accepts `isearch=1`.

### Behavior change
Submitting `incar.isearch` no longer fails parameter validation. Default VASP behavior is unchanged when the tag is omitted.