### PR TITLE
Support explicit automatic KPOINTS centering

### DIFF
--- a/src/aiida_vasp/parsers/content_parsers/kpoints.py
+++ b/src/aiida_vasp/parsers/content_parsers/kpoints.py
@@ -157,8 +157,15 @@ class KpointsParser(BaseFileParser):
         kpoints_dict['divisions'] = mesh[0]
         kpoints_dict['shifts'] = mesh[1]
         kpoints_dict['mode'] = 'automatic'
-        # Here we need to make a choice, so should add more to AiiDA to make this better defined
-        kpoints_dict['centering'] = 'Gamma'
+        # AiiDA's KpointsData does not model the VASP automatic-mesh header.
+        # Preserve the historical Gamma default while allowing callers to attach
+        # the missing VASP-specific intent explicitly before the node is stored.
+        centering = kpointsdata.base.attributes.get('vasp_centering', 'Gamma')
+        if centering not in {'Gamma', 'Monkhorst-Pack'}:
+            raise ValueError(
+                f"Unsupported VASP automatic-mesh centering {centering!r}; expected 'Gamma' or 'Monkhorst-Pack'."
+            )
+        kpoints_dict['centering'] = centering
         kpoints_dict['num_kpoints'] = 0
 
         return kpoints_dict

--- a/tests/parsers/content_parsers/test_kpoints_parser.py
+++ b/tests/parsers/content_parsers/test_kpoints_parser.py
@@ -147,6 +147,27 @@ def test_parse_kpoints_data(vasp_kpoints, tmpdir):
     compare_kpoints_content(result, result_ref)
 
 
+@pytest.mark.parametrize(['vasp_kpoints'], [('mesh',)], indirect=True)
+def test_write_automatic_monkhorst_pack_kpoints(vasp_kpoints, tmpdir):
+    """An explicit node attribute preserves the genuine VASP MP header."""
+    kpoints_data, _ = vasp_kpoints
+    kpoints_data.base.attributes.set('vasp_centering', 'Monkhorst-Pack')
+    path = str(tmpdir.join('KPOINTS'))
+    KpointsParser(data=kpoints_data).write(path)
+    with open(path, encoding='utf8') as handle:
+        result = KpointsParser(handler=handle).get_quantity('kpoints-kpoints')
+    assert result['centering'] == 'Monkhorst-Pack'
+
+
+@pytest.mark.parametrize(['vasp_kpoints'], [('mesh',)], indirect=True)
+def test_reject_unknown_automatic_mesh_centering(vasp_kpoints):
+    """Do not silently turn a misspelled centering into another mesh."""
+    kpoints_data, _ = vasp_kpoints
+    kpoints_data.base.attributes.set('vasp_centering', 'invalid')
+    with pytest.raises(ValueError, match='Unsupported VASP'):
+        KpointsParser(data=kpoints_data)._content_data_to_content_parser()
+
+
 def compare_kpoints_content(kpoints, kpoints_ref):
     """Compare the KPOINTS content with supplied reference data."""
     if kpoints['mode'] == 'explicit':


### PR DESCRIPTION
**Please check the applicable boxes, thank you**:

I, the author consider this PR
 - [x] ready to be reviewed and merged (as soon as tests have passed)
 - [ ] work in progress (early feedback welcome)

## Interactions with issues / other PRs

None of the above.

## Description

`KpointsParser._get_kpointsdict_automatic` currently writes every `KpointsData` mesh with a Gamma header. This prevents callers from requesting a genuine VASP Monkhorst-Pack mesh, for which the header changes the sampling of even meshes.

This change preserves Gamma as the default and allows callers to attach the missing VASP-specific intent as the `vasp_centering` attribute on `KpointsData` before it is stored. The accepted values are `Gamma` and `Monkhorst-Pack`; invalid values fail explicitly instead of silently selecting a different mesh.

The patch is intentionally limited to the content parser and two regression tests. It does not change offsets, mesh generation, or the historical default.

Validated on current `develop` with:

```text
ruff check src/aiida_vasp/parsers/content_parsers/kpoints.py tests/parsers/content_parsers/test_kpoints_parser.py
ruff format --check src/aiida_vasp/parsers/content_parsers/kpoints.py tests/parsers/content_parsers/test_kpoints_parser.py
pytest tests/parsers/content_parsers/test_kpoints_parser.py
```

Result: 7 tests passed.
